### PR TITLE
fix(tests): align fake RPC fixture with contract_version 8

### DIFF
--- a/tests/test_model_hub_api.py
+++ b/tests/test_model_hub_api.py
@@ -1187,7 +1187,7 @@ def test_runtime_dependency_ensure_crosses_the_controller_rpc_boundary(monkeypat
     def rpc(operation, payload=None):
         calls.append((operation, payload))
         return {
-            "contract_version": 7,
+            "contract_version": 8,
             "changed": True,
             "status": {"health": "not_started", "verified": True},
         }


### PR DESCRIPTION
## Changed capability

`master` itself is red; this makes it green again. One character.

`test_runtime_dependency_ensure_crosses_the_controller_rpc_boundary` builds a
fake RPC envelope that still returned `"contract_version": 7` after #1862 moved
the terminal version to `8`. `contract_version_closure.literal_globs` covers
`tests/test_model_hub*.py`, so the authority-closure guard reads that literal as
drift and `test_model_hub_config.py::test_model_hub_authority_closure_is_generated_from_live_files`
fails — on `master`, not only on a branch. It lands in the `unit-tests (1/6)`
shard of the `lint` workflow, so every open PR inherits it.

The version is incidental filler in that test: it asserts the `changed` flag and
the RPC call payload, never the envelope version. Its three sibling boundary
tests (`runtime_start`, `runtime_stop`, `runtime_install`, lines 1138/1155/1172)
already carry `8`; this one was simply missed. It now matches them.

## Evidence

- `test_model_hub_authority_closure_is_generated_from_live_files` fails on clean
  `origin/master` at `ab2b601cf` with
  `[{'domain': 'V1', 'file': 'tests/test_model_hub_api.py', 'kind': 'contract_version_literal_drift', 'value': 7}]`,
  and passes with this change.
- `scripts/check_model_hub_authorities.py` exits 0 and reports the closure OK.
- `tests/test_model_hub_config.py` + `tests/test_model_hub_api.py`: 546 passed.
- `ruff check` clean.
- `grep -n contract_version tests/test_model_hub_api.py` confirms this was the
  only stale literal in the file; every other occurrence is either
  `CONTRACT_VERSION` or already `8`.

## Blast radius

Test-only, single line. No production code, no `contract_version` bump, no
registry or mirror-registry change.

## History

Broke at #1862. `master`'s `lint` workflow is red at `d936f0d6b` and
`ab2b601cf`, green at `bfe4216d9` before it.

## Relationship to #1872

#1872 (`fix(model-hub): accept catalog-declared ultra tier in OpenCode config`)
documents this same failure as a pre-existing base-branch breakage it inherits.
Deliberately not folded in there: that PR's scope excludes `contract_version`-adjacent
files, and this one blocks every open PR, so it should merge on its own schedule.

