### PR TITLE
fix(model-hub): complete OpenCode Gateway turns

### DIFF
--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -109,9 +109,6 @@ _CALLER_CONTEXT_ENV_SNAPSHOT_KEY = "opencode_caller_context_env"
 _MANAGED_SKILL_PROJECT_BASE_SNAPSHOT_KEY = "opencode_managed_skill_project_base"
 _MANAGED_SKILL_BUILTIN_SNAPSHOT_KEY = "opencode_managed_skill_builtin_snapshot"
 _STATUS_RECONCILIATION_FAILURE_LIMIT = 3
-# OpenCode returns 204 after forking prompt work, before that worker necessarily
-# registers the session as busy.
-_ASYNC_PROMPT_START_CONFIRMATION_TIMEOUT_SECONDS = 5.0
 # OpenCode can report idle just before the completed assistant message becomes
 # visible through the message-list endpoint.
 _ASYNC_PROMPT_RESULT_CONFIRMATION_TIMEOUT_SECONDS = 5.0
@@ -162,7 +159,7 @@ class _OpenCodeSteerState:
     closing: bool = False
     awaiting_after_message_ids: set[str] | None = None
     awaiting_user_text: str | None = None
-    awaiting_start_confirmation_deadline: float | None = None
+    awaiting_prompt_accepted: bool = False
     awaiting_active_status_observed: bool = False
     awaiting_result_confirmation_deadline: float | None = None
     idle_reconciliation_message: str = ""
@@ -364,7 +361,7 @@ class _SteeringAwareOpenCodeServer:
     def _clear_awaiting_reconciliation(self) -> None:
         self._state.awaiting_after_message_ids = None
         self._state.awaiting_user_text = None
-        self._state.awaiting_start_confirmation_deadline = None
+        self._state.awaiting_prompt_accepted = False
         self._state.awaiting_active_status_observed = False
         self._state.awaiting_result_confirmation_deadline = None
 
@@ -531,6 +528,8 @@ class _SteeringAwareOpenCodeServer:
                                         < 0
                                     )
                                 )
+                                if not inserted_user_missing:
+                                    self._state.awaiting_active_status_observed = True
                                 last_message_id = (
                                     messages[-1].get("info", {}).get("id")
                                     if messages
@@ -540,8 +539,7 @@ class _SteeringAwareOpenCodeServer:
                                     inserted_user_missing
                                     and final_snapshot
                                     and last_message_id in awaiting
-                                    and self._state.awaiting_start_confirmation_deadline
-                                    is None
+                                    and not self._state.awaiting_prompt_accepted
                                 ):
                                     self._clear_awaiting_reconciliation()
                                     self._state.closing = True
@@ -564,16 +562,7 @@ class _SteeringAwareOpenCodeServer:
                                     if has_final_insert_result:
                                         self._state.closing = True
                                     return messages
-                                start_deadline = (
-                                    self._state.awaiting_start_confirmation_deadline
-                                )
-                                if (
-                                    start_deadline is not None
-                                    and not self._state.awaiting_active_status_observed
-                                    and time.monotonic() < start_deadline
-                                ):
-                                    wait_for_insert = True
-                                elif self._state.awaiting_active_status_observed:
+                                if self._state.awaiting_active_status_observed:
                                     result_deadline = (
                                         self._state.awaiting_result_confirmation_deadline
                                     )
@@ -593,6 +582,11 @@ class _SteeringAwareOpenCodeServer:
                                             name="NativeSessionEndedBeforeResult",
                                             message=self._idle_reconciliation_error_text(),
                                         )
