### PR TITLE
fix(model-hub): accept catalog-declared ultra tier in OpenCode config

### DIFF
--- a/modules/agents/opencode/server.py
+++ b/modules/agents/opencode/server.py
@@ -33,6 +33,7 @@ from modules.agents.opencode.caller_context import ensure_plugin_installed, serv
 from modules.agents.opencode.config_reconciler import OpenCodeConfigReconciler
 from vibe import runtime
 from vibe.opencode_config import (
+    OPENCODE_REASONING_VARIANTS,
     OpenCodeRuntimeConfigInvalidError,
     get_opencode_custom_provider_adapter,
     load_first_opencode_user_config,
@@ -2564,14 +2565,14 @@ class OpenCodeServerManager:
         if not config:
             return None
 
-        # Valid reasoning effort values
-        valid_efforts = {"none", "minimal", "low", "medium", "high", "xhigh", "max"}
+        # Accept exactly the tiers the save path can write, so a variant the
+        # user just persisted is never dropped here as "unknown".
 
         # Try agent-specific reasoningEffort first
         agent_config = self._get_agent_config(config, agent_name)
         reasoning_effort = agent_config.get("reasoningEffort")
         if isinstance(reasoning_effort, str) and reasoning_effort:
-            if reasoning_effort in valid_efforts:
+            if reasoning_effort in OPENCODE_REASONING_VARIANTS:
                 logger.debug(f"Found reasoningEffort '{reasoning_effort}' for agent '{agent_name}' in opencode.json")
                 return reasoning_effort
             else:
@@ -2580,7 +2581,7 @@ class OpenCodeServerManager:
         # Fall back to global default reasoningEffort
         reasoning_effort = config.get("reasoningEffort")
         if isinstance(reasoning_effort, str) and reasoning_effort:
-            if reasoning_effort in valid_efforts:
+            if reasoning_effort in OPENCODE_REASONING_VARIANTS:
                 logger.debug(f"Using global default reasoningEffort '{reasoning_effort}' from opencode.json")
                 return reasoning_effort
             else:

--- a/tests/test_opencode_reasoning_variants.py
+++ b/tests/test_opencode_reasoning_variants.py
@@ -1,0 +1,161 @@
+"""OpenCode must accept every reasoning tier the unified vocabulary declares.
+
+Regression guard for #1840. The OpenCode save allowlist was a hand-kept copy of
+the Model Hub vocabulary and fell behind when ``ultra`` was added for the
+gpt-5.6-sol / gpt-5.6-terra catalog rows, so a catalog-declared tier could not
+be persisted through the OpenCode provider form at all.
+
+The tests below are written as properties over the exported vocabulary rather
+than over a literal tier list: a tier added to the vocabulary later is covered
+without editing this file, which is the only form that would have caught the
+original drift.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from modules.agents.opencode import utils as opencode_utils
+from vibe import backend_model_catalog
+from vibe.backend_model_catalog import REASONING_EFFORT_VOCABULARY
+from vibe.opencode_config import (
+    OPENCODE_REASONING_VARIANTS,
+    get_opencode_config_paths,
+    upsert_opencode_provider_model,
+)
+
+
+def _written_model(home: Path, provider_id: str, model_id: str) -> dict:
+    config = json.loads(get_opencode_config_paths(home)[0].read_text(encoding="utf-8"))
+    return config["provider"][provider_id]["models"][model_id]
+
+
+def _catalog_declared_tiers() -> dict[str, tuple[str, ...]]:
+    """Every bundled-catalog row that names its own tiers, keyed by model id."""
+
+    return dict(backend_model_catalog.bundled_catalog_reasoning_efforts_by_model())
+
+
+def test_opencode_variants_mirror_the_unified_vocabulary() -> None:
+    # OpenCode adds exactly one token of its own: `none`, the opt-out.
+    assert OPENCODE_REASONING_VARIANTS == ("none", *REASONING_EFFORT_VOCABULARY)
+
+
+def test_every_vocabulary_tier_projects_to_an_openai_variant(tmp_path: Path) -> None:
+    upsert_opencode_provider_model(
+        "deepseek",
+        "relay-model",
+        reasoning_efforts=list(OPENCODE_REASONING_VARIANTS),
+        home=tmp_path,
+    )
+
+    assert _written_model(tmp_path, "deepseek", "relay-model")["variants"] == {
+        effort: {"reasoningEffort": effort} for effort in OPENCODE_REASONING_VARIANTS
+    }
+
+
+def test_every_vocabulary_tier_projects_to_an_anthropic_variant(tmp_path: Path) -> None:
+    upsert_opencode_provider_model(
+        "anthropic",
+        "relay-model",
+        reasoning_efforts=list(OPENCODE_REASONING_VARIANTS),
+        home=tmp_path,
+    )
+
+    assert _written_model(tmp_path, "anthropic", "relay-model")["variants"] == {
+        effort: {"thinking": {"type": "enabled", "effort": effort}}
+        for effort in OPENCODE_REASONING_VARIANTS
+    }
+
+
+def test_catalog_declared_tiers_round_trip_through_the_opencode_overlay(
+    tmp_path: Path,
+) -> None:
+    """Rung 2 applies a catalog row verbatim, so the overlay must take it whole.
+
+    Seeding every declaring row is complete by construction: a future row that
+    names a tier OpenCode rejects fails here without anyone remembering to add
+    a case for it.
+    """
+
+    declared = _catalog_declared_tiers()
+    assert declared, "bundled catalog declares no reasoning tiers"
+
+    for model_id, efforts in declared.items():
+        upsert_opencode_provider_model(
+            "deepseek",
+            model_id,
+            reasoning_efforts=list(efforts),
+            home=tmp_path,
+        )
+
+    for model_id, efforts in declared.items():
+        assert _written_model(tmp_path, "deepseek", model_id)["variants"] == {
+            effort: {"reasoningEffort": effort} for effort in efforts
+        }
+
+
+def test_family_default_suggestions_never_claim_ultra() -> None:
+    """Family defaults are rung-1 guesses about a model nobody has enumerated.
+
+    Claiming a tier the upstream does not have turns into a 400 on the next
+    turn, so the defaults stay a strict subset of the vocabulary even though
+    the vocabulary itself is the superset.
+    """
+
+    assert "ultra" in REASONING_EFFORT_VOCABULARY
+
+    protocol_defaults = backend_model_catalog.PROTOCOL_REASONING_EFFORT_DEFAULTS
+    assert protocol_defaults
+    assert all("ultra" not in efforts for efforts in protocol_defaults.values())
+
+    backend_defaults = backend_model_catalog._DEFAULT_REASONING_EFFORTS
+    assert backend_defaults
+    assert all("ultra" not in efforts for efforts in backend_defaults.values())
+
+    codex_options = opencode_utils.build_codex_reasoning_options()
+    assert "ultra" not in {option["value"] for option in codex_options}
+
+    claude_options = opencode_utils.build_claude_reasoning_options("claude-opus-5")
+    assert "ultra" not in {option["value"] for option in claude_options}
+
+
+def test_opencode_variant_display_tables_enumerate_the_shared_vocabulary() -> None:
+    assert tuple(opencode_utils._REASONING_VARIANT_ORDER) == OPENCODE_REASONING_VARIANTS
+    assert set(opencode_utils._REASONING_VARIANT_LABELS) == set(
+        OPENCODE_REASONING_VARIANTS
+    )
+
+
+def test_reasoning_dropdown_renders_every_vocabulary_tier_in_order() -> None:
+    catalog = {
+        "providers": [
+            {
+                "id": "avibe-openai",
+                "name": "Avibe · OpenAI",
+                "models": {
+                    "gpt-5.6-sol": {
+                        "id": "gpt-5.6-sol",
+                        "name": "GPT-5.6-Sol",
+                        "variants": {
+                            effort: {"reasoningEffort": effort}
+                            for effort in reversed(OPENCODE_REASONING_VARIANTS)
+                        },
+                        "vibe_remote": {"model_hub_projected": True},
+                    }
+                },
+            }
+        ],
+        "default": {},
+    }
+
+    options = opencode_utils.build_reasoning_effort_options(catalog, "gpt-5.6-sol")
+
+    assert options[0] == {"value": "__default__", "label": "(Default)"}
+    assert tuple(option["value"] for option in options[1:]) == OPENCODE_REASONING_VARIANTS
+    # Every tier carries a curated label; none falls through to `capitalize()`.
+    assert [option["label"] for option in options[1:]] == [
+        opencode_utils._REASONING_VARIANT_LABELS[effort]
+        for effort in OPENCODE_REASONING_VARIANTS
+    ]

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, Mock, patch
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from storage import message_deliveries as delivery_store
+from vibe.opencode_config import OPENCODE_REASONING_VARIANTS
 
 
 MODULE_PATH = Path(__file__).resolve().parents[1] / "modules" / "agents" / "opencode" / "server.py"
@@ -1136,6 +1137,26 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
                     "reasoningEffort": "high",
                 },
             )
+
+    async def test_agent_reasoning_effort_reads_back_every_savable_variant(self):
+        # A tier the save path can write must never be dropped here as unknown
+        # (#1840: catalog-declared `ultra` was rejected by both halves).
+        for effort in OPENCODE_REASONING_VARIANTS:
+            with self.subTest(effort=effort):
+                with tempfile.TemporaryDirectory() as tmp_dir:
+                    tmp_home = Path(tmp_dir)
+                    config_path = tmp_home / ".config" / "opencode" / "opencode.json"
+                    config_path.parent.mkdir(parents=True, exist_ok=True)
+                    config_path.write_text(
+                        json.dumps({"reasoningEffort": effort}),
+                        encoding="utf-8",
+                    )
+
+                    manager = OpenCodeServerManager(binary="opencode", port=4096)
+                    with patch("vibe.opencode_config.Path.home", return_value=tmp_home):
+                        resolved = manager.get_agent_reasoning_effort_from_config(None)
+
+                    self.assertEqual(resolved, effort)
 
     async def test_refresh_global_config_patches_live_server(self):
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/vibe/opencode_config.py
+++ b/vibe/opencode_config.py
@@ -7,11 +7,30 @@ import logging
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Final, Optional
 
 logger = logging.getLogger(__name__)
 
-_VALID_REASONING_VARIANTS = {"none", "minimal", "low", "medium", "high", "xhigh", "max"}
+# Every reasoning tier OpenCode accepts, in ascending order: the unified Model
+# Hub vocabulary (``vibe.backend_model_catalog.REASONING_EFFORT_VOCABULARY``)
+# plus OpenCode's own ``none``, which names the absence of reasoning rather
+# than a level.
+#
+# Mirrored rather than imported: this module is stdlib-only so the OpenCode
+# read path can stay cheap, while the catalog module pulls in the whole
+# ``config`` / ``modules`` import graph. A contract test asserts the mirror, so
+# a tier added to the vocabulary cannot silently fall out of OpenCode's save
+# path again — which is how catalog-declared ``ultra`` became unsavable (#1840).
+OPENCODE_REASONING_VARIANTS: Final[tuple[str, ...]] = (
+    "none",
+    "minimal",
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+    "max",
+    "ultra",
+)
 _CUSTOM_PROVIDER_META_KEY = "vibe_remote"
 _CUSTOM_PROVIDER_ADAPTERS = {
     "openai-compatible": "@ai-sdk/openai-compatible",
@@ -667,7 +686,7 @@ def _normalize_reasoning_variants(
         effort = raw.strip()
         if not effort:
             continue
-        if effort not in _VALID_REASONING_VARIANTS:
+        if effort not in OPENCODE_REASONING_VARIANTS:
             raise ValueError(f"unsupported reasoning effort: {effort}")
         if uses_anthropic_thinking:
             variants[effort] = {"thinking": {"type": "enabled", "effort": effort}}


### PR DESCRIPTION
Fixes #1840

## Changed capability

A catalog-declared `ultra` reasoning tier can now be persisted through the
OpenCode provider form, and read back afterwards.

Root cause: the save-path allowlist in `vibe/opencode_config.py` was a
hand-kept copy of the unified Model Hub vocabulary and fell behind when `ultra`
was added for the `gpt-5.6-sol` / `gpt-5.6-terra` catalog rows. Grepping for
the sibling lists named by the issue turned up a second drifted copy on the
read path (`OpenCodeServerManager.get_agent_reasoning_effort_from_config`),
which would have dropped a freshly-saved `ultra` as "unknown" — the same defect
one layer down, and a half-fix if left alone.

Both literals are gone. One ordered declaration, `OPENCODE_REASONING_VARIANTS`,
now owns the vocabulary for the whole OpenCode path, and a contract test pins it
to the exported `REASONING_EFFORT_VOCABULARY`, so a tier added there later cannot
silently fall out of either half again.

Family-default suggestions are deliberately unchanged: `PROTOCOL_REASONING_EFFORT_DEFAULTS`,
`_DEFAULT_REASONING_EFFORTS`, and the Codex/Claude option builders still exclude
`ultra`, per the 2026-09-03 ruling that an unknown relay model must not be
over-claimed. That exclusion now has its own test rather than being a property
nobody asserts.

## Evidence layers

**Unit** — `tests/test_opencode_reasoning_variants.py` (new, 7 tests), written as
properties over the exported vocabulary rather than over a literal tier list:

- the OpenCode list mirrors the unified vocabulary plus OpenCode's own `none`
- every vocabulary tier projects to an OpenAI-shaped `reasoningEffort` variant
- every vocabulary tier projects to an Anthropic-shaped `thinking` variant
- **every bundled-catalog row that declares tiers round-trips through the overlay
  verbatim** — seeded from the catalog, so a future row naming a tier OpenCode
  rejects fails here without anyone adding a case for it
- family defaults never claim `ultra`
- the OpenCode display order/label tables enumerate exactly the shared vocabulary
- the reasoning dropdown renders every tier in ascending order with a curated
  label (no `capitalize()` fallback)

**Unit** — `tests/test_opencode_server.py`: the agent-level read path resolves
every savable variant, iterated over the same shared declaration.

**Negative control** — reverting `ultra` out of the declaration fails the mirror
test, the display-table enumeration, and the catalog round-trip (the last one is
the #1840 reproduction). The two projection tests iterate the OpenCode list
itself, so they are anchored by the mirror test rather than independently.

**Focused suite** — `tests/{test_opencode_server,test_opencode_reasoning_variants,test_opencode_provider_base_url,test_backend_model_catalog,test_model_hub_reasoning_tiers,test_opencode_default_provider_routing}.py`: 214 passed.
Wider sweep `-k "opencode or model_hub"`: 2108 passed, 1 pre-existing failure (below).
`ruff check` clean on all changed files.

**Residual manual checks** — deferred to the integration pass: saving `ultra` on a
`gpt-5.6-sol` row through the live Settings → Models OpenCode provider form, and
confirming the tier appears in the IM reasoning-effort picker. Note that UI #1835
still clamps the checkboxes to `minimal`..`max`; this PR removes the backend gap
that made that clamp necessary, it does not change the UI.

## Dependencies

None. Branched from `origin/master` at `ab2b601cf`.

## Pre-existing failure on the base branch (not from this PR)

`tests/test_model_hub_config.py::test_model_hub_authority_closure_is_generated_from_live_files`
already fails on clean `origin/master`, so the `unit-tests` shard here will
inherit it. Verified by stashing every change in this branch and re-running.

Cause: `tests/test_model_hub_api.py:1190` carries a stale `"contract_version": 7`
literal in a fake RPC response, while the registry's terminal version is `8`;
`contract_version_closure.literal_globs` covers `tests/test_model_hub*.py`, so the
guard flags it. Introduced by #1862 — master's `lint` workflow is red at both
`d936f0d6b` and `ab2b601cf`, green at `bfe4216d9` before it.

Left untouched here: unrelated concern, and this PR was scoped to leave
`contract_version` alone. Flagged for the owner to land separately (one character).

## Known-by-design ledger

1. **`OPENCODE_REASONING_VARIANTS` mirrors `REASONING_EFFORT_VOCABULARY` instead of
   importing it.** `vibe/opencode_config.py` is stdlib-only, while
   `vibe/backend_model_catalog.py` pulls in the whole `config` → `modules.agents` →
   `core` import graph. Deriving would put that graph on the OpenCode config read
   path for one tuple. The mirror is contract-tested, so it cannot drift silently —
   which is the property that actually mattered in #1840.
2. **`none` is in the OpenCode list but not in the unified vocabulary.** It is
   OpenCode's own opt-out token, naming the absence of reasoning rather than a
   level. The mirror test states it as `("none", *REASONING_EFFORT_VOCABULARY)`
   rather than treating it as drift.
3. **Family defaults still exclude `ultra`.** Rung-1 defaults are guesses about a
   model nobody enumerated; a wrong claim becomes an upstream 400. The vocabulary
   is the superset, the defaults are not.
4. **`docs/plans/model-hub-contracts/mirror-registry.json` and `contract_version`
   are untouched.** No registered row mirrors this vocabulary, and
   `authority_table_discovery` covers only `docs/plans/model-hub.md`;
   `scripts/check_model_hub_authorities.py` reports byte-identical findings before
   and after this change. This is not a contract change.
5. **`modules/agents/opencode/server.py` is outside the file the issue names**, but
   inside what it asks for: "any matching OpenCode overlay / variant projection…
   grep for the sibling lists". Shipping the save fix without it would let the
   product accept `ultra` and then discard it on read.
