### PR TITLE
test(model-hub): typecheck the model-hub test project in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,6 +52,10 @@ jobs:
           npm ci
           npm run validate:theme
           npm run lint
+          # `npm run build` runs `tsc -b`, whose projects exclude every
+          # `*.test.ts(x)`, and vitest strips types without checking them. So no
+          # gate below reads a test file's types; this one does.
+          npm run typecheck:tests
           npm test
           npm run build
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -15,6 +15,7 @@
     "lint:baseline": "node scripts/lint-baseline.mjs --update",
     "preview": "vite preview",
     "test": "vitest run",
+    "typecheck:tests": "tsc -p src/components/settings/models/tsconfig.tests.json --noEmit",
     "test:crypto": "vitest run src/lib/vaultCrypto.test.ts",
     "e2e": "playwright test",
     "e2e:headed": "playwright test --headed",

--- a/ui/src/components/settings/models/AgentCard.test.tsx
+++ b/ui/src/components/settings/models/AgentCard.test.tsx
@@ -39,7 +39,7 @@ const localeInstance = (lng: 'en' | 'zh') => {
 const source = (id: string, name: string): Source => ({
   id, last_discovered_at: null, kind: 'api_key', vendor: 'anthropic', display_name: name,
   protocol: 'anthropic', supply_channel: 'hub', billing: 'metered', state: { status: 'active', retry_at: null, detail_key: null },
-  models: [{ id: 'claude-opus-4-6', origin: 'discovered', reasoning_efforts: [] }],
+  models: [{ id: 'claude-opus-4-6', origin: 'discovered', reasoning_efforts: [], reasoning_efforts_source: null }],
 });
 const hubAgent: AgentSupply = {
   backend: 'claude', cli_present: true, mode: 'hub', menu_kind: 'fixed', selected_model_id: 'claude-opus-4-6', selected_model_explicit: true,

--- a/ui/src/components/settings/models/RouteChainDialog.test.tsx
+++ b/ui/src/components/settings/models/RouteChainDialog.test.tsx
@@ -105,16 +105,16 @@ const stocked = () => ({
     {
       ...sources[0],
       models: [
-        { id: "claude-opus-5", origin: "discovered", reasoning_efforts: [] },
-        { id: "claude-sonnet-5", origin: "discovered", reasoning_efforts: [] },
-        { id: "claude-haiku-5", origin: "discovered", reasoning_efforts: [] },
+        { id: "claude-opus-5", origin: "discovered", reasoning_efforts: [], reasoning_efforts_source: null },
+        { id: "claude-sonnet-5", origin: "discovered", reasoning_efforts: [], reasoning_efforts_source: null },
+        { id: "claude-haiku-5", origin: "discovered", reasoning_efforts: [], reasoning_efforts_source: null },
       ],
     },
     {
       ...sources[1],
       models: [
-        { id: "opus-5", origin: "discovered", reasoning_efforts: [] },
-        { id: "sonnet-5", origin: "discovered", reasoning_efforts: [] },
+        { id: "opus-5", origin: "discovered", reasoning_efforts: [], reasoning_efforts_source: null },
+        { id: "sonnet-5", origin: "discovered", reasoning_efforts: [], reasoning_efforts_source: null },
       ],
     },
   ] satisfies Source[],

--- a/ui/src/components/settings/models/SettingsModelsPage.render.test.tsx
+++ b/ui/src/components/settings/models/SettingsModelsPage.render.test.tsx
@@ -15,7 +15,7 @@ import type { ModelsSurfaceKind } from './modelHubSurfaceState';
 import { modelsApi } from './modelsApi';
 import { SOURCE_MUTATION_REPORT_PROJECTIONS } from './mutationSettlement';
 import { SettingsModelsPage } from './SettingsModelsPage';
-import { CONTRACT_VERSION, type AgentBackend, type AgentChain, type AgentSupply, type BackendModel, type RuntimeDependency, type Source, type UsageSummary } from './types';
+import { CONTRACT_VERSION, type AgentBackend, type AgentChain, type AgentSupply, type BackendModel, type RuntimeDependency, type RuntimeManifest, type Source, type UsageSummary } from './types';
 
 const directAgent = (backend: AgentBackend): AgentSupply => ({
   backend,
@@ -24,9 +24,17 @@ const directAgent = (backend: AgentBackend): AgentSupply => ({
   menu_kind: backend === 'opencode' ? 'open' : 'fixed',
 });
 
+// Named separately from `runtime` so it keeps the arm of `RuntimeManifest` it
+// was written as. Reached through `runtime.manifest` it is the whole union, and
+// re-resolving a spread of that lands on the `unresolved` arm, which carries no
+// version or source_sha for a resolution that requires both.
+const manifest = {
+  name: 'cliproxyapi', resolution: 'resolved', version: '1', source_sha: 'a'.repeat(40), assets: [],
+} satisfies RuntimeManifest;
+
 const runtime: RuntimeDependency = {
   contract_version: 8,
-  manifest: { name: 'cliproxyapi', resolution: 'resolved', version: '1', source_sha: 'a'.repeat(40), assets: [] },
+  manifest,
   status: { installed_version: '1', verified: true, health: 'ok' },
 };
 
@@ -497,7 +505,7 @@ describe('SettingsModelsPage surface branches', () => {
     const unsupported = {
       ...runtime,
       enabled: true,
-      manifest: { ...runtime.manifest, resolution: 'unsupported' as const },
+      manifest: { ...manifest, resolution: 'unsupported' as const },
       status: { ...runtime.status, health: 'not_installed' as const },
     };
     vi.spyOn(modelsApi, 'listSources').mockResolvedValue([]);
@@ -572,7 +580,7 @@ describe('SettingsModelsPage surface branches', () => {
   it('keeps tier-editor Escape local to the provider dialog', async () => {
     const editableSource: Source = {
       ...retainedSource,
-      models: [{ id: 'model-a', display_name: null, origin: 'manual', reasoning_efforts: ['high'] }],
+      models: [{ id: 'model-a', display_name: null, origin: 'manual', reasoning_efforts: ['high'], reasoning_efforts_source: 'user' }],
     };
     renderPage([editableSource]);
     const user = userEvent.setup();
@@ -737,7 +745,7 @@ describe('SettingsModelsPage surface branches', () => {
       presentation: { expects: 'none' as const },
     };
     const reauth = vi.spyOn(modelsApi, 'reauthSource').mockResolvedValue(started);
-    vi.spyOn(modelsApi, 'getOAuthStatus').mockResolvedValue(started);
+    vi.spyOn(modelsApi, 'getOAuthStatus').mockResolvedValue({ flow: started, created: null, repaired: null });
     renderPage([blockedSubscription]);
 
     await userEvent.click(await screen.findByRole('button', { name: /Claude native login/i }));
@@ -763,7 +771,7 @@ describe('SettingsModelsPage surface branches', () => {
       presentation: { expects: 'paste_callback_url' as const, auth_url: authUrl },
     };
     vi.spyOn(modelsApi, 'reauthSource').mockResolvedValue(started);
-    vi.spyOn(modelsApi, 'getOAuthStatus').mockResolvedValue(started);
+    vi.spyOn(modelsApi, 'getOAuthStatus').mockResolvedValue({ flow: started, created: null, repaired: null });
     const tab = { closed: false, opener: {} as unknown, location: { href: '' } };
     const open = vi.spyOn(window, 'open').mockReturnValue(tab as unknown as Window);
     renderPage([blockedSubscription]);
@@ -794,7 +802,7 @@ describe('SettingsModelsPage surface branches', () => {
       .spyOn(modelsApi, 'reauthSource')
       .mockRejectedValueOnce(new Error('start failed'))
       .mockResolvedValue(started);
-    vi.spyOn(modelsApi, 'getOAuthStatus').mockResolvedValue(started);
+    vi.spyOn(modelsApi, 'getOAuthStatus').mockResolvedValue({ flow: started, created: null, repaired: null });
     renderPage([blockedSubscription]);
 
     await userEvent.click(await screen.findByRole('button', { name: /Claude native login/i }));

--- a/ui/src/components/settings/models/SourceDetailPanel.test.tsx
+++ b/ui/src/components/settings/models/SourceDetailPanel.test.tsx
@@ -46,7 +46,7 @@ const source: Source = {
   billing: 'metered',
   credential_ref: 'cred_detail',
   state: { status: 'active', retry_at: null, detail_key: null },
-  models: [{ id: 'model-a', display_name: null, origin: 'manual', reasoning_efforts: ['high'] }],
+  models: [{ id: 'model-a', display_name: null, origin: 'manual', reasoning_efforts: ['high'], reasoning_efforts_source: 'user' }],
 };
 
 const heldHops = [{
@@ -223,7 +223,13 @@ const EchoPanel: React.FC<{
   );
 };
 
-const renderEchoPanel = (reconcile = vi.fn(), scheduler?: MutationScheduler) => render(
+// Typed off the prop rather than off `vi.fn()`: the default would otherwise
+// narrow the parameter to a mock and turn away the plain deferred-backed
+// reconcilers the settlement tests hand it.
+const renderEchoPanel = (
+  reconcile: React.ComponentProps<typeof EchoPanel>['reconcile'] = vi.fn(),
+  scheduler?: MutationScheduler,
+) => render(
   <ToastProvider>
     <I18nextProvider i18n={i18n}>
       <EchoPanel reconcile={reconcile} scheduler={scheduler} />
@@ -942,7 +948,7 @@ describe('SourceDetailPanel', () => {
   it('applies the refetch Source echo before the collection refresh settles', async () => {
     const echoed = {
       ...source,
-      models: [...source.models, { id: 'model-b', display_name: null, origin: 'discovered' as const, reasoning_efforts: [] }],
+      models: [...source.models, { id: 'model-b', display_name: null, origin: 'discovered' as const, reasoning_efforts: [], reasoning_efforts_source: null }],
     };
     const refresh = vi.spyOn(modelsApi, 'refreshSource').mockResolvedValueOnce({ source: echoed, discovered: echoed.models.length });
     const reconcile = vi.fn().mockResolvedValue(undefined);
@@ -960,7 +966,7 @@ describe('SourceDetailPanel', () => {
     const update = vi.spyOn(modelsApi, 'updateModelReasoningEfforts').mockReturnValueOnce(tierResponse.promise);
     const refreshed = {
       ...source,
-      models: [...source.models, { id: 'model-b', display_name: null, origin: 'discovered' as const, reasoning_efforts: [] }],
+      models: [...source.models, { id: 'model-b', display_name: null, origin: 'discovered' as const, reasoning_efforts: [], reasoning_efforts_source: null }],
     };
     const refetch = vi.spyOn(modelsApi, 'refreshSource').mockResolvedValueOnce({ source: refreshed, discovered: refreshed.models.length });
     renderEchoPanel(vi.fn(), serializedTrack());
@@ -1033,7 +1039,7 @@ describe('SourceDetailPanel', () => {
   it('applies the manual-create Source echo without waiting for a collection read', async () => {
     const echoed = {
       ...source,
-      models: [...source.models, { id: 'model-b', display_name: null, origin: 'manual' as const, reasoning_efforts: [] }],
+      models: [...source.models, { id: 'model-b', display_name: null, origin: 'manual' as const, reasoning_efforts: [], reasoning_efforts_source: null }],
     };
     vi.spyOn(modelsApi, 'addCustomModel').mockResolvedValueOnce(echoed);
     renderEchoPanel();
@@ -1279,7 +1285,7 @@ describe('SourceDetailPanel', () => {
   it('hands the editor to the row that was clicked instead of opening a second one', async () => {
     renderProtocol('openai_responses', [
       source.models[0],
-      { id: 'model-b', display_name: null, origin: 'discovered', reasoning_efforts: [] },
+      { id: 'model-b', display_name: null, origin: 'discovered', reasoning_efforts: [], reasoning_efforts_source: null },
     ]);
     await userEvent.click(screen.getByRole('button', { name: /high/i }));
     expect(screen.getAllByPlaceholderText(/Enter to add|回车添加/i)).toHaveLength(1);
@@ -1332,7 +1338,7 @@ describe('SourceDetailPanel', () => {
     const update = vi.spyOn(modelsApi, 'updateModelReasoningEfforts').mockRejectedValueOnce(new Error('write failed'));
     renderProtocol('openai_responses', [
       source.models[0],
-      { id: 'model-b', display_name: null, origin: 'discovered', reasoning_efforts: [] },
+      { id: 'model-b', display_name: null, origin: 'discovered', reasoning_efforts: [], reasoning_efforts_source: null },
     ]);
     await userEvent.click(screen.getByRole('button', { name: /high/i }));
     await userEvent.type(screen.getByPlaceholderText(/Enter to add|回车添加/i), 'low{Enter}');
@@ -1386,7 +1392,7 @@ describe('SourceDetailPanel', () => {
     // for one without — CSS nobody wears is not a hit area.
     renderProtocol('openai_responses', [
       source.models[0],
-      { id: 'model-b', display_name: null, origin: 'discovered', reasoning_efforts: [] },
+      { id: 'model-b', display_name: null, origin: 'discovered', reasoning_efforts: [], reasoning_efforts_source: null },
     ]);
     for (const name of [/high/i, /No tiers set|未设置档位/i]) {
       expect(screen.getByRole('button', { name }).className).toContain('model-hub-source-tier-cell');

--- a/ui/src/components/settings/models/modelsApiDeadline.test.ts
+++ b/ui/src/components/settings/models/modelsApiDeadline.test.ts
@@ -35,8 +35,12 @@ describe('Model Hub request deadlines', () => {
         signal?.addEventListener('abort', () => reject(signal.reason), { once: true });
       }));
     vi.stubGlobal('fetch', fetchMock);
+    // Narrowed to a call the compiler accepts for every member of the method
+    // union: no parameters, and a result assignable to each method's own return.
+    // The test calls each one with nothing — what it asserts is that a request
+    // goes out under a deadline, not what any method resolves to.
     const methods = Object.entries(modelsApi).filter(
-      (entry): entry is [string, (...args: never[]) => Promise<unknown>] =>
+      (entry): entry is [string, () => Promise<never>] =>
         typeof entry[1] === 'function',
     );
     const issuedSignals: AbortSignal[] = [];

--- a/ui/src/components/settings/models/mutationSettlement.test.ts
+++ b/ui/src/components/settings/models/mutationSettlement.test.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it, vi } from 'vitest';
 
-import { modelChainKey } from './modelRows';
+import { modelChainKey, type ModelChainIndex } from './modelRows';
 import type { SourceCreated } from './modelsApi';
 import {
   createContinuationSettlement,
@@ -13,9 +13,18 @@ import {
   SOURCE_MUTATION_REPORT_PROJECTIONS,
   sourceMutationLanding,
   sourceMutationReadScope,
+  type SourceMutationLandingReads,
 } from './mutationSettlement';
 import { failRegionRead, readyRegion, unreadRegion } from './regionRead';
 import type { AgentChain, AgentSupply, RuntimeDependency, Source } from './types';
+
+// Fails exactly one projection, keyed generically so each key carries its own
+// value type into `failRegionRead`. Indexing the reads with a union key hands
+// the compiler four candidate types for one inference site and it picks one.
+const degradeProjection = <K extends keyof SourceMutationLandingReads>(
+  reads: SourceMutationLandingReads,
+  projection: K,
+): SourceMutationLandingReads => ({ ...reads, [projection]: failRegionRead(reads[projection]) });
 
 describe('mutation settlement fences', () => {
   it('atomically rejects every effect belonging to an invalidated attempt', () => {
@@ -82,22 +91,19 @@ describe('mutation settlement fences', () => {
       SOURCE_MUTATION_REPORT_PROJECTIONS,
     ) as (keyof typeof SOURCE_MUTATION_REPORT_PROJECTIONS)[]) {
       expect(
-        sourceMutationLanding({
-          ...reads,
-          [projection]: failRegionRead(reads[projection]),
-        }, affectedChains, true).verdict,
+        sourceMutationLanding(degradeProjection(reads, projection), affectedChains, true).verdict,
         projection,
       ).toBe('degraded');
     }
 
     for (const request of affectedChains) {
       const key = modelChainKey(request.backend, request.modelId);
-      const missing = readyRegion({
+      const missing = readyRegion<ModelChainIndex>({
         ...Object.fromEntries(affectedChains.map(({ backend, modelId }) => [
           modelChainKey(backend, modelId),
           readyRegion({} as AgentChain),
-        ])),
-        [key]: unreadRegion(),
+        ] as const)),
+        [key]: unreadRegion<AgentChain>(),
       });
       expect(sourceMutationLanding({ ...reads, chains: missing }, affectedChains, true).verdict, key)
         .toBe('degraded');

--- a/ui/src/components/settings/models/oauthFailureClass.test.ts
+++ b/ui/src/components/settings/models/oauthFailureClass.test.ts
@@ -32,6 +32,9 @@ function failureConsumers(url: URL): FailureConsumer[] {
       && ts.isIdentifier(node.name)
       && isCallTo(node.initializer, 'apiFailure')
     ) {
+      // Read out here, where the guard above still holds: a narrowing on
+      // `node.name` does not survive into the nested closure below.
+      const declared = node.name.text;
       let scope: ts.Node | undefined = node.parent;
       while (scope && !ts.isBlock(scope)) scope = scope.parent;
       let classifies = false;
@@ -39,7 +42,7 @@ function failureConsumers(url: URL): FailureConsumer[] {
         if (
           isCallTo(child, 'classifyOAuthFailure')
           && child.arguments.some(
-            (argument) => ts.isIdentifier(argument) && argument.text === node.name.text,
+            (argument) => ts.isIdentifier(argument) && argument.text === declared,
           )
         ) {
           classifies = true;

--- a/ui/src/components/settings/models/routeChainDraft.test.ts
+++ b/ui/src/components/settings/models/routeChainDraft.test.ts
@@ -21,6 +21,7 @@ const source = (id: string, models: string[]): Source => ({
     id: modelId,
     origin: "discovered",
     reasoning_efforts: [],
+    reasoning_efforts_source: null,
   })),
 });
 

--- a/ui/src/components/settings/models/useSourceMutationReport.test.tsx
+++ b/ui/src/components/settings/models/useSourceMutationReport.test.tsx
@@ -1,5 +1,4 @@
 // @vitest-environment jsdom
-import * as React from 'react';
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { I18nextProvider } from 'react-i18next';
 import { afterEach, describe, expect, it, vi } from 'vitest';


### PR DESCRIPTION
Fixes #1841

## What changes

`ui/src/components/settings/models/tsconfig.tests.json` has existed since #1339
and nothing ever invoked it — not `npm run build`, not CI, not a package script.
`tsconfig.app.json` excludes every `*.test.ts(x)`, and vitest strips types
without checking them, so no gate in this repository read a UI test file's types
at all. That is why #1836 could make `reasoning_efforts_source` required on the
v8 wire type and leave ten of master's own fixtures ill-typed with CI green.

Two changes: every error that config reports is fixed, and the config is now run
by CI so the class cannot come back.

## The sweep

Baseline on `origin/master` `ab2b601cf`: **30 errors across 9 files**, exit 2.
All 30 are fixed, not only the headline class — the new gate fails on any of
them. By root cause:

| Cause | Sites | Fix |
|---|---|---|
| Missing `reasoning_efforts_source` | 5 files | Add the field per invariant 6 |
| `getOAuthStatus` mocked with an `OAuthFlow` | 3 | Wrap as `{flow, created, repaired}` |
| Manifest spread re-resolves the union | 2 | Name the fixture so it keeps its arm |
| `renderEchoPanel` typed off `vi.fn()` | 1 | Take the type from the prop it forwards |
| Narrowing lost in a nested closure | 1 | Read the declared name out where the guard holds |
| Type predicate + call arity | 2 | Narrow to a call every union member accepts |
| Unused `React` import | 1 | Removed (automatic JSX runtime) |

**The fixture value is behavioral, not cosmetic.** `managedTierSource` treats
`upstream` and `catalog` as managed, which makes a row's tiers read-only;
`user` and `null` leave it editable, and so does the field's absence. So
invariant 6's rule — `user` where `reasoning_efforts` is non-empty, `null` where
it is empty — reproduces exactly what each fixture already meant, and no
assertion moves. Mutation-verified: writing `upstream` on the hand-typed
`model-a` row instead fails 20 tests in `SourceDetailPanel.test.tsx`.

The other six causes are each a fixture or annotation that was already wrong
about a shape the production type declares. Two are worth naming:

- `getOAuthStatus` resolves an `OAuthResult`, not the `OAuthFlow` it was handed.
  The same file already mocks it correctly at `:239`; these three were the
  outliers.
- `{ ...runtime.manifest, resolution: 'unsupported' }` spreads the whole
  `RuntimeManifest` union, and re-resolving the `unresolved` arm produces a
  manifest with no `version` or `source_sha` for a resolution that requires
  both. Naming the fixture separately from `runtime` keeps it in the arm it was
  written as.

## The gate

One line inside the existing `build-linux-artifacts` → *Build UI assets* step,
between `npm run lint` and `npm test`, plus the script it names:

```
"typecheck:tests": "tsc -p src/components/settings/models/tsconfig.tests.json --noEmit"
```

Defined as a script rather than inlined in YAML so the command is the same one
a developer can run before pushing. A check that exists only inside a workflow
is a check nobody runs locally — which is the shape that produced this issue.

The config's `include` is already `./**/*.ts(x)` over the directory, so a test
file added later is covered without editing anything. No include fix needed.

## Evidence

- **Gate is clean**: `npm run typecheck:tests` exits 0 at this head (30 → 0).
- **Gate actually bites**: re-removing `reasoning_efforts_source` from one
  fixture makes it exit 2 with the original TS2741. Restoring returns it to 0.
- **No assertion weakened**: `npm test` — 283 files / 3699 tests pass. The
  model-hub directory alone is 80 files / 1202 tests.
- **Value choice mutation-verified**: `upstream` instead of `user` on the
  hand-typed row fails 20 of that file's 95 tests; `user` passes all 95.
- **Other gates at this head**: `npm run build`, `npm run validate:theme`,
  `npm run lint` (798 sources measured, no drift in any (file, rule) pair).
- **Workflow parses**: the edited step's `run` block round-trips through a YAML
  loader to exactly the intended eight lines.

No production code is touched. Diff is 9 test files, one workflow file, and one
`package.json` line.

## Known by design

- **The gate covers one directory, not every UI test.** That is the issue's ask
  and it is also the only affordable scope: a probe config over all of `src`
  with tests included reports **313 errors** across `components/workbench`,
  `lib/vaultCrypto`, `lib/voiceRecording` and others, including one
  `erasableSyntaxOnly` violation. Extending the gate repo-wide is a separate
  piece of work, not a line in this PR. Reported rather than attempted.
- **`ui/package.json` is outside the file scope I was given** (models test
  files, that tsconfig, one workflow file). One line, no dependency change —
  `typescript` is already a devDependency. Taken deliberately: putting the
  command in the workflow only would have re-created the defect this PR fixes,
  a check with no local caller.
- **The three `getOAuthStatus` mocks now return a different runtime value.**
  The tests passed before because they never reach a status poll; the shape is
  corrected because the type declares it, not because a test needed it.
- **`ui/scripts/lintBaseline.test.mjs` makes `npm run lint` non-reentrant.** It
  writes `ui/update-integrity-probe.ts` into the checkout and removes it in
  `finally`, so a concurrent lint run races the deletion and exits ENOENT.
  Out of scope; reported rather than edited. Lint is clean when run alone.

## CI state at this head

Owner merged `master` (including #1873) into this branch at `2d7b842e5`.
`lint` run `33940762540` is green on that exact SHA — every job, including
`unit-tests (1/6)` and `install-upgrade-regression`. The new gate ran:
`npm run typecheck:tests` → `tsc -p .../tsconfig.tests.json --noEmit`, no
output. `mergeStateStatus` is `CLEAN`.
