### PR TITLE
feat(model-hub): OpenCode editor API field and bare-id rows

### DIFF
--- a/ui/e2e/model-list.spec.ts
+++ b/ui/e2e/model-list.spec.ts
@@ -74,13 +74,14 @@ test.describe('Model list · what a backend can be given', () => {
     const offered = (await escape.innerText()).trim();
     await escape.click();
 
-    // What the row offered is what the field now holds, and it still carries
-    // what was typed. A backend with an identifier scheme of its own resolves
-    // the query into an id it will accept instead of refusing it later, so the
-    // two are asserted as the same string rather than assumed to be the query.
+    // What the row offered is what the field now holds, and what it holds is
+    // what was typed. Every backend's id is the query itself — the row is read
+    // for the id rather than assumed to be it, because the offer is what a user
+    // reads before clicking, and an offer that named some other string would be
+    // the surface promising one id and creating another.
     const created = await field.inputValue();
     expect(offered).toBe(copy('gateway.modelEditor.useAsId', { query: created }));
-    expect(created).toContain(typed);
+    expect(created).toBe(typed);
 
     await labelledButton(editor, copy('gateway.modelEditor.add')).click();
     await expect(editor).toHaveCount(0);

--- a/ui/e2e/model-opencode.spec.ts
+++ b/ui/e2e/model-opencode.spec.ts
@@ -1,0 +1,304 @@
+// OpenCode's model list: the id a row is saved under, and the one field that
+// asks which API Avibe answers that model on.
+//
+// No scenario ID, for the reason model-list.spec.ts states: the e2e plan has no
+// family for a backend's model list, so these are named by the property they
+// assert. The properties are the two the v3/v4 identifier work is about —
+// docs/plans/backend-model-catalogs.md §"v3 — OpenCode" C8/C9 and Acceptance 6:
+//
+//   - an OpenCode row is stored under the BARE id it was offered or typed as,
+//     with nothing prefixed onto it on the way in;
+//   - `native_protocol` is carried by the row and named by ONE surface — the
+//     editor's last field. No list, picker, row, chip or card says it.
+//
+// SAVED, unlike model-list.spec.ts, which cancels because the list belongs to
+// the instance. It has to be: "the row is stored with the API the user chose"
+// is a claim about what the server holds, and a draft the dialog is still
+// carrying would only prove the dialog can carry it. What that costs is a real
+// restoration, so the list is snapshotted and put back by the fixture below —
+// through `restoreCatalogModels`, which re-reads its own baseline and throws if
+// the list it left is still there.
+import type { Locator } from '@playwright/test';
+
+import type { Agent, CatalogModel } from './support/api';
+import { hub as copy } from './support/copy';
+import { E2E_SOURCE_PREFIX } from './support/env';
+import { expectVisibleWithout, requireModelHub, requireRuntimeRunning } from './support/fixtures';
+import { expect, test as gatewayTest } from './support/gateway';
+import { labelledButton, pickerRowId } from './support/hub';
+import { restoreNativeSources } from './support/restore';
+
+const BACKEND = 'opencode';
+
+/** The two answers the field offers, as the row carries them. */
+const PROTOCOLS = ['openai_responses', 'anthropic'] as const;
+type Protocol = (typeof PROTOCOLS)[number];
+
+/** The words a user reads for one of them. */
+const protocolLabel = (value: Protocol): string => copy(`gateway.modelEditor.nativeProtocol.${value}`);
+
+const literal = (word: string): string => word.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/**
+ * Every word the protocol is spelled with — the value `openai_responses`, the
+ * two labels the editor offers, and the two overlay providers OpenCode is given
+ * — as one pattern a list surface must match none of.
+ *
+ * `anthropic` alone is deliberately NOT here, even though it is one of the two
+ * values. It is also a provider name, a vendor id, and a substring of half the
+ * model names a real instance lists, so its presence on a list says nothing and
+ * its absence would be asserted by accident. The words below have no innocent
+ * reading: an id, a chip or a card that contains one of them is the mechanism
+ * leaking, which is exactly what Acceptance 6 forbids.
+ */
+const PROTOCOL_WORDS = new RegExp(
+  [
+    'openai_responses',
+    'avibe-openai',
+    'avibe-anthropic',
+    protocolLabel('openai_responses'),
+    protocolLabel('anthropic'),
+  ].map(literal).join('|'),
+);
+
+/** Which of the two the field is on, named by the value the row carries rather
+ *  than by the words on the button. */
+const answeredProtocol = async (field: Locator): Promise<Protocol> => {
+  for (const value of PROTOCOLS) {
+    const radio = field.getByRole('radio', { name: protocolLabel(value), exact: true });
+    if ((await radio.getAttribute('aria-checked')) === 'true') return value;
+  }
+  throw new Error('The API field is on neither of the two protocols it offers.');
+};
+
+const otherProtocol = (value: Protocol): Protocol =>
+  PROTOCOLS.find((option) => option !== value)!;
+
+export type OpencodeCatalog = {
+  backend: string;
+  /** The list as it was found. Restored by the fixture, whatever the test did. */
+  baseline: CatalogModel[];
+};
+
+/**
+ * OpenCode in Gateway mode, with its model list snapshotted for restore.
+ *
+ * Its own fixture rather than the shared `gateway` one, which picks whichever
+ * installed backend already has a route: these two properties are OpenCode's
+ * alone — `claude` and `codex` have neither an open menu nor a protocol to
+ * choose — so a spec handed `claude` would pass by asserting nothing.
+ *
+ * "Manage models" is on the card only in Gateway mode (`AgentCard.tsx`), so the
+ * mode is arranged rather than assumed, and put back only if this fixture is
+ * what changed it.
+ */
+const test = gatewayTest.extend<{ opencode: OpencodeCatalog }>({
+  opencode: async ({ api }, provide, testInfo) => {
+    // Its own preconditions, for the reason the `gateway` fixture states: a
+    // fixture is set up before the suite's `beforeEach` guards run, so a
+    // disabled capability would reach the reads below as a thrown 404 rather
+    // than as the skip it is.
+    await requireModelHub(api);
+    await requireRuntimeRunning(api);
+    const agent = (await api.agents()).find((entry: Agent) => entry.backend === BACKEND);
+    testInfo.skip(
+      !agent?.cli_present,
+      `${BACKEND} is not installed on this instance, so it has no model list to manage and no `
+      + 'card to open one from.',
+    );
+
+    let switched = false;
+    let sourcesBeforeSwitch: Set<string> | null = null;
+    let baseline: CatalogModel[] | null = null;
+    try {
+      if (agent!.mode !== 'hub') {
+        // Same snapshot the `gateway` fixture takes, for the same reason: on a
+        // machine whose CLI holds a native login the Direct→Gateway switch
+        // APPENDS a `native_cli` source, and it carries no suite prefix for the
+        // sweep to find.
+        sourcesBeforeSwitch = new Set((await api.sources()).map((source) => source.id));
+        // Marked before the await, not after it succeeds: the server commits
+        // the mode before the response leaves, so a lost response would skip
+        // the restore on exactly the path that needs it.
+        switched = true;
+        await api.setAgentMode(BACKEND, 'hub');
+      }
+
+      baseline = await api.catalogModels(BACKEND);
+      testInfo.skip(
+        baseline === null,
+        `This instance's ${BACKEND} payload carries no \`catalog_models\`, so it predates the saved `
+        + 'model list these specs read back. That projection arrives with the compose-from-providers '
+        + 'server.',
+      );
+
+      await provide({ backend: BACKEND, baseline: baseline! });
+    } finally {
+      // The list first and the mode second, each in its own block: they are
+      // independent promises, and a mode PUT that throws must not be the reason
+      // the suite's rows stay on the instance.
+      try {
+        if (baseline) await api.restoreCatalogModels(BACKEND, baseline);
+      } finally {
+        try {
+          if (switched) await api.setAgentMode(BACKEND, 'direct');
+        } finally {
+          if (sourcesBeforeSwitch) await restoreNativeSources(api, sourcesBeforeSwitch);
+        }
+      }
+    }
+  },
+});
+
+test.describe('OpenCode models · bare ids, and the one field that names the API', () => {
+  test('takes a typed ID verbatim and stores it on the API the editor asked for', async ({ api, hub, opencode }) => {
+    await hub.goto();
+    await hub.manageModelsButton(opencode.backend).click();
+
+    const catalog = hub.catalogDialog;
+    await expect(catalog).toBeVisible();
+    // Enabled is this dialog's own "ready": it reads the saved list first, and
+    // counting rows before that would count a list still arriving.
+    const addModels = labelledButton(catalog, copy('gateway.catalog.add'));
+    await expect(addModels).toBeEnabled();
+    const before = await hub.catalogRows.count();
+
+    await addModels.click();
+    const picker = hub.pickerDialog;
+    await expect(picker).toBeVisible();
+    await picker.getByRole('button', { name: copy('gateway.picker.custom'), exact: true }).click();
+
+    const editor = hub.modelEditorDialog;
+    await expect(editor).toBeVisible();
+    // An id models.dev has never heard of, which is the case the typeahead's
+    // last row exists for — and the case the default below is chosen for.
+    const typed = `${E2E_SOURCE_PREFIX}model-${Date.now()}`;
+    await hub.modelIdField.fill(typed);
+    await hub.literalIdOption.click();
+    // Bare: the id the row will carry is the string that was typed. Nothing is
+    // prefixed onto it, by the backend's scheme or by the protocol.
+    expect(await hub.modelIdField.inputValue()).toBe(typed);
+
+    const field = hub.nativeProtocolField;
+    await expect(field).toBeVisible();
+    // Nobody published this id, so nothing can be derived from it; the form
+    // opens on the answer a self-hosted or proxied endpoint almost always is,
+    // rather than refusing to save without one.
+    expect(await answeredProtocol(field)).toBe('openai_responses');
+
+    // And the answer is the user's. An endpoint serving this model over the
+    // Messages API is the whole reason the field is asked at all, so the other
+    // one has to survive the save.
+    await field.getByRole('radio', { name: protocolLabel('anthropic'), exact: true }).click();
+    await labelledButton(editor, copy('gateway.modelEditor.add')).click();
+    await expect(editor).toHaveCount(0);
+
+    await expect(hub.catalogRow(typed)).toBeVisible();
+    await expect(hub.catalogRows).toHaveCount(before + 1);
+    // The list shows the row and says nothing about how it is spoken to.
+    await expectVisibleWithout(catalog, PROTOCOL_WORDS);
+
+    await labelledButton(catalog, copy('gateway.catalog.save')).click();
+    await expect(catalog).toHaveCount(0);
+
+    // What the SERVER holds, not what the dialog was holding: the row is stored
+    // under the bare id, carrying the API that was chosen for it.
+    const stored = (await api.catalogModels(opencode.backend)) ?? [];
+    const row = stored.find((model) => model.id === typed);
+    expect(
+      row,
+      `The saved ${opencode.backend} list has no row for ${typed}; it holds ${stored.map((model) => model.id).join(', ')}.`,
+    ).toBeDefined();
+    expect(row?.native_protocol).toBe('anthropic');
+
+    // Stored, and still not shown: the card is the surface the row reaches once
+    // the dialog is gone.
+    await expectVisibleWithout(hub.agentCard(opencode.backend), PROTOCOL_WORDS);
+  });
+
+  test('saves a picked model under the id it was offered as, on the API it was picked with', async ({ api, hub, opencode }) => {
+    test.skip(
+      !(await api.servesModelCandidates(opencode.backend)),
+      'This instance does not serve the models a backend can be given '
+        + '(GET /api/models/agents/<backend>/models/candidates), so the picker has no built-in group and no '
+        + 'provider group to offer. That read arrives with the compose-from-providers server, and the '
+        + 'integration pass on a server that has it is the layer that can execute this scenario.',
+    );
+
+    await hub.goto();
+    await hub.manageModelsButton(opencode.backend).click();
+
+    const catalog = hub.catalogDialog;
+    const addModels = labelledButton(catalog, copy('gateway.catalog.add'));
+    await expect(addModels).toBeEnabled();
+    const before = await hub.catalogRows.count();
+
+    await addModels.click();
+    const picker = hub.pickerDialog;
+    await expect(picker).toBeVisible();
+    // Settled is either an offer or the answer that there is nothing to offer;
+    // waiting on a row alone would spend the whole timeout on the second one.
+    const offers = hub.pickerOffers;
+    await expect(offers.first().or(picker.getByText(copy('gateway.picker.noMatch')))).toBeVisible();
+
+    const available = await offers.count();
+    test.skip(
+      available === 0,
+      `Every model this instance can offer ${opencode.backend} is already in its list, so the picker has `
+        + 'nothing left to add.',
+    );
+
+    // The offer is a list surface, and the protocol every candidate carries is
+    // decided by the time it is offered — so this is the first place it could
+    // leak, and the first place it may not.
+    await expectVisibleWithout(picker, PROTOCOL_WORDS);
+
+    const offered = await pickerRowId(offers.first());
+    await offers.first().click();
+    await labelledButton(picker, copy('gateway.picker.confirm', { count: 1 })).click();
+    await expect(picker).toHaveCount(0);
+
+    // The same string in the list as on the offer: an id is not rewritten by
+    // being added.
+    await expect(hub.catalogRow(offered)).toBeVisible();
+    await expect(hub.catalogRows).toHaveCount(before + 1);
+    await expectVisibleWithout(catalog, PROTOCOL_WORDS);
+
+    // The row's own actions are named after what the row DISPLAYS, which is its
+    // name when it has one and its id when it does not — so the label is read
+    // off the row rather than assumed to be the id.
+    const row = hub.catalogRow(offered);
+    const shownAs = (await row.locator('.model-hub-catalog-name').innerText()).trim();
+    await row.getByRole('button', { name: copy('gateway.catalog.edit', { model: shownAs }), exact: true }).click();
+
+    const editor = hub.modelEditorDialog;
+    await expect(editor).toBeVisible();
+    const field = hub.nativeProtocolField;
+    await expect(field).toBeVisible();
+    // A picked model arrives already answered: models.dev knows whose model it
+    // is, and the vendor family is what the protocol follows from. Which of the
+    // two it landed on depends on the model this instance happened to offer, so
+    // what is asserted is that it landed on one of them — and then that the
+    // OTHER one survives being chosen, which no default can fake.
+    const proposed = await answeredProtocol(field);
+    const chosen = otherProtocol(proposed);
+    await field.getByRole('radio', { name: protocolLabel(chosen), exact: true }).click();
+    await labelledButton(editor, copy('gateway.modelEditor.apply')).click();
+    await expect(editor).toHaveCount(0);
+
+    await labelledButton(catalog, copy('gateway.catalog.save')).click();
+    await expect(catalog).toHaveCount(0);
+
+    const stored = (await api.catalogModels(opencode.backend)) ?? [];
+    const saved = stored.find((model) => model.id === offered);
+    expect(
+      saved,
+      `The saved ${opencode.backend} list has no row for the offered id ${offered}; it holds `
+        + `${stored.map((model) => model.id).join(', ')}. An id that changed between the offer and the `
+        + 'row is the prefixing this scheme removed.',
+    ).toBeDefined();
+    expect(saved?.native_protocol).toBe(chosen);
+
+    await expectVisibleWithout(hub.agentCard(opencode.backend), PROTOCOL_WORDS);
+  });
+});

--- a/ui/e2e/support/api.ts
+++ b/ui/e2e/support/api.ts
@@ -69,6 +69,23 @@ export type Agent = {
   [key: string]: unknown;
 };
 
+/**
+ * One row of a backend's saved model list, as the server projects it back.
+ *
+ * Loose on purpose: the row carries the whole editor form, and a spec that
+ * named every field would have to be revised by every change to it. What is
+ * spelled out is the pair a projection assertion is about — the id the row is
+ * stored under, and, on an OpenCode row, which of the two APIs Avibe answers
+ * that model on. `native_protocol` is REQUIRED on an OpenCode row (C8) and
+ * absent on every other backend's, so `undefined` here is a real answer about
+ * the row, not a gap in this type.
+ */
+export type CatalogModel = {
+  id: string;
+  native_protocol?: string;
+  [key: string]: unknown;
+};
+
 export type Probe = {
   reachable: boolean;
   source_id?: string | null;
@@ -339,6 +356,60 @@ export class HubApi {
     }
     const candidates = (payload as { candidates?: unknown }).candidates;
     return typeof candidates === 'object' && candidates !== null;
+  }
+
+  /**
+   * A backend's saved model list, read where the product reads it.
+   *
+   * The list is not on `/api/models/agents`: the catalog dialog loads its
+   * baseline from this backend-scoped read, and `catalog_models` is the
+   * server's own projection of the rows — the same object a save echoes back.
+   * Asking here rather than reconstructing the list from `model_supply` is what
+   * makes a projection assertion an assertion about what was STORED; the supply
+   * carries ids and routability, and none of the row's own fields.
+   *
+   * `null` when the payload carried no `catalog_models` — a server that
+   * predates the catalog, which is a fact about the instance and a skip, not a
+   * read that failed.
+   */
+  async catalogModels(backend: string): Promise<CatalogModel[] | null> {
+    const payload = await this.read<{ agent?: { catalog_models?: CatalogModel[] | null } }>(
+      `/api/models/agents/${backend}/sources`,
+    );
+    return payload.agent?.catalog_models ?? null;
+  }
+
+  /**
+   * Puts a backend's model list back to `models`, and THROWS if it did not land.
+   *
+   * The baseline is re-read HERE rather than taken from the caller, because the
+   * server checks the PUT against the list it currently holds and the caller is
+   * teardown — which asks for this precisely when the spec that ran in between
+   * has changed that list. A restore sent against a stale baseline is refused,
+   * and a refusal a teardown swallows leaves the suite's rows on the instance
+   * for every spec after it.
+   *
+   * Removing a row can take a route with it, which the server guards; teardown
+   * is exactly the caller that means it, so the refusal's own plan is echoed
+   * back the way `deleteSource` does.
+   */
+  async restoreCatalogModels(backend: string, models: CatalogModel[]): Promise<void> {
+    const path = `/api/models/agents/${backend}/models`;
+    const baseline = (await this.catalogModels(backend)) ?? [];
+    const first = await this.mutate('put', path, { baseline, models });
+    if (first.ok) return;
+    const forced = await this.mutate('put', path, {
+      baseline,
+      models,
+      force: true,
+      ...refusedPlan(first.body),
+    });
+    if (forced.ok) return;
+    throw new Error(
+      `Could not restore backend ${backend}'s model list: first attempt ${first.status}, forced attempt `
+        + `${forced.status} ${JSON.stringify(forced.body)}. The list this spec left is still on the `
+        + 'instance, and every spec after this one inherits it.',
+    );
   }
 
   /** `null` here means the payload carried no `runtime` — an answered read with

--- a/ui/e2e/support/hub.ts
+++ b/ui/e2e/support/hub.ts
@@ -334,10 +334,18 @@ export class ModelHubPage {
 
   /** The last row of the editor's typeahead: take the query as the id. It is
    *  present in every open state, including "searching" and "unavailable", and
-   *  it names the id it will actually create — which on a backend with an
-   *  identifier scheme of its own is not the query as typed. */
+   *  it names the id it will actually create, which is the query canonicalized
+   *  rather than the raw characters in the box. */
   get literalIdOption(): Locator {
     return this.modelEditorDialog.locator('.model-hub-model-match--literal');
+  }
+
+  /** The editor's `API` field, present for OpenCode rows only. */
+  get nativeProtocolField(): Locator {
+    return this.modelEditorDialog.getByRole('radiogroup', {
+      name: hub('gateway.modelEditor.nativeProtocol.label'),
+      exact: true,
+    });
   }
 }
 

--- a/ui/src/components/settings/models/BackendModelEditorDialog.test.tsx
+++ b/ui/src/components/settings/models/BackendModelEditorDialog.test.tsx
@@ -61,6 +61,12 @@ const answered = (name: 'Tool calling' | 'Reasoning'): string | null =>
   capability(name).getAllByRole('radio').find((radio) => radio.getAttribute('aria-checked') === 'true')?.textContent
     ?? null;
 
+/** The one surface anywhere that names the protocol. */
+const protocol = () => within(screen.getByRole('radiogroup', { name: 'API' }));
+
+const protocolAnswer = (): string | null =>
+  protocol().getAllByRole('radio').find((radio) => radio.getAttribute('aria-checked') === 'true')?.textContent ?? null;
+
 const modelField = () => screen.getByLabelText('Model') as HTMLInputElement;
 
 const spy = () => vi.spyOn(modelsApi, 'searchModelsDev');
@@ -275,10 +281,76 @@ describe('BackendModelEditorDialog', () => {
     await user.click(await screen.findByRole('option', { name: 'Use "glm-4.7" as the model ID' }));
 
     expect(modelField().value).toBe('glm-4.7');
+    // An id nobody published says nothing about how it is spoken to, and the two
+    // answers are not equally likely: OpenAI Responses is what a self-hosted or
+    // proxied endpoint almost always is.
+    expect(protocolAnswer()).toBe('OpenAI Responses');
     await user.click(screen.getByRole('button', { name: 'Add model' }));
     expect(onCommit).toHaveBeenCalledWith(expect.objectContaining({
       id: 'glm-4.7',
       origin: 'manual',
+      native_protocol: 'openai_responses',
+    }));
+  });
+
+  it('asks for the API only where there is a choice, and asks for it last', () => {
+    // The protocol is how Avibe answers OpenCode for this model, not a fact
+    // about the model — so it is the one thing on this form that is about the
+    // backend, and the only backend that has two of them is the one that is
+    // asked. On the others the question has no answer to offer.
+    for (const backend of ['claude', 'codex'] as const) {
+      renderEditor({ backend });
+      expect(screen.queryByRole('radiogroup', { name: 'API' })).toBeNull();
+      cleanup();
+    }
+
+    renderEditor({ backend: 'opencode' });
+    // Last, because it is the only field the user is not expected to touch: the
+    // form reads as the model first and the wiring after it.
+    const fields = Array.from(document.querySelectorAll('[role="group"],[role="radiogroup"]'));
+    expect(fields.at(-1)?.getAttribute('aria-label')).toBe('API');
+  });
+
+  it('takes the API from the model that was picked, and commits the one the user changes it to', async () => {
+    const user = userEvent.setup();
+    search.mockResolvedValue([match({ model_id: 'glm-4.7', display_name: 'GLM 4.7' })]);
+    const { onCommit } = renderEditor({ backend: 'opencode' });
+
+    await user.type(modelField(), 'glm');
+    await user.click(await screen.findByRole('option', { name: /GLM 4\.7/ }));
+
+    // models.dev knows whose model this is, and the vendor family is what the
+    // protocol follows from — so a picked model arrives already answered.
+    expect(protocolAnswer()).toBe('Anthropic Messages');
+
+    // And the answer is still the user's: an endpoint that serves someone else's
+    // model over the other API is exactly the case this field exists for.
+    await user.click(protocol().getByRole('radio', { name: 'OpenAI Responses' }));
+    await user.click(screen.getByRole('button', { name: 'Add model' }));
+
+    expect(onCommit).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'glm-4.7',
+      origin: 'models_dev',
+      native_protocol: 'openai_responses',
+    }));
+  });
+
+  it('opens a saved OpenCode row on the API it is stored with', async () => {
+    const user = userEvent.setup();
+    const saved: BackendModel = {
+      ...blankBackendModel(),
+      id: 'glm-4.7',
+      display_name: 'GLM 4.7',
+      native_protocol: 'anthropic',
+    };
+    const { onCommit } = renderEditor({ backend: 'opencode', model: saved, takenIds: new Set([saved.id]) });
+
+    expect(protocolAnswer()).toBe('Anthropic Messages');
+    await user.click(protocol().getByRole('radio', { name: 'OpenAI Responses' }));
+    await user.click(screen.getByRole('button', { name: 'Save model' }));
+
+    expect(onCommit).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'glm-4.7',
       native_protocol: 'openai_responses',
     }));
   });

