### PR TITLE
fix(regression): recover service after failed runtime preparation

### DIFF
--- a/scripts/incus_regression.py
+++ b/scripts/incus_regression.py
@@ -1707,7 +1707,7 @@ def stop_service_for_update(runner: Runner, target: RegressionTarget, *, remote:
 
 
 def restart_service_after_failed_update(runner: Runner, target: RegressionTarget, *, remote: str | None) -> None:
-    runner.run(root_exec(target, f"systemctl start {SERVICE_NAME} || true", remote=remote), check=False)
+    runner.run(root_exec(target, f"systemctl start {SERVICE_NAME}", remote=remote))
 
 
 def migrate_legacy_backend_runtimes(runner: Runner, target: RegressionTarget, *, remote: str | None) -> None:
@@ -2512,14 +2512,11 @@ def cmd_up(args: argparse.Namespace) -> int:
     # which is why the identity is observed here and not derived from a target.
     slug = target_slug(args, repo_root)
     lock_project = project_name_for(args.target, slug)
-    # Built before the attempt, not inside it: releasing the reservation asks the
-    # daemon what it holds, and a failure while acquiring the update lock would
-    # otherwise reach that handler with no runner to ask through.
     runner = Runner(dry_run=args.dry_run)
     reservation: WorktreeReservation | None = None
     stopped_service_target: RegressionTarget | None = None
-    try:
-        with target_update_lock(repo_root, args.remote, lock_project, dry_run=args.dry_run):
+    with target_update_lock(repo_root, args.remote, lock_project, dry_run=args.dry_run):
+        try:
             with metadata.locked(dry_run=args.dry_run):
                 target = resolve_target(args, repo_root, dry_run=args.dry_run, slug=slug)
                 reservation = metadata.reserve(target, dry_run=args.dry_run)
@@ -2554,8 +2551,9 @@ def cmd_up(args: argparse.Namespace) -> int:
             )
             if not args.dry_run and not seed_requires_env and should_seed_state(runner, target, reset_mode=args.reset_mode, remote=args.remote):
                 require_runtime_seed_env()
-            stop_service_for_update(runner, target, remote=args.remote)
+            # The stop may take effect before an interrupted client returns.
             stopped_service_target = target
+            stop_service_for_update(runner, target, remote=args.remote)
             if seed_requires_env or loaded_env_file is not None or args.dry_run:
                 write_runtime_env(runner, target, repo_root=repo_root, remote=args.remote)
             else:
@@ -2593,16 +2591,23 @@ def cmd_up(args: argparse.Namespace) -> int:
             restart_and_verify(runner, target, remote=args.remote)
             stopped_service_target = None
             reservation.complete()
-    except BaseException:
-        # Not `Exception`: Ctrl-C is how an `up` is abandoned in practice, and a
-        # KeyboardInterrupt would otherwise leave exactly the row this exists for.
-        # `None` covers failing before the row was written -- resolving a target,
-        # or waiting on the update lock -- where there is nothing to give back.
-        if stopped_service_target is not None:
-            restart_service_after_failed_update(runner, stopped_service_target, remote=args.remote)
-        if reservation is not None:
-            reservation.release(runner)
-        raise
+        except BaseException:
+            # Recovery still owns the update lock: another up must not stop and
+            # sync this environment while this failed run is starting it again.
+            try:
+                if stopped_service_target is not None:
+                    restart_service_after_failed_update(runner, stopped_service_target, remote=args.remote)
+            except BaseException as exc:
+                # A launch failure or a second Ctrl-C must not replace the
+                # original update error or prevent reservation cleanup.
+                print(
+                    f"Could not restart {SERVICE_NAME} after failed update: {type(exc).__name__}: {exc}",
+                    file=sys.stderr,
+                )
+            finally:
+                if reservation is not None:
+                    reservation.release(runner)
+            raise
     print_summary(target)
     return 0
 

--- a/scripts/incus_regression.py
+++ b/scripts/incus_regression.py
@@ -1706,6 +1706,10 @@ def stop_service_for_update(runner: Runner, target: RegressionTarget, *, remote:
     runner.run(root_exec(target, f"systemctl stop {SERVICE_NAME} || true", remote=remote), check=False)
 
 
+def restart_service_after_failed_update(runner: Runner, target: RegressionTarget, *, remote: str | None) -> None:
+    runner.run(root_exec(target, f"systemctl start {SERVICE_NAME} || true", remote=remote), check=False)
+
+
 def migrate_legacy_backend_runtimes(runner: Runner, target: RegressionTarget, *, remote: str | None) -> None:
     """Move pre-#545 root-global backends into the service user's home.
 
@@ -2358,7 +2362,7 @@ fi
 """.strip(),
             remote=remote,
         ),
