### PR TITLE
fix(regression): preserve metadata after failed deletion

### DIFF
--- a/scripts/incus_regression.py
+++ b/scripts/incus_regression.py
@@ -2707,14 +2707,29 @@ def cmd_delete(args: argparse.Namespace) -> int:
     with target_update_lock(repo_root, args.remote, lock_project, dry_run=args.dry_run, blocking=False):
         target = resolve_target(args, repo_root, dry_run=args.dry_run, allocate_port=False, slug=slug)
         runner = Runner(dry_run=args.dry_run)
-        runner.run(incus("delete", remote_ref(args.remote, target.instance), "--force", project=target.project), check=False)
-        runner.run(incus("project", "delete", remote_ref(args.remote, target.project)), check=False)
+        results = (
+            runner.run(incus("delete", remote_ref(args.remote, target.instance), "--force", project=target.project), check=False),
+            runner.run(incus("project", "delete", remote_ref(args.remote, target.project)), check=False),
+        )
+        failed = [result for result in results if result.returncode != 0]
+        if failed:
+            statuses = ", ".join(str(result.returncode) for result in failed)
+            commands = "; ".join(shlex.join(result.args) for result in failed)
+            print(f"Could not delete {target.slug} ({commands} exited {statuses}); kept its metadata.", file=sys.stderr)
+            return 1
         if target.target == WORKTREE_TARGET and not args.dry_run:
             metadata = WorktreeMetadata(repo_root, args.remote)
-            metadata.forget([target.slug])
-            if not metadata.owned:
+            if metadata.owned:
+                with metadata.locked(dry_run=False):
+                    if target.slug in metadata.rows():
+                        environment = next(env for env in worktree_environments(runner, metadata) if env.slug == target.slug)
+                        if environment.exists:
+                            print(f"Could not confirm deletion of {target.slug}; kept its metadata.", file=sys.stderr)
+                            return 1
+                        metadata.forget([target.slug])
+            else:
                 # The row describes a slug and host port on this machine, and this
-                # deletion happened somewhere else, so `forget` above did nothing.
+                # deletion happened somewhere else, so this accessor cannot forget it.
                 # Saying so is all that is left to the caller: a slug used on both
                 # daemons would otherwise lose its local port reservation the moment
                 # the remote copy was removed, and lose it silently.

--- a/scripts/incus_regression.py
+++ b/scripts/incus_regression.py
@@ -2715,8 +2715,9 @@ def cmd_delete(args: argparse.Namespace) -> int:
         if failed:
             statuses = ", ".join(str(result.returncode) for result in failed)
             commands = "; ".join(shlex.join(result.args) for result in failed)
-            print(f"Could not delete {target.slug} ({commands} exited {statuses}); kept its metadata.", file=sys.stderr)
-            return 1
+            print(f"Delete commands failed for {target.slug} ({commands} exited {statuses}).", file=sys.stderr)
+        # A command's exit status does not say whether its objects still exist.
+        # Confirm the final inventory even after failure before deciding about the row.
         if target.target == WORKTREE_TARGET and not args.dry_run:
             metadata = WorktreeMetadata(repo_root, args.remote)
             if metadata.owned:
@@ -2734,7 +2735,7 @@ def cmd_delete(args: argparse.Namespace) -> int:
                 # daemons would otherwise lose its local port reservation the moment
                 # the remote copy was removed, and lose it silently.
                 print(f"Kept the local metadata for {target.slug}: it describes the local Incus daemon, not remote {args.remote}.")
-    return 0
+    return 1 if failed else 0
 
 
 def cmd_reconcile(args: argparse.Namespace) -> int:

