### PR TITLE
feat(memory): propagate capture-time sender names

### DIFF
--- a/avibe_memory/admission.py
+++ b/avibe_memory/admission.py
@@ -72,6 +72,7 @@ class InboundTurnFacts:
     attachment_capture_status: object = None
     attachment_config_generation: object = None
     attachment_selection: object = None
+    sender_name: str | None = None
 
 
 class CaptureAdmission:
@@ -217,6 +218,7 @@ class CaptureAdmission:
             occurred_at_ms=int(time.time() * 1000),
             attachments=attachments,
             attachment_config_generation=config_generation,
+            sender_name=facts.sender_name,
         )
 
 

--- a/avibe_memory/capture_adapter.py
+++ b/avibe_memory/capture_adapter.py
@@ -296,6 +296,7 @@ class EnabledMemoryAdapter:
             attachment_capture_status="unavailable",
             attachment_config_generation=None,
             attachment_selection=None,
+            sender_name=event.sender_name,
         )
         if event.platform != "avibe" and event.files:
             authorized = await run_blocking(

--- a/avibe_memory/everos.py
+++ b/avibe_memory/everos.py
@@ -129,6 +129,7 @@ class ProviderCapture:
     text: str
     provider_timestamp_ms: int
     attachments: tuple[CaptureAttachment, ...] = ()
+    sender_name: str | None = None
 
 
 def attachment_add_rejection_proves_no_write(
@@ -335,6 +336,7 @@ class EverOSPort:
                 "messages": [
                     {
                         "sender_id": capture.session_ref.principal_id,
+                        **({"sender_name": capture.sender_name} if capture.sender_name is not None else {}),
                         "role": "user",
                         "timestamp": capture.provider_timestamp_ms,
                         "content": content,

--- a/avibe_memory/module.py
+++ b/avibe_memory/module.py
@@ -656,6 +656,7 @@ class MemoryModule:
                         admission,
                         text=normalized_text,
                         bundle=None,
+                        sender_name=request.sender_name,
                     )
             await self._release_unadmitted_capture(reservation, pinned_bundle)
             if isinstance(error, AttachmentPinError) and normalized_text.strip() and request.attachments:
@@ -671,6 +672,7 @@ class MemoryModule:
             admission,
             text=normalized_text,
             bundle=pinned_bundle,
+            sender_name=request.sender_name,
         )
 
     async def _complete_capture_admission(
@@ -680,6 +682,7 @@ class MemoryModule:
         *,
         text: str,
         bundle: PinnedBundle | None,
+        sender_name: str | None = None,
     ) -> CaptureReceipt:
         if admission.outcome == "accepted":
             return await self._offer_admitted_capture(
@@ -687,6 +690,7 @@ class MemoryModule:
                 admission,
                 text=text,
                 bundle=bundle,
+                sender_name=sender_name,
             )
 
         await self._release_unadmitted_capture(reservation, bundle)
@@ -703,6 +707,7 @@ class MemoryModule:
         *,
         text: str,
         bundle: PinnedBundle | None,
+        sender_name: str | None = None,
     ) -> CaptureReceipt:
         outcome: CaptureOfferOutcome = self._writer.offer_capture(
             reservation,
@@ -710,6 +715,7 @@ class MemoryModule:
             text=text,
             attachments=(),
             bundle=bundle,
+            sender_name=sender_name,
         )
         if outcome == "queued":
             return CaptureAccepted(

--- a/avibe_memory/types.py
+++ b/avibe_memory/types.py
@@ -130,6 +130,7 @@ class CaptureRequest:
     occurred_at_ms: int
     attachments: tuple[CaptureAttachment, ...] = ()
     attachment_config_generation: int | None = None
+    sender_name: str | None = None
 
 
 def encode_capture_attachments(attachments: tuple[CaptureAttachment, ...]) -> str | None:

--- a/avibe_memory/writer.py
+++ b/avibe_memory/writer.py
@@ -255,6 +255,7 @@ class BestEffortMemoryWriter:
         text: str,
         attachments: tuple[CaptureAttachment, ...],
         bundle: PinnedBundle | None,
+        sender_name: str | None = None,
     ) -> CaptureOfferOutcome:
         """Queue one already-admitted capture without waiting for worker space."""
 
@@ -278,6 +279,7 @@ class BestEffortMemoryWriter:
                 text=text,
                 provider_timestamp_ms=admission.provider_timestamp_ms,
                 attachments=attachments,
+                sender_name=sender_name,
             ),
             bundle=bundle,
             reservation=reservation,
@@ -488,6 +490,7 @@ class BestEffortMemoryWriter:
             text=capture.text,
             provider_timestamp_ms=capture.provider_timestamp_ms,
             attachments=attachments,
+            sender_name=capture.sender_name,
         )
         attempt = 0
         while attempt < MAX_ATTEMPTS:
@@ -549,6 +552,7 @@ class BestEffortMemoryWriter:
                         session_ref=capture.session_ref,
                         text=capture.text,
                         provider_timestamp_ms=capture.provider_timestamp_ms,
+                        sender_name=capture.sender_name,
                     )
                     continue
                 await self._terminal_failure(item, "memory_processing_failed")

--- a/core/controller.py
+++ b/core/controller.py
@@ -3292,7 +3292,7 @@ class Controller:
     # The policy lives in ``avibe_memory.admission``. The controller only
     # collects the facts one turn carries and acts on the verdict.
 
-    def memory_sender_name_for_context(self, context: MessageContext) -> str | None:
+    async def memory_sender_name_for_context(self, context: MessageContext) -> str | None:
         if not bool(getattr(getattr(self.config, "memory", None), "enabled", False)):
             return None
         from core.memory_adapter import normalize_memory_sender_name