-        timeout=SHOW_RUNTIME_BUILD_TIMEOUT_SECONDS,
+        timeout=env_int("REGRESSION_SHOW_RUNTIME_BUILD_TIMEOUT_SECONDS") or SHOW_RUNTIME_BUILD_TIMEOUT_SECONDS,
     )
     result = runner.run(
         tenant_exec(target, f"{runtime_env_prefix} {VENV_DIR}/bin/vibe runtime prepare --strict", remote=remote),
@@ -2513,6 +2517,7 @@ def cmd_up(args: argparse.Namespace) -> int:
     # otherwise reach that handler with no runner to ask through.
     runner = Runner(dry_run=args.dry_run)
     reservation: WorktreeReservation | None = None
+    stopped_service_target: RegressionTarget | None = None
     try:
         with target_update_lock(repo_root, args.remote, lock_project, dry_run=args.dry_run):
             with metadata.locked(dry_run=args.dry_run):
@@ -2550,6 +2555,7 @@ def cmd_up(args: argparse.Namespace) -> int:
             if not args.dry_run and not seed_requires_env and should_seed_state(runner, target, reset_mode=args.reset_mode, remote=args.remote):
                 require_runtime_seed_env()
             stop_service_for_update(runner, target, remote=args.remote)
+            stopped_service_target = target
             if seed_requires_env or loaded_env_file is not None or args.dry_run:
                 write_runtime_env(runner, target, repo_root=repo_root, remote=args.remote)
             else:
@@ -2585,12 +2591,15 @@ def cmd_up(args: argparse.Namespace) -> int:
             # restarted process cannot keep serving code loaded before preparation.
             prepare_show_runtime(runner, target, remote=args.remote)
             restart_and_verify(runner, target, remote=args.remote)
+            stopped_service_target = None
             reservation.complete()
     except BaseException:
         # Not `Exception`: Ctrl-C is how an `up` is abandoned in practice, and a
         # KeyboardInterrupt would otherwise leave exactly the row this exists for.
         # `None` covers failing before the row was written -- resolving a target,
         # or waiting on the update lock -- where there is nothing to give back.
+        if stopped_service_target is not None:
+            restart_service_after_failed_update(runner, stopped_service_target, remote=args.remote)
         if reservation is not None:
             reservation.release(runner)
         raise

--- a/scripts/incus_regression.py
+++ b/scripts/incus_regression.py
@@ -301,6 +301,15 @@ def env_int(name: str) -> int | None:
         raise RegressionError(f"{name} must be an integer.") from exc
 
 
+def show_runtime_build_timeout() -> int:
+    timeout = env_int("REGRESSION_SHOW_RUNTIME_BUILD_TIMEOUT_SECONDS")
+    if timeout is None:
+        return SHOW_RUNTIME_BUILD_TIMEOUT_SECONDS
+    if timeout <= 0:
+        raise RegressionError("REGRESSION_SHOW_RUNTIME_BUILD_TIMEOUT_SECONDS must be a positive integer.")
+    return timeout
+
+
 def current_repo_root() -> Path:
     result = subprocess.run(
         ["git", "rev-parse", "--show-toplevel"],
@@ -1707,6 +1716,8 @@ def stop_service_for_update(runner: Runner, target: RegressionTarget, *, remote:
 
 
 def restart_service_after_failed_update(runner: Runner, target: RegressionTarget, *, remote: str | None) -> None:
+    # Start a possibly stopped unit without restarting one that is already active.
+    # A failed restart_and_verify remains an error; recovery does not retry health checks.
     runner.run(root_exec(target, f"systemctl start {SERVICE_NAME}", remote=remote))
 
 
@@ -2331,6 +2342,7 @@ def restart_and_verify(runner: Runner, target: RegressionTarget, *, remote: str 
 
 
 def prepare_show_runtime(runner: Runner, target: RegressionTarget, *, remote: str | None) -> None:
+    build_timeout = show_runtime_build_timeout()
     source_result = runner.run(
         tenant_exec(target, 'printf "%s" "${VIBE_SHOW_RUNTIME_SOURCE:-}"', remote=remote),
         capture=True,
@@ -2362,7 +2374,7 @@ fi
 """.strip(),
             remote=remote,
         ),
-        timeout=env_int("REGRESSION_SHOW_RUNTIME_BUILD_TIMEOUT_SECONDS") or SHOW_RUNTIME_BUILD_TIMEOUT_SECONDS,
+        timeout=build_timeout,
     )
     result = runner.run(
         tenant_exec(target, f"{runtime_env_prefix} {VENV_DIR}/bin/vibe runtime prepare --strict", remote=remote),
@@ -2499,6 +2511,7 @@ def cmd_build_base(args: argparse.Namespace) -> int:
 def cmd_up(args: argparse.Namespace) -> int:
     repo_root = current_repo_root()
     loaded_env_file = load_env_file(repo_root, args.env_file)
+    show_runtime_build_timeout()
     if not args.dry_run:
         require_incus()
     metadata = WorktreeMetadata(repo_root, args.remote)

--- a/tests/test_incus_regression.py
+++ b/tests/test_incus_regression.py
@@ -3599,6 +3599,7 @@ def test_up_reserves_worktree_port_under_both_locks_that_protect_it(tmp_path: Pa
         "sync_source",
         "prepare_show_runtime",
         "restart_and_verify",
+        "health_check",
     ],
 )
 def test_up_gives_its_row_back_only_when_the_daemon_says_nothing_came_of_it(
@@ -3634,6 +3635,8 @@ def test_up_gives_its_row_back_only_when_the_daemon_says_nothing_came_of_it(
     """
     calls = []
     recovery_locks = []
+    service_commands = []
+    restart_and_verify = incus_regression.restart_and_verify
     original_error = failure_type(f"{fail_at} failed")
     inventory = ("avr-wt-demo-branch",) if holds_project else ()
 
@@ -3641,6 +3644,16 @@ def test_up_gives_its_row_back_only_when_the_daemon_says_nothing_came_of_it(
         names = daemon_listing(*inventory)
 
     def run_command(command, **kwargs):
+        script = command[-1]
+        service_commands.append(script)
+        if "/health" in script:
+            raise original_error
+        if script in {
+            "systemctl daemon-reload",
+            f"systemctl enable --now {incus_regression.SERVICE_NAME}",
+            f"systemctl restart {incus_regression.SERVICE_NAME}",
+        }:
+            return subprocess.CompletedProcess(command, 0)
         calls.append("restart_service_after_failed_update")
         recovery_locks.append(incus_regression.target_run_in_flight(tmp_path, None, "avr-wt-demo-branch"))
         assert command[-1] == f"systemctl start {incus_regression.SERVICE_NAME}"
@@ -3654,6 +3667,9 @@ def test_up_gives_its_row_back_only_when_the_daemon_says_nothing_came_of_it(
     def record(name):
         def wrapper(*args, **kwargs):
             calls.append(name)
+            if name == "restart_and_verify" and fail_at == "health_check":
+                calls.append("health_check")
+                return restart_and_verify(*args, **kwargs)
             if name == fail_at:
                 raise original_error
             if name == "update_dependencies_and_build":
@@ -3742,6 +3758,9 @@ def test_up_gives_its_row_back_only_when_the_daemon_says_nothing_came_of_it(
     assert fail_at in calls
     recovery_calls = calls.count("restart_service_after_failed_update")
     assert recovery_calls == int("stop_service_for_update" in calls)
+    if fail_at == "health_check":
+        assert service_commands.count(f"systemctl restart {incus_regression.SERVICE_NAME}") == 1
+        assert sum("/health" in script for script in service_commands) == 1
     if incus_regression.fcntl is not None:
         assert recovery_locks == [True] * recovery_calls
     assert not incus_regression.target_run_in_flight(tmp_path, None, "avr-wt-demo-branch")
@@ -4558,9 +4577,35 @@ def test_missing_ui_dist_rebuilds_even_when_python_is_unchanged() -> None:
     assert "pip install -e ." not in joined
 
 
+@pytest.mark.parametrize("invalid_timeout", ["-1", "0", "not-an-integer", "0.5"])
+@pytest.mark.parametrize("from_env_file", [False, True])
+def test_up_rejects_invalid_build_timeout_before_incus_access(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, invalid_timeout: str, from_env_file: bool
+) -> None:
+    name = "REGRESSION_SHOW_RUNTIME_BUILD_TIMEOUT_SECONDS"
+    monkeypatch.setenv(name, invalid_timeout)
+    monkeypatch.setattr(incus_regression, "current_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(incus_regression, "git_common_root", lambda repo_root: repo_root)
+    if from_env_file:
+        monkeypatch.delenv(name)
+        (tmp_path / incus_regression.ENV_FILE_NAME).write_text(f"{name}={invalid_timeout}\n", encoding="utf-8")
+
+    def unexpected_incus_access(*args, **kwargs):
+        pytest.fail("Invalid configuration must fail before Incus access")
+
+    monkeypatch.setattr(incus_regression, "require_incus", unexpected_incus_access)
+    monkeypatch.setattr(incus_regression.subprocess, "run", unexpected_incus_access)
+    args = incus_regression.build_parser().parse_args(["up", "--target", "master"])
+
+    with pytest.raises(incus_regression.RegressionError, match=f"{name} must be .*integer"):
+        incus_regression.cmd_up(args)
+
+    assert not (tmp_path / ".runtime").exists()
+
+
 @pytest.mark.parametrize(
     ("timeout_env", "expected_timeout"),
-    [(None, incus_regression.SHOW_RUNTIME_BUILD_TIMEOUT_SECONDS), ("900", 900)],
+    [(None, incus_regression.SHOW_RUNTIME_BUILD_TIMEOUT_SECONDS), ("", 300), ("1", 1), (" 900 ", 900)],
 )
 def test_prepare_show_runtime_builds_archive_and_retries_from_fresh_install(
     monkeypatch: pytest.MonkeyPatch, timeout_env: str | None, expected_timeout: int

--- a/tests/test_incus_regression.py
+++ b/tests/test_incus_regression.py
@@ -3581,11 +3581,35 @@ def test_up_reserves_worktree_port_under_both_locks_that_protect_it(tmp_path: Pa
 @pytest.mark.parametrize("holds_project", [False, True], ids=["daemon-empty", "daemon-holds-project"])
 @pytest.mark.parametrize("recorded", [False, True], ids=["new-row", "existing-row"])
 @pytest.mark.parametrize(
+    ("failure_type", "recovery_error"),
+    [
+        (RuntimeError, None),
+        (KeyboardInterrupt, None),
+        (RuntimeError, OSError),
+        (RuntimeError, KeyboardInterrupt),
+        (RuntimeError, subprocess.CalledProcessError),
+    ],
+)
+@pytest.mark.parametrize(
     "fail_at",
-    ["require_runtime_seed_env", "ensure_project_and_instance", "sync_source", "prepare_show_runtime"],
+    [
+        "require_runtime_seed_env",
+        "ensure_project_and_instance",
+        "stop_service_for_update",
+        "sync_source",
+        "prepare_show_runtime",
+        "restart_and_verify",
+    ],
 )
 def test_up_gives_its_row_back_only_when_the_daemon_says_nothing_came_of_it(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, fail_at: str, recorded: bool, holds_project: bool
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    fail_at: str,
+    recorded: bool,
+    holds_project: bool,
+    failure_type: type[BaseException],
+    recovery_error: type[BaseException] | None,
 ) -> None:
     """A failed `up` drops its row exactly when the daemon holds no project for it.
 
@@ -3609,22 +3633,29 @@ def test_up_gives_its_row_back_only_when_the_daemon_says_nothing_came_of_it(
     someone deleted the slug by hand.
     """
     calls = []
+    recovery_locks = []
+    original_error = failure_type(f"{fail_at} failed")
     inventory = ("avr-wt-demo-branch",) if holds_project else ()
 
-    class NewRunner:
-        def __init__(self, *, dry_run=False):
-            self.dry_run = dry_run
-
+    class NewRunner(incus_regression.Runner):
         names = daemon_listing(*inventory)
 
-        def run(self, command, **kwargs):
-            return subprocess.CompletedProcess(command, 0, stdout="{}")
+    def run_command(command, **kwargs):
+        calls.append("restart_service_after_failed_update")
+        recovery_locks.append(incus_regression.target_run_in_flight(tmp_path, None, "avr-wt-demo-branch"))
+        assert command[-1] == f"systemctl start {incus_regression.SERVICE_NAME}"
+        assert kwargs["check"] is True
+        if recovery_error is subprocess.CalledProcessError:
+            raise subprocess.CalledProcessError(1, command)
+        if recovery_error is not None:
+            raise recovery_error("recovery failed")
+        return subprocess.CompletedProcess(command, 0, stdout="{}")
 
     def record(name):
         def wrapper(*args, **kwargs):
             calls.append(name)
             if name == fail_at:
-                raise RuntimeError(f"{name} failed")
+                raise original_error
             if name == "update_dependencies_and_build":
                 return set()
 
@@ -3657,6 +3688,7 @@ def test_up_gives_its_row_back_only_when_the_daemon_says_nothing_came_of_it(
     monkeypatch.setattr(incus_regression, "require_incus", lambda: None)
     monkeypatch.setattr(incus_regression, "ensure_host_port_available", lambda host, port: None)
     monkeypatch.setattr(incus_regression, "Runner", NewRunner)
+    monkeypatch.setattr(incus_regression.subprocess, "run", run_command)
     monkeypatch.setattr(incus_regression, "should_seed_state", lambda *args, **kwargs: False)
     monkeypatch.setattr(incus_regression, "compute_fingerprints", lambda repo_root: {})
     monkeypatch.setattr(incus_regression, "read_existing_fingerprints", lambda *args, **kwargs: {})
@@ -3675,9 +3707,8 @@ def test_up_gives_its_row_back_only_when_the_daemon_says_nothing_came_of_it(
         "write_metadata",
         "prepare_show_runtime",
         "restart_and_verify",
-        "restart_service_after_failed_update",
     ):
-        monkeypatch.setattr(incus_regression, name, record(name), raising=False)
+        monkeypatch.setattr(incus_regression, name, record(name))
 
     args = argparse.Namespace(
         target="worktree",
@@ -3704,12 +3735,22 @@ def test_up_gives_its_row_back_only_when_the_daemon_says_nothing_came_of_it(
         reset_mode="none",
     )
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(failure_type) as raised:
         incus_regression.cmd_up(args)
 
+    assert raised.value is original_error
     assert fail_at in calls
     recovery_calls = calls.count("restart_service_after_failed_update")
-    assert recovery_calls == (1 if fail_at in {"sync_source", "prepare_show_runtime"} else 0)
+    assert recovery_calls == int("stop_service_for_update" in calls)
+    if incus_regression.fcntl is not None:
+        assert recovery_locks == [True] * recovery_calls
+    assert not incus_regression.target_run_in_flight(tmp_path, None, "avr-wt-demo-branch")
+    stderr = capsys.readouterr().err
+    if recovery_calls and recovery_error is not None:
+        assert "Could not restart avibe-regression.service after failed update" in stderr
+        assert recovery_error.__name__ in stderr
+    else:
+        assert not stderr
     mapping = json.loads(mapping_path.read_text(encoding="utf-8"))["worktrees"]
     assert ("demo-branch" in mapping) == holds_project
     if holds_project:

--- a/tests/test_incus_regression.py
+++ b/tests/test_incus_regression.py
@@ -3582,7 +3582,7 @@ def test_up_reserves_worktree_port_under_both_locks_that_protect_it(tmp_path: Pa
 @pytest.mark.parametrize("recorded", [False, True], ids=["new-row", "existing-row"])
 @pytest.mark.parametrize(
     "fail_at",
-    ["require_runtime_seed_env", "ensure_project_and_instance", "sync_source"],
+    ["require_runtime_seed_env", "ensure_project_and_instance", "sync_source", "prepare_show_runtime"],
 )
 def test_up_gives_its_row_back_only_when_the_daemon_says_nothing_came_of_it(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, fail_at: str, recorded: bool, holds_project: bool
@@ -3675,8 +3675,9 @@ def test_up_gives_its_row_back_only_when_the_daemon_says_nothing_came_of_it(
         "write_metadata",
         "prepare_show_runtime",
         "restart_and_verify",
+        "restart_service_after_failed_update",
     ):
-        monkeypatch.setattr(incus_regression, name, record(name))
+        monkeypatch.setattr(incus_regression, name, record(name), raising=False)
 
     args = argparse.Namespace(
         target="worktree",
@@ -3707,6 +3708,8 @@ def test_up_gives_its_row_back_only_when_the_daemon_says_nothing_came_of_it(
         incus_regression.cmd_up(args)
 
     assert fail_at in calls
+    recovery_calls = calls.count("restart_service_after_failed_update")
+    assert recovery_calls == (1 if fail_at in {"sync_source", "prepare_show_runtime"} else 0)
     mapping = json.loads(mapping_path.read_text(encoding="utf-8"))["worktrees"]
     assert ("demo-branch" in mapping) == holds_project
     if holds_project:
@@ -4514,7 +4517,13 @@ def test_missing_ui_dist_rebuilds_even_when_python_is_unchanged() -> None:
     assert "pip install -e ." not in joined
 
 
-def test_prepare_show_runtime_builds_archive_and_retries_from_fresh_install() -> None:
+@pytest.mark.parametrize(
+    ("timeout_env", "expected_timeout"),
+    [(None, incus_regression.SHOW_RUNTIME_BUILD_TIMEOUT_SECONDS), ("900", 900)],
+)
+def test_prepare_show_runtime_builds_archive_and_retries_from_fresh_install(
+    monkeypatch: pytest.MonkeyPatch, timeout_env: str | None, expected_timeout: int
+) -> None:
     commands = []
     build_timeouts = []
 
@@ -4541,6 +4550,9 @@ def test_prepare_show_runtime_builds_archive_and_retries_from_fresh_install() ->
         ui_host="127.0.0.1",
         ui_port=5123,
     )
+    monkeypatch.delenv("REGRESSION_SHOW_RUNTIME_BUILD_TIMEOUT_SECONDS", raising=False)
+    if timeout_env is not None:
+        monkeypatch.setenv("REGRESSION_SHOW_RUNTIME_BUILD_TIMEOUT_SECONDS", timeout_env)
 
     incus_regression.prepare_show_runtime(RecordingRunner(), target, remote=None)
 
@@ -4548,7 +4560,7 @@ def test_prepare_show_runtime_builds_archive_and_retries_from_fresh_install() ->
     assert "git clone --depth 1 https://github.com/avibe-bot/vibe-show-runtime.git" in joined
     assert "npm run bundle:vibe-remote" in joined
     assert 'install -D -m 0644 "$1" "$VIBE_SHOW_RUNTIME_ARCHIVE_PATH"' in joined
-    assert build_timeouts == [incus_regression.SHOW_RUNTIME_BUILD_TIMEOUT_SECONDS]
+    assert build_timeouts == [expected_timeout]
     build_command = next(command for command in commands if "git clone --depth 1" in command)
     assert build_command.index("VIBE_SHOW_RUNTIME_ARCHIVE_PATH is required") < build_command.index("git clone")
     assert joined.count("vibe runtime prepare --strict") == 2


### PR DESCRIPTION
## Summary

When a local Incus regression update times out while rebuilding Show Runtime, it previously exited with the Avibe service still stopped. An update now attempts to start the same service on failure from the moment it issues the stop, while retaining the original update error.

Recovery runs under the environment's update lock so another update cannot begin syncing files before recovery finishes. A failed or interrupted recovery is reported separately, and reservation cleanup still runs. `REGRESSION_SHOW_RUNTIME_BUILD_TIMEOUT_SECONDS` overrides the existing 300-second build timeout when network-dependent builds need more time. Overrides must be positive integers; invalid values from the environment or `.env.regression` fail before Incus access or update mutations.

Fixes #1847

## Validation

- Unit and contract coverage: `tests/test_incus_regression.py` passes all 306 cases. The expanded recovery matrix had 80 failures before its fix; all eight timeout preflight cases failed before validation was added.
- The failure-path tests use the real recovery helper and command runner with external subprocesses stubbed, checking lock ownership, original exception identity, recovery diagnostics, and daemon-owned reservation cleanup.
- Coverage includes interruption during stop and update, command-launch failure, interruption during recovery, nonzero recovery exit, pre-stop failure, default/overridden timeouts, and invalid timeout values loaded through the real environment-file parser.
- Health-failure cases run the real `restart_and_verify`, assert the original failure remains visible, and assert exactly one restart and one health-check loop.
- Ruff passes for both changed Python files.
- Scenario IDs: not applicable to this operational regression-runner path. No live Incus environment was changed.

## Known-by-design

- **KBD-1: Recovery starts a potentially stopped unit; it does not retry an active unhealthy process.** The normal update path already restarts the service and checks its health. If that check fails, the update still fails with the original error; recovery never claims readiness or marks the update successful. An idempotent `systemctl start` leaves an already active process alone. Another restart and health-check loop would introduce an automatic retry without evidence that the fault is transient. This is an intentional scope decision after reviewing the recovery lifecycle across both reviewed heads (`a965cadfb0` and `efb4250e7`), backed by the health-failure tests above.

## Limits

Recovery is best-effort service startup, not a source or dependency rollback. An environment whose files or dependencies were left incomplete can still require manual repair.