--- a/tests/test_incus_regression.py
+++ b/tests/test_incus_regression.py
@@ -2434,45 +2434,86 @@ def test_delete_round_trips_generated_worktree_slug(tmp_path: Path, monkeypatch:
 
 
 @pytest.mark.parametrize(
-    ("returncode", "project_present"),
-    [(1, False), (0, True)],
-    ids=["delete-fails", "listing-still-present"],
+    "delete_codes", [(0, 0), (1, 0), (0, 1), (1, 1)],
+    ids=["deleted", "instance-delete-fails", "project-delete-fails", "both-deletes-fail"],
+)
+@pytest.mark.parametrize(
+    "inventory",
+    [
+        "absent", "project", "instance", "project-and-instance",
+        "project-list-fails", "instance-list-fails",
+        "unreadable-project-list", "unreadable-instance-list",
+    ],
 )
 def test_delete_keeps_worktree_metadata_until_absence_is_confirmed(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, returncode: int, project_present: bool
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+    delete_codes: tuple[int, int], inventory: str,
 ) -> None:
     repo = tmp_path / "repo"
     runtime = repo / ".runtime" / "incus-regression"
     runtime.mkdir(parents=True)
     slug = "delete-failed"
     row = {"path": str(repo), "project": f"avr-wt-{slug}", "instance": f"avibe-wt-{slug}", "host_port": 15206}
+    other_row = {"host_port": 15207, "claim": "unrelated-reservation"}
+    rows = {slug: row, "another-worktree": other_row}
     mapping_path = runtime / "worktrees.json"
-    mapping_path.write_text(json.dumps({"schema_version": 1, "worktrees": {slug: row}}), encoding="utf-8")
+    mapping_path.write_text(json.dumps({"schema_version": 1, "worktrees": rows}), encoding="utf-8")
+    delete_commands = [
+        ["incus", "--project", row["project"], "delete", row["instance"], "--force"],
+        ["incus", "project", "delete", row["project"]],
+    ]
+    listing_commands = [
+        ["incus", "project", "list", "--format", "json"],
+        ["incus", "list", "--all-projects", "--format", "json"],
+    ]
+    commands = []
 
-    class RecordingRunner:
-        def __init__(self, *, dry_run=False):
-            self.dry_run = dry_run
-
-        def run(self, command, *, check=True, **kwargs):
-            return subprocess.CompletedProcess(command, returncode, stderr="daemon unavailable")
-
-        def records(self, command, *, what):
-            if what == "Incus projects" and project_present:
-                return [{"name": row["project"]}]
-            return []
-
-        def names(self, command, *, what):
-            return [item["name"] for item in self.records(command, what=what)]
+    def run(command, **kwargs):
+        assert incus_regression.target_run_in_flight(repo, None, row["project"])
+        commands.append(command)
+        if command in delete_commands:
+            assert kwargs["check"] is False
+            return subprocess.CompletedProcess(command, delete_codes[delete_commands.index(command)])
+        assert command in listing_commands
+        kind = "project" if command == listing_commands[0] else "instance"
+        if inventory == f"{kind}-list-fails":
+            return subprocess.CompletedProcess(command, 1, stderr="daemon unavailable")
+        if inventory == f"unreadable-{kind}-list":
+            return subprocess.CompletedProcess(command, 0, stdout=json.dumps([{"unexpected": "schema"}]))
+        objects = []
+        if inventory in {kind, "project-and-instance"}:
+            objects.append(
+                {"name": row["project"]} if kind == "project"
+                else {"name": row["instance"], "project": row["project"], "status": "Running"}
+            )
+        return subprocess.CompletedProcess(command, 0, stdout=json.dumps(objects))
 
     monkeypatch.setattr(incus_regression, "current_repo_root", lambda: repo)
     monkeypatch.setattr(incus_regression, "git_common_root", lambda _repo_root: repo)
     monkeypatch.setattr(incus_regression, "load_env_file", lambda _repo_root, _env_file: None)
     monkeypatch.setattr(incus_regression, "require_incus", lambda: None)
-    monkeypatch.setattr(incus_regression, "Runner", RecordingRunner)
+    monkeypatch.setenv("INCUS_CMD", "incus")
+    monkeypatch.setattr(incus_regression.subprocess, "run", run)
 
-    assert incus_regression.cmd_delete(_delete_args(slug)) == 1
+    if "list" in inventory:
+        with pytest.raises(incus_regression.RegressionError):
+            incus_regression.cmd_delete(_delete_args(slug))
+    else:
+        assert incus_regression.cmd_delete(_delete_args(slug)) == int(any(delete_codes) or inventory != "absent")
+
+    expected_listings = (
+        listing_commands[:1] if inventory in {"project-list-fails", "unreadable-project-list"}
+        else listing_commands
+    )
+    assert commands == delete_commands + expected_listings
+    assert not incus_regression.target_run_in_flight(repo, None, row["project"])
     payload = json.loads(mapping_path.read_text(encoding="utf-8"))
-    assert payload["worktrees"] == {slug: row}
+    assert payload["worktrees"] == ({"another-worktree": other_row} if inventory == "absent" else rows)
+    err = capsys.readouterr().err
+    if any(delete_codes):
+        assert "exited" in err
+    if inventory == "absent":
+        assert "kept its metadata" not in err
 
 
 def test_delete_against_a_remote_keeps_the_local_metadata(

--- a/tests/test_incus_regression.py
+++ b/tests/test_incus_regression.py
@@ -2381,6 +2381,7 @@ def test_delete_round_trips_generated_worktree_slug(tmp_path: Path, monkeypatch:
         encoding="utf-8",
     )
     commands = []
+    listings = []
 
     class RecordingRunner:
         def __init__(self, *, dry_run=False):
@@ -2389,6 +2390,13 @@ def test_delete_round_trips_generated_worktree_slug(tmp_path: Path, monkeypatch:
         def run(self, command, *, check=True, **kwargs):
             commands.append(command)
             return subprocess.CompletedProcess(command, 0)
+
+        def records(self, command, *, what):
+            listings.append((command, what))
+            return []
+
+        def names(self, command, *, what):
+            return [item["name"] for item in self.records(command, what=what)]
 
     monkeypatch.setattr(incus_regression, "current_repo_root", lambda: repo)
     monkeypatch.setattr(incus_regression, "git_common_root", lambda _repo_root: repo)
@@ -2417,8 +2425,54 @@ def test_delete_round_trips_generated_worktree_slug(tmp_path: Path, monkeypatch:
         ["incus", "--project", project, "delete", instance, "--force"],
         ["incus", "project", "delete", project],
     ]
+    assert listings == [
+        (["incus", "project", "list", "--format", "json"], "Incus projects"),
+        (["incus", "list", "--all-projects", "--format", "json"], "Incus instances"),
+    ]
     payload = json.loads(mapping_path.read_text(encoding="utf-8"))
     assert payload["worktrees"] == {}
+
+
+@pytest.mark.parametrize(
+    ("returncode", "project_present"),
+    [(1, False), (0, True)],
+    ids=["delete-fails", "listing-still-present"],
+)
+def test_delete_keeps_worktree_metadata_until_absence_is_confirmed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, returncode: int, project_present: bool
+) -> None:
+    repo = tmp_path / "repo"
+    runtime = repo / ".runtime" / "incus-regression"
+    runtime.mkdir(parents=True)
+    slug = "delete-failed"
+    row = {"path": str(repo), "project": f"avr-wt-{slug}", "instance": f"avibe-wt-{slug}", "host_port": 15206}
+    mapping_path = runtime / "worktrees.json"
+    mapping_path.write_text(json.dumps({"schema_version": 1, "worktrees": {slug: row}}), encoding="utf-8")
+
+    class RecordingRunner:
+        def __init__(self, *, dry_run=False):
+            self.dry_run = dry_run
+
+        def run(self, command, *, check=True, **kwargs):
+            return subprocess.CompletedProcess(command, returncode, stderr="daemon unavailable")
+
+        def records(self, command, *, what):
+            if what == "Incus projects" and project_present:
+                return [{"name": row["project"]}]
+            return []
+
+        def names(self, command, *, what):
+            return [item["name"] for item in self.records(command, what=what)]
+
+    monkeypatch.setattr(incus_regression, "current_repo_root", lambda: repo)
+    monkeypatch.setattr(incus_regression, "git_common_root", lambda _repo_root: repo)
+    monkeypatch.setattr(incus_regression, "load_env_file", lambda _repo_root, _env_file: None)
+    monkeypatch.setattr(incus_regression, "require_incus", lambda: None)
+    monkeypatch.setattr(incus_regression, "Runner", RecordingRunner)
+
+    assert incus_regression.cmd_delete(_delete_args(slug)) == 1
+    payload = json.loads(mapping_path.read_text(encoding="utf-8"))
+    assert payload["worktrees"] == {slug: row}
 
 
 def test_delete_against_a_remote_keeps_the_local_metadata(
@@ -2568,6 +2622,12 @@ def test_delete_holds_the_slug_lock_across_the_objects_and_the_row(
         def run(self, command, *, check=True, **kwargs):
             observed.append(("objects", held()))
             return subprocess.CompletedProcess(command, 0)
+
+        def records(self, command, *, what):
+            return []
+
+        def names(self, command, *, what):
+            return []
 
     forget = incus_regression.WorktreeMetadata.forget
 


### PR DESCRIPTION
## Summary

- Capability: `incus_regression delete`.
- Local worktree metadata and its reserved host port are released only after complete listings from the owning Incus daemon confirm that neither the project nor the instance remains.
- Both deletion attempts are followed by inventory confirmation even when either command exits nonzero. An unavailable or unreadable inventory, or any remaining footprint, keeps the row intact.
- The existing environment update lock covers deletion and confirmation; the metadata lock covers the inventory-to-write decision. Remote deletion cannot remove local metadata.

Fixes #1848

## Scenario Coverage

- Scenario IDs: not applicable.
- Unit / contract: the real Runner and listing parsers are exercised with subprocess responses for independent delete outcomes, absent and partial footprints, unavailable or unreadable listings, update-lock scope, and unrelated reservation preservation. Existing remote-ownership and deletion tests remain covered.
- Scenario: live Incus validation was not performed. No local, production, or remote Incus environment was changed.
- Dependencies: none.

## Validation

- `python -m pytest -q tests/test_incus_regression.py`: 338 passed.
- `ruff check scripts/incus_regression.py tests/test_incus_regression.py`: passed.
- Red/green evidence: 24 of the 32 final-inventory combinations failed on the original PR head because failed delete commands skipped confirmation; all pass after the fix.

## Known-by-design

- KBD-1: A failed delete command still makes the overall command exit nonzero even when a subsequent complete inventory confirms absence and releases the row. Command execution and final resource existence are separate facts; retaining the failure preserves evidence without stranding a port. An interrupted or unlaunchable command still unwinds with its error and leaves metadata intact; this change does not add interruption recovery.

## Risks / Follow-ups

- When Incus cannot confirm absence, metadata and its reserved port remain intact. A later successful delete or explicit reconciliation can reclaim the row.
- Real-environment acceptance remains deferred; hermetic tests do not prove live Incus behavior.