@@ -3302,9 +3302,13 @@ class Controller:
             payload = context.platform_specific if isinstance(context.platform_specific, dict) else {}
             platform = context.platform or payload.get("platform")
             if platform != "avibe":
-                name = _SettingsUserBindings(
-                    getattr(self, "platform_settings_managers", None)
-                ).display_name(platform, context.user_id)
+                name = await run_blocking(
+                    _SettingsUserBindings(
+                        getattr(self, "platform_settings_managers", None)
+                    ).display_name,
+                    platform,
+                    context.user_id,
+                )
         except Exception:
             pass
         return normalize_memory_sender_name(name) or i18n_t(

--- a/core/controller.py
+++ b/core/controller.py
@@ -125,6 +125,15 @@ class _SettingsUserBindings:
         user = store.get_user(user_id, platform=platform)
         return bool(user is not None and user.enabled)
 
+    def display_name(self, platform: str, user_id: str) -> str | None:
+        manager = self._managers.get(platform)
+        if manager is None:
+            return None
+        store = manager.get_store()
+        store.maybe_reload()
+        user = store.get_user(user_id, platform=platform)
+        return user.display_name if user is not None and user.enabled else None
+
 
 class RemovedPlatformIMClient(BaseIMClient):
     """No-op sink for stale replies after an IM platform is hot-disabled."""
@@ -1332,6 +1341,11 @@ class Controller:
             _load_memory_capture_types()
         )
         del _CaptureAccepted, _CaptureRequest
+        if request.provenance == "agent":
+            request = replace(
+                request,
+                sender_name=i18n_t("memory.sender.agent", getattr(self.config, "language", "en")),
+            )
         async with self._memory_replacement_lock():
             implementation_error = getattr(self, "_memory_implementation_error", None)
             if implementation_error is not None:
@@ -3277,6 +3291,25 @@ class Controller:
     #
     # The policy lives in ``avibe_memory.admission``. The controller only
     # collects the facts one turn carries and acts on the verdict.
+
+    def memory_sender_name_for_context(self, context: MessageContext) -> str | None:
+        if not bool(getattr(getattr(self.config, "memory", None), "enabled", False)):
+            return None
+        from core.memory_adapter import normalize_memory_sender_name
+
+        name = None
+        try:
+            payload = context.platform_specific if isinstance(context.platform_specific, dict) else {}
+            platform = context.platform or payload.get("platform")
+            if platform != "avibe":
+                name = _SettingsUserBindings(
+                    getattr(self, "platform_settings_managers", None)
+                ).display_name(platform, context.user_id)
+        except Exception:
+            pass
+        return normalize_memory_sender_name(name) or i18n_t(
+            "memory.sender.user", getattr(self.config, "language", "en")
+        )
 
     def _memory_admission(self) -> CaptureAdmission:
         # ``getattr`` keeps a controller assembled without a Memory runtime

--- a/core/handlers/message_handler.py
+++ b/core/handlers/message_handler.py
@@ -42,6 +42,7 @@ def memory_turn_event(
     session_id: str,
     lifecycle_snapshot: object,
     attachment_lease: object = None,
+    sender_name: str | None = None,
 ) -> TurnAccepted:
     """Close one live message context into immutable host-owned facts."""
 
@@ -64,6 +65,7 @@ def memory_turn_event(
         is_ordinary_attachment=context.is_original_human_attachment,
         lifecycle_snapshot=lifecycle_snapshot,
         attachment_lease=attachment_lease,
+        sender_name=sender_name,
     )
 
 
@@ -304,7 +306,11 @@ class MessageHandler(BaseHandler):
             base_session_id, working_path, composite_key = self.session_handler.get_session_info(context, source=source)
             capture_session_id = base_session_id
             capture_lifecycle_snapshot: object | None = None
+            capture_sender_name = None
             if is_human:
+                sender_name_for_context = getattr(self.controller, "memory_sender_name_for_context", None)
+                if callable(sender_name_for_context):
+                    capture_sender_name = sender_name_for_context(context)
                 capture_lifecycle_snapshot = lifecycle_snapshot
                 if capture_lifecycle_snapshot is None:
                     snapshot = getattr(
@@ -334,6 +340,7 @@ class MessageHandler(BaseHandler):
                         control_message,
                         capture_session_id,
                         capture_lifecycle_snapshot,
+                        sender_name=capture_sender_name,
                     )
                 )
                 capture_lifecycle_snapshot = None
@@ -731,6 +738,7 @@ class MessageHandler(BaseHandler):
                                 control_message,
                                 capture_session_id,
                                 capture_lifecycle_snapshot,
+                                sender_name=capture_sender_name,
                             )
                         )
                     raise
@@ -758,6 +766,7 @@ class MessageHandler(BaseHandler):
                         capture_session_id,
                         capture_lifecycle_snapshot,
                         attachment_lease,
+                        sender_name=capture_sender_name,
                     )
                 )
                 capture_lifecycle_snapshot = None

--- a/core/handlers/message_handler.py
+++ b/core/handlers/message_handler.py
@@ -310,7 +310,7 @@ class MessageHandler(BaseHandler):
             if is_human:
                 sender_name_for_context = getattr(self.controller, "memory_sender_name_for_context", None)
                 if callable(sender_name_for_context):
