### PR TITLE
fix(chat): simplify shell command activity summaries

### DIFF
--- a/docs/plans/chat-agent-activity-panel.md
+++ b/docs/plans/chat-agent-activity-panel.md
@@ -306,7 +306,7 @@ Names/arg-keys differ per backend (Claude Capitalized `file_path`/`command`; Cod
 `bash`/`file_change` with `file`+`type`; OpenCode lowercase `file_path||path`; a
 restore path emits `` `name`: `arg` `` with no JSON) — hence the degrade. Pure
 helpers in `ui/src/lib/agentActivity.ts`: `parseToolCall` (name + parsed JSON args
-or `null`), `toolRecipe` (tier-1 known-tool recipe: command → `$ cmd`; read → dir
+or `null`), `toolRecipe` (tier-1 known-tool recipe: command → command body; read → dir
 muted + basename; edit/write → basename + op badge, op from name or Codex `type`;
 web/search/grep → quoted query/URL; task → description — case-insensitive prefix,
 paths probe `file_path`→`path`→`file`), `genericChips` (tier-2 ≤3 scalar chips +
@@ -315,6 +315,13 @@ oversize (>20k) → `args: null` → tier 3; `ActivityToolRow` also wraps the pa
 try/catch so nothing can blank a row. Rendered by `ToolSummary` in
 `AgentActivityGroup.tsx`. Unit-tested per tier + exception fallback in
 `agentActivity.test.ts`.
+
+Command summaries omit the decorative shell prompt and unwrap a single
+`bash`/`zsh`/`sh -c` or `-lc` invocation only when its command argument is a
+fully decoded literal word. Extra arguments, outer expansions, operators, and
+unrecognized syntax keep the original invocation visible. Nested shells are not
+recursively unwrapped. Stored arguments, expanded details, and JSON remain
+unchanged; this is a display-only projection shared by live and historical rows.
 
 ### B — Tool-row visibility eye toggle + `config.ui.show_tool_calls`
 

--- a/ui/src/components/workbench/AgentActivityGroup.test.tsx
+++ b/ui/src/components/workbench/AgentActivityGroup.test.tsx
@@ -16,6 +16,49 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
+describe('shell tool-call display', () => {
+  it.each(['live', 'history'])('shows the command body and preserves the original in %s details', (surface) => {
+    const command = "/bin/zsh -lc 'npm test'";
+    const rows = [{
+      id: 'shell-command',
+      kind: 'tool_call' as const,
+      text: `🔧 \`bash\` \`${JSON.stringify({ command, exit_code: 0, output: 'passed' })}\``,
+      created_at: '2026-09-05T02:00:00Z',
+    }];
+    render(surface === 'live' ? (
+      <ActivityCard
+        rows={rows}
+        startedAtMs={Date.now()}
+        expanded
+        onToggleExpanded={vi.fn()}
+        showToolCalls
+        onToggleTools={vi.fn()}
+      />
+    ) : (
+      <ActivityChip
+        group={{
+          id: 'completed-turn', anchorMessageId: 'reply', anchorPosition: 'before',
+          open: false, status: 'done', steps: 1, durationMs: 1000, rows,
+        }}
+        expanded
+        loading={false}
+        onToggle={vi.fn()}
+        showToolCalls
+        onToggleTools={vi.fn()}
+      />
+    ));
+
+    const tool = screen.getByRole('button', { name: /^bash\s*npm test$/ });
+    expect(tool.textContent).toBe('bashnpm test');
+    expect(screen.queryByText(command)).toBeNull();
+
+    fireEvent.click(tool);
+    expect(screen.getByText(command)).toBeTruthy();
+    expect(screen.getByText('passed')).toBeTruthy();
+    expect(tool.textContent).toBe('bashnpm test');
+  });
+});
+
 describe('ActivityCard display shortcut', () => {
   it('shows hour and day units when a live run crosses those boundaries', () => {
     vi.useFakeTimers();

--- a/ui/src/components/workbench/AgentActivityGroup.tsx
+++ b/ui/src/components/workbench/AgentActivityGroup.tsx
@@ -176,7 +176,6 @@ const ToolSummary: React.FC<{ parsed: ParsedToolCall }> = ({ parsed }) => {
       case 'command':
         return (
           <span className="min-w-0 flex-1 truncate font-mono text-[12px] text-foreground/80">
-            <span className="text-muted">$ </span>
             {recipe.command}
           </span>
         );

--- a/ui/src/lib/agentActivity.test.ts
+++ b/ui/src/lib/agentActivity.test.ts
@@ -102,6 +102,79 @@ describe('toolRecipe (tier 1: known-tool recipes, backend-agnostic)', () => {
     });
   });
 
+  describe('shell command summaries preserve the literal command body', () => {
+    const bodies = [
+      'git status --short',
+      'npm test',
+      'printf "%s\\n" "it\'s ready"',
+      'printf "%s" "$HOME"; echo `pwd` && cat *.txt | head -n 2',
+      'printf "你好"\nprintf "done"',
+      '/bin/bash -c "npm test"',
+    ];
+    const quoteForms = [
+      (body: string) => `'${body.replace(/'/g, `'"'"'`)}'`,
+      (body: string) => `'${body.replace(/'/g, `'\\''`)}'`,
+      (body: string) => `"${body.replace(/["\\$`]/g, '\\$&')}"`,
+    ];
+
+    it.each(bodies)('decodes only the outer wrapper around %j', (body) => {
+      for (const shell of ['zsh', '/bin/zsh', '/bin/bash', '/usr/bin/sh', '/opt/homebrew/bin/bash']) {
+        for (const flag of ['-lc', '-c']) {
+          for (const quote of quoteForms) {
+            const command = `${shell} ${flag} ${quote(body)}`;
+            const args = Object.freeze({ command, status: 'completed', exit_code: 0, output: 'done' });
+            const raw = `🔧 \`bash\` \`${JSON.stringify(args)}\``;
+            const parsed = parseToolCall(raw);
+
+            expect(toolRecipe(parsed.name, args)).toEqual({ kind: 'command', command: body });
+            expect(parsed.args).toEqual(args);
+            expect(parsed.raw).toBe(raw);
+            expect(toolParams(args).find((param) => param.key === 'command')?.value).toBe(command);
+          }
+        }
+      }
+    });
+
+    it.each([
+      ['/bin/zsh -lc pwd', 'pwd'],
+      ['/bin/zsh -lc npm\\ test', 'npm test'],
+      ['/bin/zsh -lc npm" test"', 'npm test'],
+      ['/bin/zsh -lc "printf \\q"', 'printf \\q'],
+    ])('decodes equivalent literal-word forms: %s', (command, expected) => {
+      expect(toolRecipe('exec_command', { cmd: command })).toEqual({ kind: 'command', command: expected });
+    });
+
+    it.each([
+      ' extra-argument', ' --flag', ' > output.txt', ' 2>&1', ' | cat',
+      ' && npm test', '; npm test', '\nnpm test', ' # comment', '\u00a0', '\u2003',
+    ])('retains the full invocation when a wrapper has a suffix %j', (suffix) => {
+      const command = `/bin/zsh -lc 'git status --short'${suffix}`;
+      expect(toolRecipe('bash', { command })).toEqual({ kind: 'command', command });
+    });
+
+    it.each([
+      'git status --short',
+      'echo /bin/zsh -lc pwd',
+      'env NAME=value /bin/zsh -lc pwd',
+      'sudo /bin/zsh -lc pwd',
+      '/bin/fish -c pwd',
+      '/bin/zsh -e -lc pwd',
+      '/bin/zsh -lc $COMMAND',
+      '/bin/zsh -lc "$COMMAND"',
+      '/bin/zsh -lc "${COMMAND}"',
+      '/bin/zsh -lc "$(cat script.sh)"',
+      '/bin/zsh -lc "`cat script.sh`"',
+      '/bin/zsh -lc *.sh',
+      '/bin/zsh -lc "unterminated',
+      '/bin/zsh -lc trailing\\',
+      '/bin/zsh -lc',
+      '/bin/zsh -lc ""',
+      '/bin/zsh -lc "  "',
+    ])('falls back unchanged outside the literal-wrapper contract: %s', (command) => {
+      expect(toolRecipe('bash', { command })).toEqual({ kind: 'command', command });
+    });
+  });
+
   it('read/list family → dir muted + basename (probes file_path → path → file)', () => {
     expect(toolRecipe('Read', { file_path: '研报/中金_CATL_2026展望.pdf' })).toEqual({
       kind: 'read',

--- a/ui/src/lib/agentActivity.ts
+++ b/ui/src/lib/agentActivity.ts
@@ -303,13 +303,30 @@ export type FileOp = 'create' | 'modify' | 'delete';
 
 // Tier-1 render intents (keyed on known tool-name prefix + expected arg presence).
 export type ToolRecipe =
-  | { kind: 'command'; command: string } // bash/shell → ``$ <command>``
+  | { kind: 'command'; command: string } // bash/shell → the command body
   | { kind: 'read'; dir: string; base: string } // read/list → dir muted + base bold
   | { kind: 'fileop'; dir: string; base: string; op: FileOp } // edit/write → base + op badge
   | { kind: 'query'; text: string } // web/search/fetch → quoted query / URL
   | { kind: 'text'; text: string }; // task/agent → description
 
 const asStr = (v: unknown): string | undefined => (typeof v === 'string' && v.length > 0 ? v : undefined);
+
+const summarizeShellCommand = (command: string): string => {
+  const wrapper = /^(?:\/(?:[\w.+-]+\/)*)?(?:bash|zsh|sh)[ \t]+-(?:lc|c)[ \t]+/.exec(command);
+  if (!wrapper) return command;
+
+  // Decode one literal shell argument, not a shell program. Any expansion,
+  // extra argument, or operator keeps the original invocation visible.
+  const argument = command.slice(wrapper[0].length).replace(/[ \t]+$/, '');
+  const parts = /'([^']*)'|"((?:[^"\\$`]|\\[^\r\n])*)"|\\([^\r\n])|([\w@%+=:,./-]+)/gy;
+  let summary = '';
+  while (parts.lastIndex < argument.length) {
+    const part = parts.exec(argument);
+    if (!part) return command;
+    summary += part[1] ?? part[2]?.replace(/\\([$`"\\])/g, '$1') ?? part[3] ?? part[4];
+  }
+  return summary.trim() ? summary : command;
+};
 
 const fileOpFrom = (name: string, args: Record<string, unknown>): FileOp => {
   const type = (asStr(args.type) || '').toLowerCase();
@@ -332,7 +349,7 @@ export const toolRecipe = (name: string, args: Record<string, unknown>): ToolRec
   const command = asStr(args.command) ?? asStr(args.cmd);
 
   if (starts(['bash', 'shell', 'exec', 'run', 'sh', 'zsh', 'terminal', 'command'])) {
-    return command != null ? { kind: 'command', command } : null;
+    return command != null ? { kind: 'command', command: summarizeShellCommand(command) } : null;
   }
   if (starts(['write', 'edit', 'create', 'update', 'apply', 'patch', 'notebook', 'multiedit', 'file_change', 'filechange'])) {
     return path != null ? { kind: 'fileop', ...splitPath(path), op: fileOpFrom(n, args) } : null;


### PR DESCRIPTION
## Summary

- Show the literal command body in chat activity summaries instead of the shell runner's outer `zsh`/`bash`/`sh -c` or `-lc` invocation.
- Remove the decorative `$` prompt from command summaries.
- Preserve original stored arguments, expanded details, JSON, and execution behavior. Live and historical activity rows use the same projection.
- Update the existing activity-panel behavior documentation.

## Evidence

- Unit and component: 82 tests passed across `agentActivity.test.ts` and `AgentActivityGroup.test.tsx`.
- Contract: round-trip literal quoting tests cover embedded quotes, escapes, multiline and non-ASCII command bodies; original parameters and raw JSON remain unchanged. Inputs outside the single-literal-argument contract remain unchanged.
- Browser: actual components rendered through Vite in headless Chromium at 1440x900 and 390x844. Command summaries, original expanded details, and lack of horizontal overflow were verified. The preview did not contact or mutate a running Avibe instance.
- Changed-file ESLint, the full UI lint baseline gate, `npm run build`, and `git diff --check` passed.
- Scenario IDs: no applicable entry in the Model Hub scenario catalog; scope is the existing chat activity-panel A/D presentation contract.
- Residual manual check: live-session integration on LOCAL Incus after merge. No host restart, regression deployment, or release was performed.

## Dependencies

None. No new package or unmerged PR dependency.

## Known By Design

- Only a recognized outer POSIX shell invocation with one fully decoded literal command argument is simplified. Extra arguments, outer expansions, operators, unsupported shells/options, and unrecognized syntax retain the original command.
- Unwrapping is deliberately single-level. A shell invocation inside the command body is meaningful command content and stays visible.
- Full invocation details remain available by expanding the row; no stored history or executable input is rewritten.