--- a/ui/src/components/settings/models/BackendModelEditorDialog.tsx
+++ b/ui/src/components/settings/models/BackendModelEditorDialog.tsx
@@ -29,11 +29,13 @@ import {
   BACKEND_MODEL_ID_MAX_LENGTH,
   BACKEND_MODEL_INPUT_MODALITIES,
   BACKEND_MODEL_OUTPUT_MODALITIES,
+  NATIVE_PROTOCOLS,
   type AgentBackend,
   type BackendModel,
   type BackendModelInputModality,
   type BackendModelOutputModality,
   type ModelsDevMatch,
+  type NativeProtocol,
 } from './types';
 
 type FillState = 'idle' | 'loading' | 'error';
@@ -181,10 +183,8 @@ export const BackendModelEditorDialog: React.FC<{
     // A seeded add opens with the query already running: the user typed it in
     // the picker, and asking for it again would be the surface forgetting. The
     // id it lands as goes through the one chokepoint like every other produced
-    // id — a seed that skipped it would be an id the backend refuses, arriving
-    // by the one route nobody watches. The query stays what was typed: it is a
-    // models.dev search, and searching for the resolved id would search for the
-    // vendor prefix the resolver just added.
+    // id — a seed that skipped it would be a row missing what that chokepoint
+    // is the only place to give it, arriving by the one route nobody watches.
     const next = model ?? draftWithId(blankBackendModel(), seedId?.trim() ?? '', backend);
     seed(next);
     setLookup(model === null ? seedId?.trim() ?? '' : '');
@@ -400,6 +400,7 @@ export const BackendModelEditorDialog: React.FC<{
 
   const efforts = [...new Set([...effortSuggestions, ...draft.reasoning_efforts])];
   const backendName = t(`settings.models.backends.${backend}`, { defaultValue: backend });
+  const protocolLabel = t('settings.models.gateway.modelEditor.nativeProtocol.label') as string;
   const idHint = submitted && idError ? t(`settings.models.gateway.modelEditor.id.${idError}`) as string : null;
 
   return (
@@ -517,9 +518,9 @@ export const BackendModelEditorDialog: React.FC<{
                             activeRow === matches.length && 'is-selected',
                           )}
                         >
-                          {/* The id it will create, not the raw query: on
-                              OpenCode those differ, and the row that names the
-                              other one would be describing a different model. */}
+                          {/* The id it will create, through the same resolver
+                              `commit` uses — not the raw query, whose
+                              surrounding whitespace is not part of the id. */}
                           <span className="model-hub-model-match-literal min-w-0 truncate">
                             {t('settings.models.gateway.modelEditor.useAsId', {
                               query: backendModelId(lookup.trim()),
@@ -675,6 +676,40 @@ export const BackendModelEditorDialog: React.FC<{
               </div>
             )}
           </section>
+
+          {/* The protocol, and the only surface that names it.
+            *
+            * It is a fact about the provider overlay OpenCode is given — which
+            * of the two APIs Avibe answers this model on — not a capability of
+            * the model, so it gets its own block rather than a place under the
+            * group above. Unlabelled, and last: the field label is the one
+            * string this mechanism is allowed to add anywhere, which is also
+            * why no list, picker, row, or chip shows it.
+            *
+            * The value is read from `resolved` rather than from a default of
+            * this component's own, so the box shows what the row would be
+            * stored with. Non-null because C8 makes it required on an OpenCode
+            * row: the server sends one with every saved row, and `draftWithId`
+            * gives every produced row its own — a missing value here would be
+            * that chokepoint broken, not a state to render. */}
+          {backend === 'opencode' && (
+            <section className="model-hub-model-section">
+              <div className="grid gap-3 sm:grid-cols-2 sm:gap-6">
+                <div className="flex min-w-0 flex-col gap-1.5">
+                  <p className="model-hub-model-field-label">{protocolLabel}</p>
+                  <SegmentedRadio
+                    value={resolved.native_protocol!}
+                    onChange={(next: NativeProtocol) => patch({ native_protocol: next })}
+                    options={NATIVE_PROTOCOLS.map((id) => ({
+                      id,
+                      label: t(`settings.models.gateway.modelEditor.nativeProtocol.${id}`) as string,
+                    }))}
+                    ariaLabel={protocolLabel}
+                  />
+                </div>
+              </div>
+            </section>
+          )}
         </div>
 
         <DialogFooter className="model-hub-model-editor-foot shrink-0 items-center border-t border-border sm:justify-end">

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -1011,8 +1011,7 @@
             "placeholder": "Search models.dev or enter a model ID",
             "required": "Enter a backend model ID.",
             "tooLong": "A model ID may be at most 256 characters.",
-            "invalid": "An OpenCode model ID is provider/model, and needs both halves.",
-          "duplicate": "This list already has a model with this ID."
+            "duplicate": "This list already has a model with this ID."
           },
           "displayName": {
             "label": "Display name",
@@ -1046,6 +1045,11 @@
           "customEffort": "Custom effort",
           "customEffortPlaceholder": "e.g. medium",
           "effortNote": "Efforts are sent to the provider verbatim; with none selected, the request omits the effort parameter.",
+          "nativeProtocol": {
+            "label": "API",
+            "openai_responses": "OpenAI Responses",
+            "anthropic": "Anthropic Messages"
+          },
           "cancel": "Cancel",
           "add": "Add model",
           "apply": "Save model"

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -1011,8 +1011,7 @@
             "placeholder": "搜索 models.dev 或输入模型 ID",
             "required": "请填写 Backend 模型 ID。",
             "tooLong": "模型 ID 最多 256 个字符。",
-            "invalid": "OpenCode 模型 ID 的格式是 provider/model，两段都不能为空。",
-          "duplicate": "列表中已存在相同 ID 的模型。"
+            "duplicate": "列表中已存在相同 ID 的模型。"
           },
           "displayName": {
             "label": "显示名称",
@@ -1046,6 +1045,11 @@
           "customEffort": "自定义档位",
           "customEffortPlaceholder": "如 medium",
           "effortNote": "档位按原样发送给供应商；不选则请求不带 effort 参数。",
+          "nativeProtocol": {
+            "label": "API",
+            "openai_responses": "OpenAI Responses",
+            "anthropic": "Anthropic Messages"
+          },
           "cancel": "取消",
           "add": "添加模型",
           "apply": "保存模型"


### PR DESCRIPTION
## What changes

The UI half of OpenCode v4. The backend lane (#1865, merged) made `native_protocol`
travel on every picker candidate, every models.dev match, and every OpenCode
`BackendModel` row, and made menu ids bare. This lane gives that field its one
surface and makes sure it has no others.

- **Model editor** — for OpenCode rows only, a last field labelled `API` with two
  options, `OpenAI Responses` and `Anthropic Messages`. It sits after the
  capabilities section, uses the same `SegmentedRadio` primitive and the same
  label/grid/gap classes as `Tool calling` and `Reasoning`, and carries no helper
  text. Saving sends the value as `native_protocol` on the row. The field is absent
  for Claude Code and Codex.
- **Default** — the value the picked candidate or models.dev match proposed; for a
  typed id, `openai_responses` (`draftWithId` already applies that rule, so the
  editor reads it rather than restating it).
- **Everywhere else** — the protocol is an internal mechanism. Two stale
  `vendor/model` comments left behind by the id change are rewritten, and
  `model-list.spec.ts` now asserts the created id `toBe` the typed string rather
  than merely containing it, so a reintroduced prefix fails the test instead of
  passing it.

Copy lands in `en.json` and `zh.json` 1:1. `zh.json` keeps `OpenAI Responses` /
`Anthropic Messages` verbatim in English, matching how it already keeps
`models.dev`, `tokens`, and `PDF`. The dead
`settings.models.gateway.modelEditor.id.invalid` key — the old "an OpenCode model ID
is `provider/model`" error, unreferenced since the bare-id change — is removed from
both bundles.

Depends on #1865 (merged). Branched from `9fc35b19d`.

## Spec

- `docs/plans/backend-model-catalogs.md` — "v3 — OpenCode: bare ids, per-protocol
  overlay (2026-09-04)": C8, the Copy table, Acceptance 6.
- `docs/plans/model-hub.md` §4.8 v4.

Pre-release: no compatibility shims, no fallbacks for old ids or shapes.

## Evidence

**Unit** — `BackendModelEditorDialog.test.tsx`, 27 passing. Four claims are new or
extended:

- an OpenCode query is taken as the bare model id, and the editor answers
  `OpenAI Responses` for it;
- the `API` field is asked for only where there is a choice, and asked for last —
  the same assertion reads the Codex and Claude Code editors and finds no such
  field;
- the value a picked model arrived with is the one shown, and the one the user
  changes it to is the one committed;
- a saved OpenCode row opens on the protocol it is stored with.

**E2E** — `ui/e2e/model-opencode.spec.ts` (new), against a live instance with
OpenCode installed and the hub in Gateway mode; it skips itself otherwise and
restores both the source mode and the catalog baseline in nested `finally` blocks.

- a typed custom id is created verbatim, defaults to `OpenAI Responses`, and is
  stored on whichever protocol the editor was left on;
- a picked model keeps the id it was offered as and the protocol it was picked
  with, read back from the row projection;
- both tests scan every list surface — catalog rows, picker rows, the agent card —
  against a regex over `openai_responses`, `avibe-openai`, `avibe-anthropic`, and
  the two copy labels, and assert no match. (Bare `anthropic` is deliberately out
  of that alternation: it is also a provider name, a vendor id, and a substring of
  real model ids, so matching it would fail on correct output.)

**Visual** — the editor was rendered for a saved OpenCode row at 1440×900 (dpr 2)
and 390×844 (dpr 3, mobile + touch), in light and dark, and compared against the
design's `编辑模型 Dialog` frame in `../avibe-docs/design.pen`.

- The design's field pattern is a `字段名` label above its control; the new field
  follows it, and at 1440 the label renders at the same size, weight, and colour as
  `Tool calling` and `Reasoning` directly above it.
- One half-width grid column at 1440, stacking full-width at 390, from
  `grid gap-3 sm:grid-cols-2 sm:gap-6` — the same declaration `CapabilityField`
  uses.
- The section divider and padding come from `.model-hub-model-section`; in dark
  theme every colour resolves through the same tokens with no separate rule.
- Control render: the same editor opened for a Codex row at 1440 light has exactly
  two radiogroups, `Tool calling` and `Reasoning`.

No new design-system entries, no new tokens, and no hardcoded values: the field's
entire class set is `.model-hub-model-section`, `grid gap-3 sm:grid-cols-2 sm:gap-6`,
`flex min-w-0 flex-col gap-1.5`, `.model-hub-model-field-label`, and
`SegmentedRadio`. `modelHubStylePolicy.test.ts` runs over every non-test source in
the models directory and enforces that mechanically; it passes.

The renders themselves are not embedded here, by owner ruling: screenshots are not
committed to this public repo. The written comparison above and
`modelHubStylePolicy.test.ts` are the evidence of record; the images were reviewed
off-repo.

**Gates** — `npm run lint` (798 sources, no drift), `npx tsc --noEmit` over the e2e
sources, `npm run build` (✓ 2.12s), `npx vitest run` (3698 tests / 283 files, all
passing). No Python changed, so `ruff` has nothing in scope locally.

## Scope

Untouched by design: Python, contracts, `ui/src/…/types.ts` (already carries
`native_protocol`), and the backend e2e drivers.