-                    capture_sender_name = sender_name_for_context(context)
+                    capture_sender_name = await sender_name_for_context(context)
                 capture_lifecycle_snapshot = lifecycle_snapshot
                 if capture_lifecycle_snapshot is None:
                     snapshot = getattr(

--- a/core/memory_adapter.py
+++ b/core/memory_adapter.py
@@ -4,6 +4,19 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Protocol, TypeAlias
+import unicodedata
+
+
+def normalize_memory_sender_name(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    name = "".join(
+        character
+        for character in value
+        if unicodedata.category(character) not in {"Cc", "Cs"}
+        and (unicodedata.category(character) != "Cf" or character in {"\u200c", "\u200d"})
+    ).strip()[:128].rstrip()
+    return name or None
 
 
 @dataclass(frozen=True, slots=True)
@@ -57,6 +70,7 @@ class TurnAccepted:
     is_ordinary_attachment: bool | None
     lifecycle_snapshot: object
     attachment_lease: object | None = None
+    sender_name: str | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/docs/plans/memory-sender-name-propagation.md
+++ b/docs/plans/memory-sender-name-propagation.md
@@ -18,6 +18,8 @@ The separate owner-identity investigation is background, not this PR's contract.
 - Resolve once before an accepted capture can queue, including before delayed
   attachment materialization. Lookup failure falls back; disabled Memory does
   not resolve names. The adapter offer hot path continues performing no IO.
+  The async handler awaits the snapshot; existing `run_blocking` keeps bound-user
+  settings reads off the shared event loop, before any accepted event is offered.
 - Normalize the label once: remove controls, surrogates and formatting controls
   (retain Unicode joiners), trim and bound to 128 code points. Preserve ordinary
   Unicode. Empty/missing labels use localized User or Agent. Labels are metadata,
@@ -75,3 +77,15 @@ until clean gate. No merge, deployment, or local service restart.
   fails because local Lima instance `avibe-incus-regression` is stopped.
   No container/service was started or restarted. Incus behavioral regression
   remains unverified; host tests use synthetic/test-owned state only.
+
+### Review round 1
+
+P2 on `2bac2928ea`: IM settings revision reads could block the async handler.
+The snapshot method now awaits existing `run_blocking` for the bound-user read;
+the handler awaits its result before creating any capture event. Web/disabled
+paths still avoid settings reads. A hermetic threaded-wait regression proves
+event-loop callback progress while the simulated settings read is blocked,
+and verifies the lookup runs on a different thread. All new name call sites
+were checked; the explicit Agent path only reads an in-memory i18n fallback.
+Focused validation: 401 passed, 2 known baseline failures deselected; changed
+Python Ruff and whitespace checks passed. No new cache or framework.

--- a/docs/plans/memory-sender-name-propagation.md
+++ b/docs/plans/memory-sender-name-propagation.md
@@ -1,0 +1,77 @@
+# Memory sender-name propagation
+
+Date: 2026-09-05. Current scope: owner-authorized sender_name ONLY.
+
+The owner-unification checkpoint in lane `ses6amq3uhtuh` was withdrawn, not
+approved. Owner binding, settings, aliases, read-label projection, history
+federation, migration, transfer workflows, and dependency upgrades are deferred.
+The separate owner-identity investigation is background, not this PR's contract.
+
+## Contract
+
+- Preserve existing principals, authentication, source authors, content,
+  timestamps, roles, and user/agent origins.
+- Add optional `sender_name` through `TurnAccepted`, `InboundTurnFacts`,
+  `CaptureRequest`, `ProviderCapture`, and EverOS `messages[].sender_name`.
+- Resolve IM names only from the existing platform-scoped enabled bound-user
+  record. Web uses localized User; browser author_name/email/sub are not sources.
+- Resolve once before an accepted capture can queue, including before delayed
+  attachment materialization. Lookup failure falls back; disabled Memory does
+  not resolve names. The adapter offer hot path continues performing no IO.
+- Normalize the label once: remove controls, surrogates and formatting controls
+  (retain Unicode joiners), trim and bound to 128 code points. Preserve ordinary
+  Unicode. Empty/missing labels use localized User or Agent. Labels are metadata,
+  not instructions; never prepend them to message text.
+- Explicit controller capture uses Agent for agent provenance and retains the
+  existing -agent principal. Carry the snapshot through attachment downgrade and
+  provider retries. Existing callers omitting sender_name remain compatible;
+  a provider request with no name omits the optional wire field.
+
+## Approved scope
+
+The PM approved the narrow extension to `core/handlers/message_handler.py` on
+2026-09-05: the `memory_turn_event` optional snapshot argument, its three call
+sites, and one local snapshot preparation. No routing, author selection, or
+authorization changes. Other changes are limited to host Memory capture wiring,
+capture DTO/admission/adapter/module/writer/provider transport, backend Memory
+labels, and focused existing tests. No config/storage/UI schema changes.
+
+## Validation
+
+Cover automatic and explicit capture, Unicode, missing/empty/duplicate names,
+rename while queued, best-effort lookup failure, disabled lookup avoidance,
+unchanged raw content and identities, and attachment retry preservation.
+Keep the no-IO offer sentinel. Test the synthetic host/provider transport and
+the supported published DTO, not a mocked peer contract alone.
+
+The exact lock-input wheels for EverOS 1.2.3, EverAlgo user-memory 0.4.0 and
+core 0.4.0 were hash-verified. A hermetic DTO/real MemCell/episode-renderer probe
+passed Unicode and old omitted-field cases. This is not a verified managed
+runtime archive or model-generated output: the checked-in archive manifest is
+unavailable with placeholder hashes. The old profile algorithm may still emit
+IDs. No real Memory data, installed packages, or services are modified for tests.
+
+Run focused pytest and changed-Python Ruff before push. Open a non-draft PR
+against master as rkrkrkk and keep the combined exact-head review/CI watch alive
+until clean gate. No merge, deployment, or local service restart.
+
+### Implementation evidence (2026-09-05)
+
+- Unit/contract: 400 focused capture, adapter, admission, module, writer, provider,
+  disabled-isolation and message-handler tests passed; 16 additional Slice 3
+  tests and 233 internal-server/Memory CLI tests passed (649 total).
+  Changed-Python Ruff and `git diff --check` passed.
+- Scenarios: MEMORY-SEARCH-019 exercises six automatic/explicit synthetic
+  host-to-provider HTTP captures; MEMORY-SEARCH-020 verifies rename-after-offer
+  snapshot preservation. Each catalog reference names one executable test.
+- Published contract: all six actual HTTP payloads from MEMORY-SEARCH-019 also
+  validated against the published EverOS 1.2.3 request DTO symbols extracted
+  from the hash-verified wheel. No live service, archive startup or model call.
+- Baseline failures: MEMORY-INDEP-013 and MEMORY-INDEP-014 fail because startup
+  creates `memory-config.tx.lock`. Both reproduce in a pristine archive of base
+  `9a260407daf0b65273b52954624faf0545e8017f`; excluded from the 400-pass command,
+  not changed or suppressed in source.
+- Residual environment gate: the supported Incus runner's read-only doctor
+  fails because local Lima instance `avibe-incus-regression` is stopped.
+  No container/service was started or restarted. Incus behavioral regression
+  remains unverified; host tests use synthetic/test-owned state only.

--- a/tests/scenarios/memory_search/catalog.yaml
+++ b/tests/scenarios/memory_search/catalog.yaml
@@ -122,3 +122,15 @@ scenarios:
     kind: boundary
     layer: contract
     test: tests/test_memory_module.py::test_capture_and_search_delegate_payload_size_to_everos
+  - id: MEMORY-SEARCH-019
+    name: Automatic and explicit capture preserve source identity and text while carrying sender names
+    status: covered
+    kind: boundary
+    layer: scenario
+    test: tests/test_memory_everos.py::test_sender_name_crosses_automatic_and_explicit_capture_http_boundary
+  - id: MEMORY-SEARCH-020
+    name: Accepted sender-name snapshots remain unchanged by asynchronous processing or later renames
+    status: covered
+    kind: lifecycle
+    layer: contract
+    test: tests/test_memory_adapter.py::test_sender_name_snapshot_survives_rename_before_async_admission

--- a/tests/test_memory_adapter.py
+++ b/tests/test_memory_adapter.py
@@ -322,38 +322,77 @@ def _sender_name_controller(*, enabled=True, language="en", user=None):
 
 
 @pytest.mark.parametrize("platform", ["slack", "avibe"])
-def test_sender_name_uses_only_bound_records_not_browser_claims(platform) -> None:
+@pytest.mark.asyncio
+async def test_sender_name_uses_only_bound_records_not_browser_claims(platform) -> None:
     user = SimpleNamespace(display_name="  小王\n ", enabled=True)
     controller, store, manager = _sender_name_controller(user=user)
     context = MessageContext(
         user_id="native-1", channel_id="channel-1", platform=platform,
         platform_specific={"author_id": "remote:subject", "author_name": "Untrusted"},
     )
-    assert controller.memory_sender_name_for_context(context) == ("小王" if platform == "slack" else "User")
+    assert await controller.memory_sender_name_for_context(context) == ("小王" if platform == "slack" else "User")
     if platform == "slack":
         store.get_user.assert_called_once_with("native-1", platform="slack")
     else:
         manager.get_store.assert_not_called()
 
 
-def test_sender_name_lookup_failure_and_disabled_capture_are_best_effort() -> None:
+@pytest.mark.asyncio
+async def test_sender_name_lookup_failure_and_disabled_capture_are_best_effort() -> None:
     controller, store, manager = _sender_name_controller(language="zh")
     context = MessageContext(user_id="raw-id", channel_id="channel", platform="slack")
     store.maybe_reload.side_effect = OSError("settings unavailable")
-    assert controller.memory_sender_name_for_context(context) == "用户"
+    assert await controller.memory_sender_name_for_context(context) == "用户"
     manager.reset_mock()
     controller.config.memory.enabled = False
-    assert controller.memory_sender_name_for_context(context) is None
+    assert await controller.memory_sender_name_for_context(context) is None
     manager.get_store.assert_not_called()
 
 
 @pytest.mark.parametrize("name", [None, "", " \x00 "])
-def test_missing_bound_name_falls_back_without_using_native_id(name) -> None:
+@pytest.mark.asyncio
+async def test_missing_bound_name_falls_back_without_using_native_id(name) -> None:
     controller, _store, _manager = _sender_name_controller(
         user=SimpleNamespace(display_name=name, enabled=True)
     )
     context = MessageContext(user_id="raw-id", channel_id="channel", platform="slack")
-    assert controller.memory_sender_name_for_context(context) == "User"
+    assert await controller.memory_sender_name_for_context(context) == "User"
+
+
+@pytest.mark.asyncio
+async def test_sender_name_lookup_wait_does_not_block_event_loop() -> None:
+    import threading
+
+    loop = asyncio.get_running_loop()
+    loop_thread = threading.get_ident()
+    started = asyncio.Event()
+    release = threading.Event()
+    lookup_threads = []
+    controller, store, _manager = _sender_name_controller(
+        user=SimpleNamespace(display_name="小王", enabled=True)
+    )
+
+    def blocked_reload():
+        lookup_threads.append(threading.get_ident())
+        loop.call_soon_threadsafe(started.set)
+        assert release.wait(timeout=3), "event loop could not release the lookup"
+
+    store.maybe_reload.side_effect = blocked_reload
+    context = MessageContext(user_id="user-1", channel_id="channel", platform="slack")
+    task = asyncio.create_task(controller.memory_sender_name_for_context(context))
+    try:
+        await asyncio.wait_for(started.wait(), timeout=1)
+        assert lookup_threads and lookup_threads[0] != loop_thread
+        assert not task.done()
+        # A separate loop callback must progress while the settings read waits.
+        heartbeat = asyncio.Event()
+        loop.call_soon(heartbeat.set)
+        await asyncio.wait_for(heartbeat.wait(), timeout=1)
+    finally:
+        release.set()
+        name = await task
+    assert name == "小王"
+    store.maybe_reload.assert_called_once_with()
 
 
 @pytest.mark.asyncio
@@ -366,7 +405,7 @@ async def test_sender_name_snapshot_survives_rename_before_async_admission() -> 
         platform_specific={"is_dm": True}, is_original_human_text=True,
     )
     text = "原文\n`u-synthetic` https://example.invalid/u-synthetic"
-    name = controller.memory_sender_name_for_context(context)
+    name = await controller.memory_sender_name_for_context(context)
     event = memory_turn_event(context, text, "session-1", 1, sender_name=name)
     module = _Module()
     adapter, _lifecycle = _adapter(module)

--- a/tests/test_memory_adapter.py
+++ b/tests/test_memory_adapter.py
@@ -22,6 +22,7 @@ from core.memory_adapter import (
     SessionArchived,
     SessionReset,
     TurnAccepted,
+    normalize_memory_sender_name,
 )
 from core.handlers.message_handler import memory_turn_event
 from modules.im.base import FileAttachment, MessageContext
@@ -275,12 +276,13 @@ def test_host_event_is_closed_and_uses_authenticated_workbench_author() -> None:
         is_original_human_attachment=True,
     )
 