+                                elif self._state.awaiting_prompt_accepted:
+                                    # A successful prompt_async response transfers
+                                    # ownership before OpenCode must publish a
+                                    # message or mark the session busy.
+                                    wait_for_insert = True
                                 else:
                                     self._clear_awaiting_reconciliation()
                                     return self._terminal_reconciliation_failure(
@@ -660,12 +654,12 @@ class _SteeringAwareOpenCodeServer:
             if snapshot_ids is not None:
                 self._state.awaiting_after_message_ids = set(snapshot_ids)
                 self._state.awaiting_user_text = prompt_text or None
-                self._state.awaiting_start_confirmation_deadline = (
-                    time.monotonic() + _ASYNC_PROMPT_START_CONFIRMATION_TIMEOUT_SECONDS
-                )
+                self._state.awaiting_prompt_accepted = False
                 self._state.awaiting_active_status_observed = False
                 self._state.awaiting_result_confirmation_deadline = None
             await self._server.prompt_async(*args, **{k: v for k, v in kwargs.items() if k != "awaiting_after_ids"})
+            if snapshot_ids is not None:
+                self._state.awaiting_prompt_accepted = True
 
     async def abort_session(self, *args, **kwargs) -> bool:
         async with self._state.lock:
@@ -1673,10 +1667,7 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                 baseline_message_ids=set(baseline_message_ids),
                 awaiting_after_message_ids=set(baseline_message_ids),
                 awaiting_user_text=prompt_text,
-                awaiting_start_confirmation_deadline=(
-                    time.monotonic()
-                    + _ASYNC_PROMPT_START_CONFIRMATION_TIMEOUT_SECONDS
-                ),
+                awaiting_prompt_accepted=True,
                 idle_reconciliation_message=self._idle_reconciliation_message(
                     display_model_dict,
                     reasoning_effort,
@@ -2054,15 +2045,12 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                 except (asyncio.TimeoutError, TimeoutError, aiohttp.ClientConnectionError):
                     state.awaiting_after_message_ids = before_insert
                     state.awaiting_user_text = request.text
-                    state.awaiting_start_confirmation_deadline = None
+                    state.awaiting_prompt_accepted = False
                     state.awaiting_active_status_observed = False
                     raise
                 state.awaiting_after_message_ids = before_insert
                 state.awaiting_user_text = request.text
-                state.awaiting_start_confirmation_deadline = (
-                    time.monotonic()
-                    + _ASYNC_PROMPT_START_CONFIRMATION_TIMEOUT_SECONDS
-                )
+                state.awaiting_prompt_accepted = True
                 state.awaiting_active_status_observed = False
                 await asyncio.sleep(_STEER_POST_WRITE_STATUS_SETTLE_SECONDS)
                 try:

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -109,6 +109,10 @@ _CALLER_CONTEXT_ENV_SNAPSHOT_KEY = "opencode_caller_context_env"
 _MANAGED_SKILL_PROJECT_BASE_SNAPSHOT_KEY = "opencode_managed_skill_project_base"
 _MANAGED_SKILL_BUILTIN_SNAPSHOT_KEY = "opencode_managed_skill_builtin_snapshot"
 _STATUS_RECONCILIATION_FAILURE_LIMIT = 3
+# A successful prompt_async response transfers ownership to a forked worker,
+# but does not prove that worker will publish its first message. Keep this
+# handoff bounded independently of the optional whole-turn timeout.
+_ASYNC_PROMPT_ACCEPTED_ACTIVITY_TIMEOUT_SECONDS = 120.0
 # OpenCode can report idle just before the completed assistant message becomes
 # visible through the message-list endpoint.
 _ASYNC_PROMPT_RESULT_CONFIRMATION_TIMEOUT_SECONDS = 5.0
@@ -160,6 +164,7 @@ class _OpenCodeSteerState:
     awaiting_after_message_ids: set[str] | None = None
     awaiting_user_text: str | None = None
     awaiting_prompt_accepted: bool = False
+    awaiting_prompt_activity_deadline: float | None = None
     awaiting_active_status_observed: bool = False
     awaiting_result_confirmation_deadline: float | None = None
     idle_reconciliation_message: str = ""
@@ -362,6 +367,7 @@ class _SteeringAwareOpenCodeServer:
         self._state.awaiting_after_message_ids = None
         self._state.awaiting_user_text = None
         self._state.awaiting_prompt_accepted = False
+        self._state.awaiting_prompt_activity_deadline = None
         self._state.awaiting_active_status_observed = False
         self._state.awaiting_result_confirmation_deadline = None
 
@@ -586,7 +592,27 @@ class _SteeringAwareOpenCodeServer:
                                     # A successful prompt_async response transfers
                                     # ownership before OpenCode must publish a
                                     # message or mark the session busy.
-                                    wait_for_insert = True
+                                    activity_deadline = (
+                                        self._state.awaiting_prompt_activity_deadline
+                                    )
+                                    if activity_deadline is None:
+                                        activity_deadline = (
+                                            time.monotonic()
+                                            + _ASYNC_PROMPT_ACCEPTED_ACTIVITY_TIMEOUT_SECONDS
+                                        )
+                                        self._state.awaiting_prompt_activity_deadline = (
+                                            activity_deadline
+                                        )
+                                    if time.monotonic() < activity_deadline:
+                                        wait_for_insert = True
+                                    else:
+                                        self._clear_awaiting_reconciliation()
+                                        return self._terminal_reconciliation_failure(
+                                            session_id,
+                                            messages,
+                                            name="NativeSessionEndedBeforeResult",
+                                            message=self._idle_reconciliation_error_text(),
+                                        )
                                 else:
                                     self._clear_awaiting_reconciliation()
                                     return self._terminal_reconciliation_failure(
@@ -655,11 +681,16 @@ class _SteeringAwareOpenCodeServer:
                 self._state.awaiting_after_message_ids = set(snapshot_ids)
                 self._state.awaiting_user_text = prompt_text or None
                 self._state.awaiting_prompt_accepted = False
+                self._state.awaiting_prompt_activity_deadline = None
                 self._state.awaiting_active_status_observed = False
                 self._state.awaiting_result_confirmation_deadline = None
             await self._server.prompt_async(*args, **{k: v for k, v in kwargs.items() if k != "awaiting_after_ids"})
             if snapshot_ids is not None:
                 self._state.awaiting_prompt_accepted = True
+                self._state.awaiting_prompt_activity_deadline = (
+                    time.monotonic()
+                    + _ASYNC_PROMPT_ACCEPTED_ACTIVITY_TIMEOUT_SECONDS
+                )
 
     async def abort_session(self, *args, **kwargs) -> bool:
         async with self._state.lock:
@@ -1668,6 +1699,10 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                 awaiting_after_message_ids=set(baseline_message_ids),
                 awaiting_user_text=prompt_text,
                 awaiting_prompt_accepted=True,
+                awaiting_prompt_activity_deadline=(
+                    time.monotonic()
+                    + _ASYNC_PROMPT_ACCEPTED_ACTIVITY_TIMEOUT_SECONDS
+                ),
                 idle_reconciliation_message=self._idle_reconciliation_message(
                     display_model_dict,
                     reasoning_effort,
@@ -2046,11 +2081,16 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                     state.awaiting_after_message_ids = before_insert
                     state.awaiting_user_text = request.text
                     state.awaiting_prompt_accepted = False
+                    state.awaiting_prompt_activity_deadline = None
                     state.awaiting_active_status_observed = False
                     raise
                 state.awaiting_after_message_ids = before_insert
                 state.awaiting_user_text = request.text
                 state.awaiting_prompt_accepted = True
+                state.awaiting_prompt_activity_deadline = (
+                    time.monotonic()
+                    + _ASYNC_PROMPT_ACCEPTED_ACTIVITY_TIMEOUT_SECONDS
+                )
                 state.awaiting_active_status_observed = False
                 await asyncio.sleep(_STEER_POST_WRITE_STATUS_SETTLE_SECONDS)
                 try:

--- a/tests/e2e/drivers/mock_llm_upstream.py
+++ b/tests/e2e/drivers/mock_llm_upstream.py
@@ -151,6 +151,15 @@ OPENCODE_V4_S4_VARIANT_FIXTURES = {
             "output_config": {"effort": "high"},
         },
     },
+    "responses_to_openai_chat": {
+        "protocol": "openai_chat",
+        "frontend_protocol": "openai_responses",
+        "stored_model": "deepseek-v3.2",
+        "variant": {"reasoningEffort": "high"},
+        "upstream_fragment": {
+            "reasoning_effort": "high",
+        },
+    },
 }
 CAPTURED_HEADER_NAMES = (
     "accept",

--- a/tests/e2e/test_model_hub_mock_upstream.py
+++ b/tests/e2e/test_model_hub_mock_upstream.py
@@ -250,7 +250,9 @@ def _send_through_opencode_gateway_engine(
     native_protocol: str,
     stored_model: str,
     variant: dict[str, Any],
-) -> dict[str, Any]:
+    prompt_start_delay_seconds: float = 0,
+    require_terminal_result: bool = False,
+) -> tuple[dict[str, Any], dict[str, Any] | None]:
     binary = shutil.which("opencode")
     if binary is None:
         pytest.skip("OpenCode executable is unavailable")
@@ -259,11 +261,11 @@ def _send_through_opencode_gateway_engine(
         if native_protocol == "anthropic"
         else "deepseek-v3.2"
     )
-    upstream_path = (
-        "/v1/messages"
-        if upstream_protocol == "anthropic"
-        else "/v1/responses"
-    )
+    upstream_path = {
+        "anthropic": "/v1/messages",
+        "openai_responses": "/v1/responses",
+        "openai_chat": "/v1/chat/completions",
+    }[upstream_protocol]
     with _engine_app(model_hub_app_factory) as app:
         configured = app.client.post(
             "/api/config",
@@ -378,6 +380,17 @@ def _send_through_opencode_gateway_engine(
             },
         )
         assert agent.status == 200, agent.json()
+        if prompt_start_delay_seconds > 0:
+            plugin_dir = app.runtime_root / ".opencode" / "plugins"
+            plugin_dir.mkdir(parents=True)
+            (plugin_dir / "delay-prompt.js").write_text(
+                "export const DelayPrompt = async () => ({\n"
+                '  "chat.message": async () => {\n'
+                f"    await Bun.sleep({prompt_start_delay_seconds * 1000});\n"
+                "  },\n"
+                "});\n",
+                encoding="utf-8",
+            )
         project = app.client.post(
             "/api/projects",
             {
@@ -412,8 +425,9 @@ def _send_through_opencode_gateway_engine(
             {"text": "hello"},
         )
         assert sent.status == 202, sent.json()
-        deadline = time.monotonic() + 30
+        deadline = time.monotonic() + 60
         captured: list[dict[str, Any]] = []
+        result: dict[str, Any] | None = None
         while time.monotonic() < deadline:
             captured = [
                 request
@@ -422,10 +436,29 @@ def _send_through_opencode_gateway_engine(
                 and "You are a title generator"
                 not in json.dumps(request["body"], sort_keys=True)
             ]
-            if captured:
+            if require_terminal_result:
+                transcript = app.client.get(
+                    f"/api/sessions/{session.json()['id']}/messages?tail=1"
+                )
+                assert transcript.status == 200, transcript.json()
+                result = next(
+                    (
+                        row
+                        for row in reversed(transcript.json()["messages"])
+                        if row["type"] == "result"
+                    ),
+                    None,
+                )
+            if captured and (result is not None or not require_terminal_result):
                 break
             time.sleep(0.1)
         assert len(captured) == 1, app.diagnostics()
+        if require_terminal_result:
+            assert result is not None, app.diagnostics()
+            assert result["text"] == "mock response", {
+                "result": result,
+                "diagnostics": app.diagnostics(),
+            }
         overlay = json.loads(
             (
                 app.avibe_home
@@ -484,7 +517,7 @@ def _send_through_opencode_gateway_engine(
         assert set(live_providers["avibe-anthropic"]["models"]) == {
             "claude-opus-5"
         }
-        return captured[0]["body"]
+        return captured[0]["body"], result
 
 
 @pytest.mark.parametrize(
@@ -524,7 +557,7 @@ def test_opencode_v4_s4_variant_shapes_are_frozen_against_mock_capture(
     mock_llm_upstream,
     fixture: dict[str, Any],
 ) -> None:
-    captured_body = _send_through_opencode_gateway_engine(
+    captured_body, _ = _send_through_opencode_gateway_engine(
         model_hub_app_factory,
         mock_llm_upstream,
         upstream_protocol=fixture["protocol"],
@@ -534,6 +567,53 @@ def test_opencode_v4_s4_variant_shapes_are_frozen_against_mock_capture(
     )
 
     assert captured_body["model"] == fixture["stored_model"]
+    for key, value in fixture["upstream_fragment"].items():
+        assert captured_body.get(key) == value, captured_body
+
+
+def test_opencode_responses_turn_completes_through_openai_chat_upstream(
+    model_hub_app_factory,
+    mock_llm_upstream,
+) -> None:
+    fixture = OPENCODE_V4_S4_VARIANT_FIXTURES["responses_to_openai_chat"]
+
+    captured_body, result = _send_through_opencode_gateway_engine(
+        model_hub_app_factory,
+        mock_llm_upstream,
+        upstream_protocol=fixture["protocol"],
+        native_protocol=fixture["frontend_protocol"],
+        stored_model=fixture["stored_model"],
+        variant=fixture["variant"],
+        require_terminal_result=True,
+    )
+
+    assert captured_body["model"] == fixture["stored_model"]
+    assert result is not None
+    assert result["text"] == "mock response"
+    for key, value in fixture["upstream_fragment"].items():
+        assert captured_body.get(key) == value, captured_body
+
+
+def test_opencode_anthropic_turn_waits_for_accepted_prompt_worker(
+    model_hub_app_factory,
+    mock_llm_upstream,
+) -> None:
+    fixture = OPENCODE_V4_S4_VARIANT_FIXTURES["anthropic_same_protocol"]
+
+    captured_body, result = _send_through_opencode_gateway_engine(
+        model_hub_app_factory,
+        mock_llm_upstream,
+        upstream_protocol=fixture["protocol"],
+        native_protocol=fixture["frontend_protocol"],
+        stored_model=fixture["stored_model"],
+        variant=fixture["variant"],
+        prompt_start_delay_seconds=6.5,
+        require_terminal_result=True,
+    )
+
+    assert captured_body["model"] == fixture["stored_model"]
+    assert result is not None
+    assert result["text"] == "mock response"
     for key, value in fixture["upstream_fragment"].items():
         assert captured_body.get(key) == value, captured_body
 

--- a/tests/test_agent_steering.py
+++ b/tests/test_agent_steering.py
@@ -648,6 +648,8 @@ async def test_opencode_steers_existing_runner_without_abort_or_new_turn() -> No
         state = agent._steering_states[primary.base_session_id]
         assert state.awaiting_user_text == STEER_TEXT
         assert state.awaiting_prompt_accepted is True
+        assert state.awaiting_prompt_activity_deadline is not None
+        assert state.awaiting_prompt_activity_deadline > time.monotonic()
         assert state.awaiting_active_status_observed is False
         assert server.prompt_calls == [
             {
@@ -694,6 +696,7 @@ async def test_opencode_keeps_reconciliation_armed_after_post_write_idle() -> No
         assert state.awaiting_user_text == STEER_TEXT
         assert state.awaiting_after_message_ids == {"primary-user"}
         assert state.awaiting_prompt_accepted is True
+        assert state.awaiting_prompt_activity_deadline is not None
         assert server.abort_calls == []
     finally:
         await _cancel_tasks(gate_task)
@@ -1045,6 +1048,8 @@ async def test_opencode_coordinator_error_aborts_through_steering_owner(
     state = agent._steering_states[primary.base_session_id]
     assert state.awaiting_user_text == primary.message
     assert state.awaiting_prompt_accepted is True
+    assert state.awaiting_prompt_activity_deadline is not None
+    assert state.awaiting_prompt_activity_deadline > time.monotonic()
     assert state.awaiting_active_status_observed is False
     target = ActiveSteerTarget(
         runtime_key=primary.base_session_id,
@@ -2100,6 +2105,33 @@ async def test_opencode_accepted_prompt_stays_owned_until_delayed_result() -> No
         assert state.awaiting_after_message_ids is None
         assert state.closing is True
         assert server.list_calls == 2
+    finally:
+        await _cancel_tasks(gate_task)
+
+
+@pytest.mark.anyio
+async def test_opencode_accepted_prompt_without_activity_is_bounded() -> None:
+    primary = _primary_request(backend="opencode")
+    gate_task = await _held_task()
+    server = _OpenCodeServer(status={"type": "idle"})
+    agent = _opencode_agent(primary, gate_task, server)
+    state = agent._steering_states[primary.base_session_id]
+    state.awaiting_after_message_ids = set()
+    state.awaiting_user_text = "follow-up"
+    state.awaiting_prompt_accepted = True
+    state.awaiting_prompt_activity_deadline = time.monotonic() - 1
+    poll_server = _SteeringAwareOpenCodeServer(server, state)
+    try:
+        messages = await poll_server.list_messages(
+            "opencode-session",
+            primary.working_path,
+        )
+
+        assert messages[-1]["info"]["error"]["name"] == (
+            "NativeSessionEndedBeforeResult"
+        )
+        assert state.awaiting_after_message_ids is None
+        assert state.closing is True
     finally:
         await _cancel_tasks(gate_task)
 

--- a/tests/test_agent_steering.py
+++ b/tests/test_agent_steering.py
@@ -647,8 +647,7 @@ async def test_opencode_steers_existing_runner_without_abort_or_new_turn() -> No
         assert receipt.outcome is SteerOutcome.ACCEPTED
         state = agent._steering_states[primary.base_session_id]
         assert state.awaiting_user_text == STEER_TEXT
-        assert state.awaiting_start_confirmation_deadline is not None
-        assert state.awaiting_start_confirmation_deadline > time.monotonic()
+        assert state.awaiting_prompt_accepted is True
         assert state.awaiting_active_status_observed is False
         assert server.prompt_calls == [
             {
@@ -694,7 +693,7 @@ async def test_opencode_keeps_reconciliation_armed_after_post_write_idle() -> No
         assert receipt.reason == "native_turn_start_pending"
         assert state.awaiting_user_text == STEER_TEXT
         assert state.awaiting_after_message_ids == {"primary-user"}
-        assert state.awaiting_start_confirmation_deadline is not None
+        assert state.awaiting_prompt_accepted is True
         assert server.abort_calls == []
     finally:
         await _cancel_tasks(gate_task)
@@ -1045,8 +1044,7 @@ async def test_opencode_coordinator_error_aborts_through_steering_owner(
     await poll_started.wait()
     state = agent._steering_states[primary.base_session_id]
     assert state.awaiting_user_text == primary.message
-    assert state.awaiting_start_confirmation_deadline is not None
-    assert state.awaiting_start_confirmation_deadline > time.monotonic()
+    assert state.awaiting_prompt_accepted is True
     assert state.awaiting_active_status_observed is False
     target = ActiveSteerTarget(
         runtime_key=primary.base_session_id,
@@ -1497,7 +1495,7 @@ async def test_opencode_regular_turn_streams_snapshot_while_busy() -> None:
     state = agent._steering_states[primary.base_session_id]
     state.awaiting_after_message_ids = {"baseline-user"}
     state.awaiting_user_text = "primary"
-    state.awaiting_start_confirmation_deadline = time.monotonic() + 5.0
+    state.awaiting_prompt_accepted = True
     poll_server = _SteeringAwareOpenCodeServer(server, state)
     try:
         intermediate = await asyncio.wait_for(
@@ -1552,7 +1550,7 @@ async def test_opencode_regular_turn_waits_for_unconfirmed_start() -> None:
     state = agent._steering_states[primary.base_session_id]
     state.awaiting_after_message_ids = {"primary-user"}
     state.awaiting_user_text = "primary"
-    state.awaiting_start_confirmation_deadline = time.monotonic() + 5.0
+    state.awaiting_prompt_accepted = True
     poll_server = _SteeringAwareOpenCodeServer(server, state)
     poll_task = None
     try:
@@ -1733,7 +1731,7 @@ async def test_opencode_retry_keeps_completed_error_snapshots_gated() -> None:
     state = agent._steering_states[primary.base_session_id]
     state.awaiting_after_message_ids = set()
     state.awaiting_user_text = "primary"
-    state.awaiting_start_confirmation_deadline = time.monotonic() + 5.0
+    state.awaiting_prompt_accepted = True
     poll_server = _SteeringAwareOpenCodeServer(server, state)
     poll_task = None
     try:
@@ -1977,7 +1975,7 @@ async def test_opencode_accepted_prompt_waits_for_delayed_busy_registration() ->
     state.baseline_message_ids = {"primary-assistant"}
     state.awaiting_after_message_ids = {"primary-assistant"}
     state.awaiting_user_text = "follow-up"
-    state.awaiting_start_confirmation_deadline = time.monotonic() + 1
+    state.awaiting_prompt_accepted = True
     poll_server = _SteeringAwareOpenCodeServer(server, state)
     try:
         messages = await asyncio.wait_for(
@@ -2030,7 +2028,7 @@ async def test_opencode_idle_waits_for_delayed_terminal_message_visibility() -> 
     state = agent._steering_states[primary.base_session_id]
     state.awaiting_after_message_ids = set()
     state.awaiting_user_text = "follow-up"
-    state.awaiting_start_confirmation_deadline = time.monotonic() - 1
+    state.awaiting_prompt_accepted = True
     poll_server = _SteeringAwareOpenCodeServer(server, state)
     try:
         intermediate = await asyncio.wait_for(
@@ -2058,35 +2056,50 @@ async def test_opencode_idle_waits_for_delayed_terminal_message_visibility() -> 
 
 
 @pytest.mark.anyio
-async def test_opencode_accepted_prompt_idle_start_timeout_is_terminal() -> None:
+async def test_opencode_accepted_prompt_stays_owned_until_delayed_result() -> None:
     primary = _primary_request(backend="opencode")
     gate_task = await _held_task()
-    server = _OpenCodeServer(
-        messages=[
-            {
-                "info": {"id": "follow-up-user", "role": "user"},
-                "parts": [{"type": "text", "text": "follow-up"}],
-            }
-        ],
-        status={"type": "idle"},
-    )
+
+    class _DelayedAcceptedPromptServer(_OpenCodeServer):
+        async def list_messages(self, session_id: str, directory: str) -> list[dict]:
+            if self.list_calls == 1:
+                self.messages.extend(
+                    [
+                        {
+                            "info": {"id": "follow-up-user", "role": "user"},
+                            "parts": [{"type": "text", "text": "follow-up"}],
+                        },
+                        {
+                            "info": {
+                                "id": "follow-up-assistant",
+                                "role": "assistant",
+                                "time": {"completed": 2},
+                                "finish": "stop",
+                            },
+                            "parts": [{"type": "text", "text": "answered"}],
+                        },
+                    ]
+                )
+            return await super().list_messages(session_id, directory)
+
+    server = _DelayedAcceptedPromptServer(status={"type": "idle"})
     agent = _opencode_agent(primary, gate_task, server)
     state = agent._steering_states[primary.base_session_id]
     state.awaiting_after_message_ids = set()
     state.awaiting_user_text = "follow-up"
-    state.awaiting_start_confirmation_deadline = time.monotonic() - 1
+    state.awaiting_prompt_accepted = True
     poll_server = _SteeringAwareOpenCodeServer(server, state)
     try:
-        messages = await poll_server.list_messages(
-            "opencode-session",
-            primary.working_path,
+        messages = await asyncio.wait_for(
+            poll_server.list_messages("opencode-session", primary.working_path),
+            timeout=1,
         )
 
-        assert messages[-1]["info"]["error"]["name"] == (
-            "NativeSessionEndedBeforeResult"
-        )
+        assert messages[-1]["info"]["id"] == "follow-up-assistant"
+        assert state.terminal_status_failure_messages is None
         assert state.awaiting_after_message_ids is None
         assert state.closing is True
+        assert server.list_calls == 2
     finally:
         await _cancel_tasks(gate_task)
 

--- a/tests/test_model_hub_runtime.py
+++ b/tests/test_model_hub_runtime.py
@@ -15,6 +15,7 @@ from contextlib import contextmanager
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from types import SimpleNamespace
+from urllib.parse import urlsplit
 
 import pytest
 import yaml
@@ -1506,7 +1507,7 @@ def test_config_generation_is_private_and_never_logs_secrets(
     assert payload["openai-compatibility"][0]["api-key-entries"][0]["api-key"] == ("upstream-secret-value")
     assert {
         entry["base-url"] for entry in payload["openai-compatibility"]
-    } == {"https://api.example.test/v1", "https://api.deepseek.com"}
+    } == {"https://api.example.test/v1", "https://api.deepseek.com/v1"}
     assert len(payload["codex-api-key"]) == 2
     assert {entry["base-url"] for entry in payload["codex-api-key"]} == {"https://api.openai.com/v1"}
     responses_entry = next(
@@ -1836,6 +1837,56 @@ def test_api_key_vendor_catalog_populates_runtime_official_base_urls(
 
 
 @pytest.mark.parametrize(
+    ("base_url", "expected_base_url"),
+    [
+        ("https://relay.example.test", "https://relay.example.test/v1"),
+        (
+            "https://relay.example.test/custom/root?tenant=one",
+            "https://relay.example.test/custom/root?tenant=one",
+        ),
+    ],
+)
+def test_openai_compatibility_engine_base_url_uses_configured_api_root(
+    tmp_path: Path,
+    base_url: str,
+    expected_base_url: str,
+) -> None:
+    store = EngineStateStore(tmp_path / "state")
+    instance_dir, runtime_secrets = store.prepare_instance("install-1")
+    credential_ref = store.store_api_key(
+        "secret",
+        vendor="custom",
+        protocol="openai_chat",
+        base_url=base_url,
+    )
+    store.sync_sources(
+        [
+            _binding(
+                credential_ref,
+                source_id="src_custom123",
+                vendor="custom",
+                protocol="openai_chat",
+                base_url=base_url,
+            )
+        ]
+    )
+    config_path = instance_dir / "config.yaml"
+
+    write_engine_config(
+        config_path,
+        host="127.0.0.1",
+        port=18231,
+        auth_dir=store.auth_dir,
+        runtime_secrets=runtime_secrets,
+        sources=store.list_sources(),
+        state_store=store,
+    )
+
+    payload = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert payload["openai-compatibility"][0]["base-url"] == expected_base_url
+
+
+@pytest.mark.parametrize(
     ("vendor", "protocol", "expected_base_url"),
     API_KEY_VENDOR_RUNTIME_CASES,
 )
@@ -1885,7 +1936,10 @@ def test_catalog_owned_api_key_sources_without_explicit_base_url_sync_and_write_
     if protocol == "openai_responses":
         assert payload["codex-api-key"][0]["base-url"] == expected_base_url
         return
-    assert payload["openai-compatibility"][0]["base-url"] == expected_base_url
+    expected_engine_base_url = expected_base_url
+    if not urlsplit(expected_engine_base_url).path.rstrip("/"):
+        expected_engine_base_url = f"{expected_engine_base_url.rstrip('/')}/v1"
+    assert payload["openai-compatibility"][0]["base-url"] == expected_engine_base_url
 
 
 def test_state_removes_secret_bearing_configs_on_upgrade_and_revocation(tmp_path: Path) -> None:

--- a/vibe/model_hub_runtime/config.py
+++ b/vibe/model_hub_runtime/config.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any, Iterable
+from urllib.parse import urlsplit
 
 import yaml
 
 from config.atomic_io import write_atomic
+from config.v2_config import normalize_model_hub_base_url
 from vibe.model_hub_runtime.api_key_vendors import official_api_key_base_url
 from vibe.model_hub_runtime.state import EngineStateError, EngineStateStore, RuntimeSecrets, SourceRecord
 
@@ -114,11 +116,21 @@ def _append_source(payload: dict[str, Any], source: SourceRecord, store: EngineS
             base_url = official_api_key_base_url(source.vendor)
         if not base_url:
             raise EngineStateError("OpenAI-compatible source requires a base URL")
+        normalized_base_url = normalize_model_hub_base_url(base_url)
+        assert normalized_base_url is not None
+        if not urlsplit(normalized_base_url).path.rstrip("/"):
+            # CLIProxyAPI appends /chat/completions; Source origins use the
+            # standard /v1 endpoint root used by discovery and probes.
+            normalized_base_url = normalize_model_hub_base_url(
+                normalized_base_url,
+                append_path="/v1",
+            )
+            assert normalized_base_url is not None
         payload.setdefault("openai-compatibility", []).append(
             {
                 "name": source.prefix,
                 "prefix": source.prefix,
-                "base-url": base_url,
+                "base-url": normalized_base_url,
                 "api-key-entries": [{"api-key": api_key}],
                 "models": models,
             }


### PR DESCRIPTION
## Summary

- project bare-origin OpenAI-compatible Sources to the `/v1` API root expected by CLIProxyAPI before it appends `/chat/completions`
- keep ownership of a successful OpenCode `prompt_async` call until durable native activity or a terminal result is observed, while bounding a worker that never publishes any activity after 120 seconds
- add real OpenCode + real CLIProxyAPI + mock-upstream turn coverage for Responses -> OpenAI Chat and delayed-start Messages -> Anthropic

## Root causes

- The Source contract says a bare origin uses standard `/v1` endpoints, but the engine config received the origin literally. CLIProxyAPI appended `/chat/completions`, called the wrong path, and returned 404 before the mock upstream's `/v1/chat/completions` handler.
- OpenCode returns 204 before its forked prompt worker must publish a user message or `busy` status. Avibe treated five seconds of accepted-but-not-started idle state as `NativeSessionEndedBeforeResult`, so it emitted failure while OpenCode still owned and later completed the prompt.

## Evidence

- Failing-before: the Responses -> OpenAI Chat turn received engine 404 `not_found`, captured no `/v1/chat/completions`, and produced no Avibe result.
- Failing-before: a project plugin delayed OpenCode's `chat.message` hook by 6.5 seconds; Avibe emitted `NativeSessionEndedBeforeResult` at five seconds even though the Anthropic request later reached the mock.
- Passing: the two defect-specific real-runtime E2E turns pass (`2 passed`): the mock receives the expected protocol body and Avibe delivers `mock response`.
- Passing: `tests/test_agent_steering.py` (`63 passed`), including delayed accepted-worker completion and accepted-without-activity settlement.
- Passing: `tests/test_opencode_restore_polls.py` plus `tests/test_model_hub_runtime.py` (`263 passed`).
- Passing: Ruff on every changed Python file and `git diff --check`.
- Residual manual acceptance: refresh the read-only 15200 acceptance environment and rerun the two real CLI turns after merge.

## Known By Design

- The two reported CLI dispatcher turn ids return `turn_not_found` because Model Hub provenance v2 writes only for FSM-tracked Web turns. CLI/IM turns have no FSM attribution record, and the contract forbids approximate provenance (`docs/plans/model-hub-implementation.md`, "No FSM truth -> no record"); wider CLI/IM coverage remains the documented v2.1 candidate.

## Contract References

- `docs/plans/model-hub-contracts/api.md`: a bare-origin Base URL uses standard `/v1` endpoint paths; a URL with a path is the complete API root.
- `docs/plans/model-hub-implementation.md`: provenance is limited to exactly attributable FSM-tracked turns.
