### PR TITLE
feat(codex): add GPT-6 Astra model metadata

### DIFF
--- a/tests/test_backend_model_catalog.py
+++ b/tests/test_backend_model_catalog.py
@@ -357,6 +357,48 @@ def test_codex_hub_catalog_preserves_native_modalities_without_an_override():
     assert payload["models"][0]["auto_compact_token_limit"] == 180_000
 
 
+def test_codex_hub_catalog_promotes_a_configured_hidden_native_model():
+    raw = json.dumps(
+        {
+            "models": [
+                {
+                    "slug": "gpt-6-astra",
+                    "display_name": "GPT-6-Astra",
+                    "priority": 1,
+                    "visibility": "hide",
+                    "supported_in_api": True,
+                    "default_reasoning_level": "low",
+                    "supported_reasoning_levels": [
+                        {"effort": "low", "description": "Low"},
+                        {"effort": "ultra", "description": "Ultra"},
+                    ],
+                }
+            ]
+        }
+    ).encode()
+
+    payload = json.loads(
+        backend_model_catalog._codex_hub_catalog_bytes(
+            raw,
+            [
+                {
+                    "id": "gpt-6-astra",
+                    "display_name": "GPT-6-Astra",
+                    "reasoning_efforts": ["low", "ultra"],
+                }
+            ],
+        )
+    )
+
+    assert payload["models"][0]["slug"] == "gpt-6-astra"
+    assert payload["models"][0]["visibility"] == "list"
+    assert payload["models"][0]["supported_in_api"] is True
+    assert payload["models"][0]["supported_reasoning_levels"] == [
+        {"effort": "low", "description": "Low"},
+        {"effort": "ultra", "description": "Ultra"},
+    ]
+
+
 def test_codex_hub_catalog_retires_native_compaction_limit_after_context_override():
     raw = json.dumps(
         {
@@ -1053,11 +1095,15 @@ def test_fetch_remote_catalog_rejects_unknown_backend(monkeypatch):
         backend_model_catalog.fetch_remote_catalog("https://example.test/catalog.json")
 
 
-def test_bundled_codex_56_efforts_include_ultra():
+def test_bundled_codex_astra_is_first_with_native_reasoning_efforts():
     snapshot = backend_model_catalog.backend_model_snapshot("codex", schedule_refresh=False)
 
-    values = {entry["value"] for entry in snapshot["reasoning_options"]["gpt-5.6-terra"]}
-    assert "ultra" in values
+    assert snapshot["models"][0] == "gpt-6-astra"
+    assert snapshot["model_labels"]["gpt-6-astra"] == "GPT-6-Astra"
+    assert [
+        entry["value"]
+        for entry in snapshot["reasoning_options"]["gpt-6-astra"]
+    ] == ["__default__", "low", "medium", "high", "xhigh", "max", "ultra"]
 
 
 def test_codex_catalog_readers_expand_codex_home(monkeypatch, tmp_path):

--- a/tests/test_backend_model_catalog.py
+++ b/tests/test_backend_model_catalog.py
@@ -358,6 +358,7 @@ def test_codex_hub_catalog_preserves_native_modalities_without_an_override():
 
 
 def test_codex_hub_catalog_promotes_a_configured_hidden_native_model():
+    efforts = ["low", "medium", "high", "xhigh", "max", "ultra"]
     raw = json.dumps(
         {
             "models": [
@@ -369,8 +370,13 @@ def test_codex_hub_catalog_promotes_a_configured_hidden_native_model():
                     "supported_in_api": True,
                     "default_reasoning_level": "low",
                     "supported_reasoning_levels": [
-                        {"effort": "low", "description": "Low"},
-                        {"effort": "ultra", "description": "Ultra"},
+                        {
+                            "effort": effort,
+                            "description": backend_model_catalog._REASONING_LABELS[
+                                effort
+                            ],
+                        }
+                        for effort in efforts
                     ],
                 }
             ]
@@ -384,7 +390,7 @@ def test_codex_hub_catalog_promotes_a_configured_hidden_native_model():
                 {
                     "id": "gpt-6-astra",
                     "display_name": "GPT-6-Astra",
-                    "reasoning_efforts": ["low", "ultra"],
+                    "reasoning_efforts": efforts,
                 }
             ],
         )
@@ -393,9 +399,13 @@ def test_codex_hub_catalog_promotes_a_configured_hidden_native_model():
     assert payload["models"][0]["slug"] == "gpt-6-astra"
     assert payload["models"][0]["visibility"] == "list"
     assert payload["models"][0]["supported_in_api"] is True
+    assert payload["models"][0]["default_reasoning_level"] == "low"
     assert payload["models"][0]["supported_reasoning_levels"] == [
-        {"effort": "low", "description": "Low"},
-        {"effort": "ultra", "description": "Ultra"},
+        {
+            "effort": effort,
+            "description": backend_model_catalog._REASONING_LABELS[effort],
+        }
+        for effort in efforts
     ]
 
 
@@ -453,7 +463,7 @@ def test_codex_hub_catalog_does_not_give_custom_models_template_modalities():
     assert payload["models"][0]["supports_image_detail_original"] is False
 
 
-def test_codex_hub_catalog_can_disable_and_restore_native_reasoning():
+def test_codex_hub_catalog_can_disable_reasoning_and_preserve_native_default():
     raw = json.dumps(
         {
             "models": [
@@ -488,7 +498,7 @@ def test_codex_hub_catalog_can_disable_and_restore_native_reasoning():
 
     assert disabled["default_reasoning_level"] == "none"
     assert disabled["supported_reasoning_levels"] == [{"effort": "none", "description": "None"}]
-    assert restored["default_reasoning_level"] == "low"
+    assert restored["default_reasoning_level"] == "high"
     assert restored["supported_reasoning_levels"] == [
         {"effort": "low", "description": "Low"},
         {"effort": "high", "description": "High"},
@@ -672,7 +682,10 @@ def test_merge_sources_applies_tombstones_and_fills_missing_metadata():
     }
 
 
-def test_codex_local_hidden_tombstone_overrides_remote_visible(monkeypatch, tmp_path):
+def test_codex_local_hidden_tombstone_overrides_implicit_remote_entry(
+    monkeypatch,
+    tmp_path,
+):
     codex_home = tmp_path / ".codex"
     codex_home.mkdir()
     (codex_home / "models_cache.json").write_text(
@@ -708,6 +721,43 @@ def test_codex_local_hidden_tombstone_overrides_remote_visible(monkeypatch, tmp_
 
     assert "account-hidden" not in snapshot["models"]
     assert snapshot["models"][:2] == ["remote-model", "account-visible"]
+
+
+def test_codex_explicit_catalog_visibility_overrides_local_hidden(
+    monkeypatch,
+    tmp_path,
+):
+    codex_home = tmp_path / ".codex"
+    codex_home.mkdir()
+    (codex_home / "models_cache.json").write_text(
+        json.dumps(
+            {
+                "models": [
+                    {"slug": "gpt-6-astra", "visibility": "hide"},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    monkeypatch.setattr(
+        backend_model_catalog,
+        "load_cached_remote_catalog",
+        lambda **kwargs: {},
+    )
+
+    picker_snapshot = backend_model_catalog.backend_model_snapshot(
+        "codex",
+        schedule_refresh=False,
+    )
+    builtin_snapshot = backend_model_catalog.backend_builtin_snapshot(
+        "codex",
+        cli_installed=True,
+        schedule_refresh=False,
+    )
+
+    assert picker_snapshot["models"][0] == "gpt-6-astra"
+    assert builtin_snapshot["models"][0]["id"] == "gpt-6-astra"
 
 
 def test_codex_local_efforts_override_remote_metadata(monkeypatch, tmp_path):

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -2453,7 +2453,12 @@ def test_codex_models_merges_cli_cache_and_filters_hidden_models(monkeypatch, tm
     result = api.codex_models(schedule_refresh=False)
 
     assert result["ok"] is True
-    assert result["models"][:3] == ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]
+    assert result["models"][:4] == [
+        "gpt-6-astra",
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
+    ]
     assert result["models"].index("gpt-5.4") < result["models"].index("gpt-5.4-mini")
     assert "gpt-5.3-codex-spark" in result["models"]
     assert "gpt-5.1-codex-mini" in result["models"]
@@ -2482,7 +2487,12 @@ def test_codex_models_falls_back_when_cli_cache_missing(monkeypatch, tmp_path):
     result = api.codex_models(schedule_refresh=False)
 
     assert result["ok"] is True
-    assert result["models"][:3] == ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]
+    assert result["models"][:4] == [
+        "gpt-6-astra",
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
+    ]
     assert "custom-codex-model" in result["models"]
     assert "legacy-codex" in result["models"]
     assert "gpt-5.1-codex-max" in result["models"]

--- a/vibe/backend_model_catalog.py
+++ b/vibe/backend_model_catalog.py
@@ -40,8 +40,9 @@ CODEX_HUB_CATALOG_TIMEOUT_SECONDS = 15.0
 CODEX_HUB_CATALOG_MAX_BYTES = 8 * 1024 * 1024
 
 _HIDDEN_VISIBILITIES = {"hide", "hidden"}
+_VISIBLE_VISIBILITIES = {"visible", "list"}
 _SUPPORTED_BACKENDS = {"claude", "codex"}
-_SUPPORTED_VISIBILITIES = {"visible", "list", *_HIDDEN_VISIBILITIES}
+_SUPPORTED_VISIBILITIES = {*_VISIBLE_VISIBILITIES, *_HIDDEN_VISIBILITIES}
 _DEFAULT_REASONING_EFFORTS = {
     "claude": ["low", "medium", "high"],
     "codex": ["minimal", "low", "medium", "high", "xhigh"],
@@ -231,11 +232,17 @@ def _codex_hub_catalog_bytes(
             else:
                 settled_efforts = None
             if settled_efforts is not None:
-                row["default_reasoning_level"] = (
-                    "medium"
-                    if "medium" in settled_efforts
-                    else settled_efforts[0]
-                )
+                native_default = row.get("default_reasoning_level")
+                if not (
+                    isinstance(native_default, str)
+                    and native_default in settled_efforts
+                ):
+                    native_default = (
+                        "medium"
+                        if "medium" in settled_efforts
+                        else settled_efforts[0]
+                    )
+                row["default_reasoning_level"] = native_default
                 row["supported_reasoning_levels"] = [
                     {
                         "effort": effort,
@@ -552,11 +559,11 @@ def backend_model_snapshot(backend: str, *, schedule_refresh: bool = True) -> di
     else:
         local_catalog = _read_codex_models_cache()
         remote_entries = backend_model_entries("codex", remote_catalog)
-        blocked = {
-            entry["id"]
-            for entry in [*local_catalog, *remote_entries]
-            if _model_hidden(entry)
-        }
+        blocked = _codex_blocked_model_ids(
+            remote_entries,
+            local_catalog,
+            bundled_catalog,
+        )
         sources = _codex_sources(remote_entries, local_catalog, bundled_catalog)
 
     merged = merge_model_sources(sources, blocked_model_ids=blocked)
@@ -658,11 +665,11 @@ def backend_builtin_snapshot(
         local_catalog, local_catalog_read = _read_codex_models_cache_with_status()
         local_complete = not cli_installed or local_catalog_read
         remote_entries = backend_model_entries("codex", remote_catalog)
-        blocked = {
-            entry["id"]
-            for entry in [*local_catalog, *remote_entries]
-            if _model_hidden(entry)
-        }
+        blocked = _codex_blocked_model_ids(
+            remote_entries,
+            local_catalog,
+            bundled_catalog,
+        )
         sources = _codex_sources(remote_entries, local_catalog, bundled_catalog)[:-1]
 
     merged = merge_model_sources(sources, blocked_model_ids=blocked)
@@ -914,6 +921,31 @@ def _reasoning_option_items(efforts: Iterable[object]) -> list[dict[str, str]]:
 def _model_hidden(entry: dict[str, Any]) -> bool:
     visibility = entry.get("visibility")
     return isinstance(visibility, str) and visibility.strip().lower() in _HIDDEN_VISIBILITIES
+
+
+def _model_explicitly_visible(entry: dict[str, Any]) -> bool:
+    visibility = entry.get("visibility")
+    return isinstance(visibility, str) and visibility.strip().lower() in _VISIBLE_VISIBILITIES
+
+
+def _codex_blocked_model_ids(
+    remote_entries: Sequence[dict[str, Any]],
+    local_catalog: Sequence[dict[str, Any]],
+    bundled_catalog: dict[str, Any],
+) -> set[str]:
+    bundled_entries = backend_model_entries("codex", bundled_catalog)
+    explicit_catalog_models = {
+        entry["id"]
+        for entry in [*remote_entries, *bundled_entries]
+        if _model_explicitly_visible(entry)
+    }
+    return {
+        entry["id"] for entry in remote_entries if _model_hidden(entry)
+    } | {
+        entry["id"]
+        for entry in local_catalog
+        if _model_hidden(entry) and entry["id"] not in explicit_catalog_models
+    }
 
 
 def _ordered_entries(entries: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/vibe/data/backend_models.json
+++ b/vibe/data/backend_models.json
@@ -26,10 +26,11 @@
     },
     "codex": {
       "models": [
-        {"id": "gpt-5.6-sol", "label": "GPT-5.6-Sol", "priority": 1, "reasoning_efforts": ["low", "medium", "high", "xhigh", "max", "ultra"]},
-        {"id": "gpt-5.6-terra", "label": "GPT-5.6-Terra", "priority": 2, "reasoning_efforts": ["low", "medium", "high", "xhigh", "max", "ultra"]},
-        {"id": "gpt-5.6-luna", "label": "GPT-5.6-Luna", "priority": 3, "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"]},
-        {"id": "gpt-5.5", "label": "GPT-5.5", "priority": 7, "reasoning_efforts": ["low", "medium", "high", "xhigh"]},
+        {"id": "gpt-6-astra", "label": "GPT-6-Astra", "priority": 1, "reasoning_efforts": ["low", "medium", "high", "xhigh", "max", "ultra"]},
+        {"id": "gpt-5.6-sol", "label": "GPT-5.6-Sol", "priority": 6, "reasoning_efforts": ["low", "medium", "high", "xhigh", "max", "ultra"]},
+        {"id": "gpt-5.6-terra", "label": "GPT-5.6-Terra", "priority": 7, "reasoning_efforts": ["low", "medium", "high", "xhigh", "max", "ultra"]},
+        {"id": "gpt-5.6-luna", "label": "GPT-5.6-Luna", "priority": 8, "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"]},
+        {"id": "gpt-5.5", "label": "GPT-5.5", "priority": 12, "reasoning_efforts": ["low", "medium", "high", "xhigh"]},
         {"id": "gpt-5.4", "label": "GPT-5.4", "priority": 16, "reasoning_efforts": ["low", "medium", "high", "xhigh"]},
         {"id": "gpt-5.4-mini", "label": "GPT-5.4-Mini", "priority": 23, "reasoning_efforts": ["low", "medium", "high", "xhigh"]},
         {"id": "gpt-5.2", "label": "GPT-5.2", "priority": 29, "reasoning_efforts": ["low", "medium", "high", "xhigh"]}

--- a/vibe/data/backend_models.json
+++ b/vibe/data/backend_models.json
@@ -26,7 +26,7 @@
     },
     "codex": {
       "models": [
-        {"id": "gpt-6-astra", "label": "GPT-6-Astra", "priority": 1, "reasoning_efforts": ["low", "medium", "high", "xhigh", "max", "ultra"]},
+        {"id": "gpt-6-astra", "label": "GPT-6-Astra", "priority": 1, "visibility": "list", "reasoning_efforts": ["low", "medium", "high", "xhigh", "max", "ultra"]},
         {"id": "gpt-5.6-sol", "label": "GPT-5.6-Sol", "priority": 6, "reasoning_efforts": ["low", "medium", "high", "xhigh", "max", "ultra"]},
         {"id": "gpt-5.6-terra", "label": "GPT-5.6-Terra", "priority": 7, "reasoning_efforts": ["low", "medium", "high", "xhigh", "max", "ultra"]},
         {"id": "gpt-5.6-luna", "label": "GPT-5.6-Luna", "priority": 8, "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"]},


### PR DESCRIPTION
## Summary

- add the official `gpt-6-astra` model to Avibe's bundled Codex catalog as the first built-in choice
- expose the Codex-native `low`, `medium`, `high`, `xhigh`, `max`, and `ultra` reasoning ladder
- refresh the neighboring Codex priorities from the current 0.153.2 bundled catalog and verify that Avibe's configured catalog projection promotes the native hidden row to `list`

Official reference:
- https://developers.openai.com/api/docs/models/gpt-6-astra

## Evidence

- Unit: 48 backend catalog tests and 3 focused Codex API tests passed
- Integration: 3 Model Hub built-in/reconciliation tests passed
- Contract: the backend snapshot asserts Astra ordering, display name, exact reasoning metadata, local hidden-row override behavior, and preservation of the native `low` default
- Scenario: N/A; no catalog scenario IDs are defined for this metadata-only change
- Manual: the installed Codex 0.153.2 bundled catalog exposes `gpt-6-astra`, and Avibe's runtime projection produced `gpt-6-astra list low 6`
- Static: Ruff, JSON parsing, and `git diff --check` passed
- Review: Codex passed current head `77a8f8e`; both earlier P2 findings were fixed and their threads resolved
- CI: [`lint` run 33911599648](https://github.com/avibe-bot/avibe/actions/runs/33911599648) passed on the current head, including the successful rerun of the transient install-upgrade regression job

## Dependencies

None.

## Known-by-design ledger

- Codex 0.153.2 currently marks `gpt-6-astra` as hidden during OpenAI's staged rollout. Avibe intentionally surfaces the official full model ID now; calls can still fail until the user's OpenAI account has model entitlement.