-    event = memory_turn_event(context, "记住原件", "session-1", (3, 4))
+    event = memory_turn_event(context, "记住原件", "session-1", (3, 4), sender_name="用户")
     file.name = "mutated.pdf"
     context.user_id = "mutated-user"
     context.files.clear()
 
     assert event.user_id == "authenticated-author"
+    assert event.sender_name == "用户"
     assert event.text == "记住原件"
     assert event.files == (
         MemoryFile(
@@ -289,6 +291,98 @@ def test_host_event_is_closed_and_uses_authenticated_workbench_author() -> None:
             local_path="/private/original.pdf",
         ),
     )
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (None, None),
+        (123, None),
+        (" \n\x00\ud800\u202e ", None),
+        ("  小王 Élodie 🌱\n\u202e ", "小王 Élodie 🌱"),
+        ("👩\u200d💻", "👩\u200d💻"),
+        ("名" * 140, "名" * 128),
+    ],
+)
+def test_sender_name_normalization_preserves_bounded_unicode(raw, expected) -> None:
+    assert normalize_memory_sender_name(raw) == expected
+
+
+def _sender_name_controller(*, enabled=True, language="en", user=None):
+    from core.controller import Controller
+
+    controller = Controller.__new__(Controller)
+    controller.config = SimpleNamespace(memory=SimpleNamespace(enabled=enabled), language=language)
+    store = Mock()
+    store.get_user.return_value = user
+    manager = Mock()
+    manager.get_store.return_value = store
+    controller.platform_settings_managers = {"slack": manager}
+    return controller, store, manager
+
+
+@pytest.mark.parametrize("platform", ["slack", "avibe"])
+def test_sender_name_uses_only_bound_records_not_browser_claims(platform) -> None:
+    user = SimpleNamespace(display_name="  小王\n ", enabled=True)
+    controller, store, manager = _sender_name_controller(user=user)
+    context = MessageContext(
+        user_id="native-1", channel_id="channel-1", platform=platform,
+        platform_specific={"author_id": "remote:subject", "author_name": "Untrusted"},
+    )
+    assert controller.memory_sender_name_for_context(context) == ("小王" if platform == "slack" else "User")
+    if platform == "slack":
+        store.get_user.assert_called_once_with("native-1", platform="slack")
+    else:
+        manager.get_store.assert_not_called()
+
+
+def test_sender_name_lookup_failure_and_disabled_capture_are_best_effort() -> None:
+    controller, store, manager = _sender_name_controller(language="zh")
+    context = MessageContext(user_id="raw-id", channel_id="channel", platform="slack")
+    store.maybe_reload.side_effect = OSError("settings unavailable")
+    assert controller.memory_sender_name_for_context(context) == "用户"
+    manager.reset_mock()
+    controller.config.memory.enabled = False
+    assert controller.memory_sender_name_for_context(context) is None
+    manager.get_store.assert_not_called()
+
+
+@pytest.mark.parametrize("name", [None, "", " \x00 "])
+def test_missing_bound_name_falls_back_without_using_native_id(name) -> None:
+    controller, _store, _manager = _sender_name_controller(
+        user=SimpleNamespace(display_name=name, enabled=True)
+    )
+    context = MessageContext(user_id="raw-id", channel_id="channel", platform="slack")
+    assert controller.memory_sender_name_for_context(context) == "User"
+
+
+@pytest.mark.asyncio
+async def test_sender_name_snapshot_survives_rename_before_async_admission() -> None:
+    """MEMORY-SEARCH-020: a queued capture keeps its accepted name snapshot."""
+    user = SimpleNamespace(display_name="  小王 Élodie 🌱 ", enabled=True)
+    controller, _store, _manager = _sender_name_controller(user=user)
+    context = MessageContext(
+        user_id="user-1", channel_id="channel", platform="slack", message_id="message-1",
+        platform_specific={"is_dm": True}, is_original_human_text=True,
+    )
+    text = "原文\n`u-synthetic` https://example.invalid/u-synthetic"
+    name = controller.memory_sender_name_for_context(context)
+    event = memory_turn_event(context, text, "session-1", 1, sender_name=name)
+    module = _Module()
+    adapter, _lifecycle = _adapter(module)
+    try:
+        adapter.offer(event)
+        user.display_name = "Renamed"
+        await _settle(adapter)
+        assert len(module.captures) == 1
+        captured = module.captures[0]
+        assert captured.sender_name == "小王 Élodie 🌱"
+        assert captured.text == text
+        assert captured.principal_id == PRINCIPAL
+        assert captured.provenance == "user_input"
+        assert event.user_id == "user-1"
+    finally:
+        await adapter.cancel_memory_capture_tasks()
 
 
 @pytest.mark.asyncio

--- a/tests/test_memory_admission.py
+++ b/tests/test_memory_admission.py
@@ -80,6 +80,17 @@ def _facts(**overrides) -> InboundTurnFacts:
     return InboundTurnFacts(**{**defaults, **overrides})
 
 
+@pytest.mark.parametrize("name", [None, "", "小王 Élodie 🌱"])
+def test_sender_name_is_optional_metadata_not_principal_input(name) -> None:
+    principals = _Principals()
+    admission = _admission(principals=principals)
+    captured = admission.decide(_facts(sender_name=name))
+    assert captured.sender_name == name
+    assert captured.principal_id == PRINCIPAL
+    assert captured.text == "ordinary text"
+    assert principals.keys == ["slack:user-1"]
+
+
 class _PdfDownloader:
     async def download_file_to_path(
         self,

--- a/tests/test_memory_disabled_isolation.py
+++ b/tests/test_memory_disabled_isolation.py
@@ -18,7 +18,7 @@ from config.v2_compat import to_app_config
 from config.v2_config import V2Config
 from core import memory_legacy_cleanup
 from core.controller import Controller
-from avibe_memory import CaptureRequest, CaptureSkipped
+from avibe_memory import CaptureAccepted, CaptureRequest, CaptureSkipped
 from core.memory_adapter import DisabledMemoryAdapter
 from vibe.memory_contract import (
     MemoryImplementationIncompatibleError,
@@ -1300,6 +1300,28 @@ async def test_implementation_failure_rechecked_after_blocked_capture_lock() -> 
 
     with pytest.raises(MemoryImplementationUnavailableError):
         await capture
+
+
+@pytest.mark.asyncio
+async def test_explicit_agent_capture_snapshots_semantic_name_before_waiting() -> None:
+    controller = _controller_with_memory(replace(_disabled_app_config().memory, enabled=True))
+    captures = []
+
+    async def capture(request):
+        captures.append(request)
+        return CaptureAccepted()
+
+    controller.memory_runtime = types.SimpleNamespace(
+        available=True, module=types.SimpleNamespace(capture=capture)
+    )
+    request = replace(_capture_request(), sender_name="Not the human")
+    gate = controller._memory_replacement_lock()
+    await gate.acquire()
+    pending = asyncio.create_task(controller.capture_memory(request))
+    await asyncio.sleep(0)
+    gate.release()
+    await pending
+    assert captures == [replace(request, sender_name="Agent")]
 
 
 @pytest.mark.asyncio

--- a/tests/test_memory_everos.py
+++ b/tests/test_memory_everos.py
@@ -131,7 +131,7 @@ def test_sender_name_crosses_automatic_and_explicit_capture_http_boundary(tmp_pa
                 )
                 event = memory_turn_event(
                     context, text, "shared-project-session", 1,
-                    sender_name=controller.memory_sender_name_for_context(context),
+                    sender_name=await controller.memory_sender_name_for_context(context),
                 )
                 adapter.offer(event)
                 expected_owners.append(store.principal_for_user_key(f"{platform}:{source}"))

--- a/tests/test_memory_everos.py
+++ b/tests/test_memory_everos.py
@@ -73,6 +73,112 @@ def _sidecar_transport(handler):
     return patch("avibe_memory.everos.httpx.AsyncHTTPTransport", return_value=httpx.MockTransport(handler))
 
 
+def test_sender_name_crosses_automatic_and_explicit_capture_http_boundary(tmp_path) -> None:
+    """MEMORY-SEARCH-019: accepted source identity survives named provider capture."""
+    from types import SimpleNamespace
+
+    from avibe_memory.capture_adapter import EnabledMemoryAdapter
+    from avibe_memory.module import MIN_FREE_DISK_BYTES, MemoryModule
+    from avibe_memory.types import CaptureRequest
+    from core.controller import Controller
+    from core.handlers.message_handler import memory_turn_event
+    from modules.im.base import MessageContext
+
+    requests = []
+    text = "原文\n`u-synthetic` https://example.invalid/u-synthetic"
+
+    def handler(request):
+        payload = json.loads(request.content)
+        if request.url.path.endswith("/add"):
+            requests.append(payload)
+        return httpx.Response(200, json={"request_id": "synthetic", "data": {"status": "accumulated"}})
+
+    async def acquire(_session_id):
+        return SimpleNamespace(release=lambda: None)
+
+    async def run():
+        store = MemoryStore(tmp_path / "state/memory/memory.sqlite", effective_home=tmp_path)
+        module = MemoryModule(
+            store, EverOSPort(tmp_path / "synthetic.sock"), enabled=True,
+            disk_free_bytes=lambda: MIN_FREE_DISK_BYTES, effective_home=tmp_path,
+        )
+        controller = Controller.__new__(Controller)
+        controller.config = SimpleNamespace(memory=SimpleNamespace(enabled=True), language="en")
+        controller.memory_runtime = SimpleNamespace(available=True, module=module)
+        bound_users = SimpleNamespace(
+            maybe_reload=lambda: None,
+            get_user=lambda *_args, **_kwargs: SimpleNamespace(enabled=True, display_name="小王 Élodie 🌱"),
+        )
+        controller.platform_settings_managers = {"slack": SimpleNamespace(get_store=lambda: bound_users)}
+        adapter = EnabledMemoryAdapter(
+            module=module, principals=store, is_enabled_user=lambda *_args: True,
+            lifecycle_snapshot_matches=lambda *_args: True,
+            acquire_lifecycle_admission=acquire,
+            attachment_capture_status=lambda: asyncio.sleep(0, result="ready"),
+            attachment_config_generation=lambda: 1,
+        )
+        adapter.start(task_factory=asyncio.create_task)
+        expected_owners = []
+        try:
+            sources = [("avibe", source) for source in ("local", "remote:owner", "remote:other")]
+            sources.extend([("slack", "user-1"), ("slack", "user-2")])
+            for platform, source in sources:
+                context = MessageContext(
+                    user_id=source, channel_id="shared-project-session", platform=platform,
+                    message_id=source,
+                    platform_specific={"author_id": source, "author_name": "Untrusted", "is_dm": True},
+                    is_original_human_text=True,
+                )
+                event = memory_turn_event(
+                    context, text, "shared-project-session", 1,
+                    sender_name=controller.memory_sender_name_for_context(context),
+                )
+                adapter.offer(event)
+                expected_owners.append(store.principal_for_user_key(f"{platform}:{source}"))
+            await adapter.wait_idle_for_tests()
+            principal = expected_owners[0]
+            await controller.capture_memory(CaptureRequest(
+                source_message_id="explicit", session_id="shared-project-session",
+                principal_id=principal, project_id="default", provenance="agent",
+                text=text, occurred_at_ms=1_725_000_001_234,
+            ))
+            await module.wait_writer_idle_for_tests()
+            messages = [payload["messages"][0] for payload in requests]
+            names = ["User", "User", "User", "小王 Élodie 🌱", "小王 Élodie 🌱", "Agent"]
+            assert {message["sender_id"]: message["sender_name"] for message in messages} == dict(
+                zip([*expected_owners, principal + "-agent"], names)
+            )
+            assert len(messages) == len({message["sender_id"] for message in messages}) == 6
+            assert all(message["content"] == text and message["role"] == "user" for message in messages)
+            assert all(isinstance(message["timestamp"], int) for message in messages)
+        finally:
+            await adapter.cancel_memory_capture_tasks()
+            await module.close_writer()
+
+    with _sidecar_transport(handler):
+        asyncio.run(run())
+
+
+@pytest.mark.parametrize("name", [None, "", "小王 Élodie 🌱"])
+def test_sender_name_is_optional_in_provider_payload(name) -> None:
+    requests = []
+
+    def handler(request):
+        requests.append(json.loads(request.content))
+        return httpx.Response(200, json={"request_id": "synthetic", "data": {"status": "accumulated"}})
+
+    with _sidecar_transport(handler):
+        asyncio.run(EverOSPort(Path("/tmp/synthetic.sock")).add(ProviderCapture(
+            session_ref=SESSION_REF, text="原文 stays", provider_timestamp_ms=1_725_000_001_234,
+            sender_name=name,
+        )))
+    message = requests[0]["messages"][0]
+    assert message == {
+        "sender_id": PRINCIPAL, "role": "user", "timestamp": 1_725_000_001_234,
+        "content": "原文 stays", **({"sender_name": name} if name is not None else {}),
+    }
+
+
 class _FailingResponseStream(httpx.AsyncByteStream):
     def __init__(
         self,
@@ -262,6 +368,7 @@ def test_provider_capture_has_one_canonical_session_identity() -> None:
         "text",
         "provider_timestamp_ms",
         "attachments",
+        "sender_name",
     )
     assert capture.session_ref.principal_id == PRINCIPAL
     derived_session_ids = {

--- a/tests/test_memory_module.py
+++ b/tests/test_memory_module.py
@@ -87,6 +87,23 @@ async def test_capture_is_accepted_and_duplicate_is_process_local(tmp_path: Path
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("provenance", ["user_input", "agent"])
+async def test_sender_name_reaches_writer_without_changing_capture_identity(tmp_path, provenance) -> None:
+    module, store, provider = _module(tmp_path)
+    principal = store.principal_for_user_key("avibe:local")
+    text = "原文\n`u-synthetic` https://example.invalid/u-synthetic"
+    name = "小王 Élodie 🌱" if provenance == "user_input" else "Agent"
+    request = _request(principal_id=principal, provenance=provenance, text=text, sender_name=name)
+    assert await module.capture(request) == CaptureAccepted()
+    await module.wait_writer_idle_for_tests()
+    capture = provider.captures[0]
+    assert capture.sender_name == name
+    assert capture.text == text
+    assert capture.session_ref.principal_id == principal + ("-agent" if provenance == "agent" else "")
+    await module.close_writer()
+
+
+@pytest.mark.asyncio
 async def test_lifecycle_barrier_does_not_wait_for_writer(tmp_path: Path) -> None:
     """MEMORY-SEARCH-017: a lifecycle barrier is offered without a drain."""
 

--- a/tests/test_memory_writer.py
+++ b/tests/test_memory_writer.py
@@ -11,6 +11,7 @@ import pytest
 
 from avibe_memory.everos import (
     AddAck,
+    AddRejected,
     FakeMemoryProvider,
     FlushRetryable,
     FlushSucceeded,
@@ -18,7 +19,7 @@ from avibe_memory.everos import (
 )
 from avibe_memory.attachments import AttachmentBundleInvalidError
 from avibe_memory.store import MemoryStore, VolatileAdmission
-from avibe_memory.types import ProviderSessionRef
+from avibe_memory.types import CaptureAttachment, ProviderSessionRef
 from avibe_memory.writer import (
     IDLE_FLUSH_SECONDS,
     MAX_ATTEMPTS,
@@ -252,6 +253,41 @@ async def test_only_proven_pre_execution_failures_retry_three_times(tmp_path: Pa
     _reserve_and_offer(writer, 0)
     await writer.wait_idle_for_tests()
     assert calls == MAX_ATTEMPTS
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("downgrade_attachment", [False, True])
+async def test_sender_name_survives_provider_retry_and_attachment_downgrade(tmp_path, downgrade_attachment) -> None:
+    provider = FakeMemoryProvider()
+    attempts = []
+
+    async def add(capture):
+        attempts.append(capture)
+        if len(attempts) == 1:
+            if downgrade_attachment:
+                return AddRejected(request_id=None, error_code="UNSUPPORTED_FORMAT", server_fault=False)
+            raise MemoryProviderFailure("memory_sidecar_unavailable")
+        return AddAck(request_id="synthetic", status="accumulated")
+
+    provider.add = add
+    writer = _writer(tmp_path, provider)
+    reservation = writer.reserve("named-capture")
+    assert not isinstance(reservation, str)
+    attachments = (CaptureAttachment("pdf", "原件.pdf", "file:///synthetic.pdf", "pdf"),) if downgrade_attachment else ()
+    assert writer.offer_capture(
+        reservation, _admission(0), text="原文\nunchanged", attachments=attachments,
+        bundle=None, sender_name="小王 🌱",
+    ) == "queued"
+    await writer.wait_idle_for_tests()
+    assert len(attempts) == 2
+    assert all(capture.sender_name == "小王 🌱" for capture in attempts)
+    assert all(capture.text == "原文\nunchanged" for capture in attempts)
+    assert all(capture.session_ref == _ref(0) for capture in attempts)
+    assert all(capture.provider_timestamp_ms == 1 for capture in attempts)
+    if downgrade_attachment:
+        assert attempts[0].attachments == attachments
+        assert attempts[1].attachments == ()
+    await writer.close()
 
 
 @pytest.mark.asyncio

--- a/vibe/i18n/en.json
+++ b/vibe/i18n/en.json
@@ -788,6 +788,10 @@
     }
   },
   "memory": {
+    "sender": {
+      "user": "User",
+      "agent": "Agent"
+    },
     "cli": {
       "help": {
         "command": "Use local Memory through the running controller",

--- a/vibe/i18n/zh.json
+++ b/vibe/i18n/zh.json
@@ -788,6 +788,10 @@
     }
   },
   "memory": {
+    "sender": {
+      "user": "用户",
+      "agent": "Agent"
+    },
     "cli": {
       "help": {
         "command": "通过运行中的控制器使用本地记忆",


### PR DESCRIPTION
## Outcome

Connect optional capture-time `sender_name` to the existing EverOS message field without changing message content or identity. **Sender names only: the earlier owner-unification checkpoint was withdrawn, not approved.** The existing lane/branch name is historical, not the feature scope.

## Contract and scope

- Trusted enabled platform-bound IM records supply display names. Local/Cloud Web use localized User; agent-origin explicit remember uses Agent and retains the existing `-agent` principal.
- Snapshot once before queuing (including delayed attachments), normalize bounded Unicode metadata once, and carry it through accepted-event → admission → CaptureRequest → writer → ProviderCapture → HTTP. No content prefixing, author-name claims, network name lookup, or name IO in `offer`.
- Lookup errors fall back without aborting chat; disabled Memory does not resolve names. Old omitted-field callers remain valid; the optional HTTP field is omitted when absent. Retries and attachment downgrades retain the snapshot.
- Author IDs, timestamp calculation, role, origin, auth, principal derivation and raw content remain unchanged. Same-name users remain distinct. Existing history is untouched.
- Scope is capture wiring/DTOs, focused tests, backend Memory i18n labels, and the concise approved [sender-name spec](docs/plans/memory-sender-name-propagation.md). PM explicitly approved the narrow message-handler helper/three-call-site extension.

Deferred/out of scope: owner binding/unification, display-name settings/UI, aliases, new storage/config, history aggregation/migration/regeneration, read-label projection, transfer workflows, backend/EverOS changes, dependency upgrades. No real user records or Memory data were written.

## Evidence

- **Unit/contract:** 400 focused adapter/admission/module/writer/provider/disabled-isolation/message-handler tests; 16 Slice 3 tests; 233 internal-server/Memory CLI tests: **649 passed**. Existing no-IO offer sentinel retained. Changed-Python Ruff and `git diff --check` passed. No UI files changed.
- **Scenario:** `MEMORY-SEARCH-019` exercises six synthetic automatic/explicit captures across actual host/adapter/admission/module/writer/provider HTTP wiring, including Unicode, same names with distinct IDs, unchanged content and agent separation. `MEMORY-SEARCH-020` verifies rename-after-offer snapshots. Both catalog references collect exactly one test.
- **Published contract:** exact lock-input wheel hashes verified for EverOS 1.2.3 / EverAlgo user-memory and core 0.4.0. DTO/MemCell/real episode-renderer probe passed; all six actual scenario HTTP payloads additionally validate against the published request DTO symbols without importing/running the API service. No dependency installation into the app and no upgrades.

## Known limitations / residual checks

- Two disabled-startup tests (`MEMORY-INDEP-013`, `MEMORY-INDEP-014`) fail due to existing `memory-config.tx.lock` creation. Both reproduce on pristine base `9a260407daf0b65273b52954624faf0545e8017f`. They were deselected from the 400-pass command, not edited/suppressed in source; this PR does not expand into that unrelated startup fix.
- Supported Incus runner `doctor` fails because local Lima instance `avibe-incus-regression` is stopped. No existing service/container was started/restarted; Incus behavioral regression remains unverified.
- The checked-in managed-runtime archive manifest is unavailable with placeholder hashes. This verifies published wheel DTO/render and synthetic capture transport, **not archive startup, live EverOS ingestion, LLM output or regenerated/profile prose**. Existing profile algorithms may still display IDs.
- No merge/deployment authorization; exact-head Codex review and all CI remain delivery gates.
