### PR TITLE
test(ci): await supervisor work completion

### DIFF
--- a/docs/plans/ci-test-runtime.md
+++ b/docs/plans/ci-test-runtime.md
@@ -231,3 +231,36 @@ integration passed 130 tests, and four focused UI files passed 62 tests. The
 1,092 original top-level functions/classes across the four behavioral test
 modules are unchanged. No test assertions were removed. Dependency compatibility
 and Ruff checks passed; main-checkout dirty-file checksums remain unchanged.
+
+### Post-merge supervisor test synchronization
+
+PR #1882 head `feb73e6c33` passed exact-head bot review, all 17 checks and
+the complete whole-PR thread gate. Its green run 33967285557 took 6m24s;
+all 399 Python files ran exactly once. The merge source `1ec7842f1` has the
+same tree, but master run 33967925507 failed one existing supervisor test:
+HFR-163 stopped the supervisor after 100 `sleep(0)` iterations with four of
+five partitions completed. All other independent jobs passed. The master's
+6m41s failed run is not a green performance measurement.
+
+The supervisor scans through a thread executor. Yielding the event loop a fixed
+number of times does not guarantee that the executor result has been delivered.
+Stopping the supervisor then correctly closes admission before the last partition
+can run. A controlled local probe delayed each real scan result by 200 event-loop
+turns, without changing that result or the production implementation. It reproduced
+premature assertions in HFR-163 and the same positive-wait pattern in HFR-162
+(backoff entry) and HFR-175 (global lease-loss shutdown).
+
+The orchestrator chooses a separate, test-only follow-up PR for these three
+waits. Await bounded events for actual backoff entry, all five completions, and
+the real stop-task creation. The stop observer delegates to the original method;
+it does not replace lease-loss handling or trigger shutdown itself. Retain every
+deadline, capacity, completion, lease-loss and ownership assertion, and always join
+the supervisor on assertion failure. The remaining fixed yields inspect absence
+of extra work or same-loop callbacks, not completion of an off-loop scan, and are
+outside this diagnosed class. No production, timeout, discovery, dependency or
+shard change is needed. No blind rerun of the failed master run is requested.
+
+Validation: all 38 supervisor tests passed normally (0.95s) and with the
+controlled 200-turn scan-result delay (0.52s). The same delay made all three
+original positive waits fail. Ruff 0.4.9 and dependency compatibility passed.
+These are local correctness checks, not estimates of CI performance.

--- a/tests/test_runtime_work_supervisor.py
+++ b/tests/test_runtime_work_supervisor.py
@@ -326,6 +326,7 @@ async def test_hfr_288_expired_backoff_preserves_forward_scan_before_retry() -> 
 async def test_hfr_162_backoff_budget_preserves_exact_partition_deadline() -> None:
     now = 0.0
     release_retry = asyncio.Event()
+    retry_entered = asyncio.Event()
     retry_delays: list[float] = []
     exact_retried = asyncio.Event()
     later_started = asyncio.Event()
@@ -333,6 +334,7 @@ async def test_hfr_162_backoff_budget_preserves_exact_partition_deadline() -> No
 
     async def controlled_retry(delay: float) -> None:
         retry_delays.append(delay)
+        retry_entered.set()
         await release_retry.wait()
 
     class _TwoPartitions(RuntimeWorkHandler):
@@ -367,10 +369,7 @@ async def test_hfr_162_backoff_budget_preserves_exact_partition_deadline() -> No
     supervisor.register(RuntimeWorkLane.REQUESTS, _TwoPartitions())
     await supervisor.activate()
     try:
-        for _ in range(10):
-            await asyncio.sleep(0)
-            if retry_delays:
-                break
+        await asyncio.wait_for(retry_entered.wait(), 1)
         assert retry_delays == [10.0]
         assert attempts == {"exact": 1}
 
@@ -1058,6 +1057,7 @@ async def test_hfr_159_blocked_store_scan_does_not_block_another_lane() -> None:
 async def test_hfr_163_lane_capacity_bounds_distinct_partition_workers() -> None:
     release = asyncio.Event()
     two_started = asyncio.Event()
+    all_completed = asyncio.Event()
     active = 0
     peak = 0
     completed = 0
@@ -1084,6 +1084,8 @@ async def test_hfr_163_lane_capacity_bounds_distinct_partition_workers() -> None
             active -= 1
             done.add(item.partition_key)
             completed += 1
+            if completed == 5:
+                all_completed.set()
 
     supervisor = RuntimeWorkSupervisor(
         reconcile_interval=3600,
@@ -1092,14 +1094,14 @@ async def test_hfr_163_lane_capacity_bounds_distinct_partition_workers() -> None
     )
     supervisor.register(RuntimeWorkLane.RUN_CALLBACKS, _Backlog())
     await supervisor.activate()
-    await asyncio.wait_for(two_started.wait(), 1)
-    assert peak == 2
-    release.set()
-    for _ in range(100):
-        if completed == 5:
-            break
-        await asyncio.sleep(0)
-    await supervisor.stop()
+    try:
+        await asyncio.wait_for(two_started.wait(), 1)
+        assert peak == 2
+        release.set()
+        await asyncio.wait_for(all_completed.wait(), 1)
+    finally:
+        release.set()
+        await supervisor.stop()
     assert completed == 5
     assert peak == 2
 
@@ -1718,6 +1720,7 @@ async def test_hfr_175_global_lease_loss_joins_every_registration(
 ) -> None:
     owns_lease = True
     scanned = threading.Event()
+    stop_started = asyncio.Event()
     processed: list[str] = []
 
     class _LeaseHandler(RuntimeWorkHandler):
@@ -1739,6 +1742,14 @@ async def test_hfr_175_global_lease_loss_joins_every_registration(
     )
     supervisor = RuntimeWorkSupervisor(reconcile_interval=3600)
     supervisor._requires_service_lease = True
+    begin_stop = supervisor._begin_stop
+
+    def observe_stop() -> asyncio.Task[None]:
+        task = begin_stop()
+        stop_started.set()
+        return task
+
+    monkeypatch.setattr(supervisor, "_begin_stop", observe_stop)
     handlers = {
         RuntimeWorkLane.SESSION_DELIVERIES: _LeaseHandler(),
         RuntimeWorkLane.REQUESTS: _LeaseHandler(),
@@ -1746,17 +1757,17 @@ async def test_hfr_175_global_lease_loss_joins_every_registration(
     for lane, handler in handlers.items():
         supervisor.register(lane, handler)
     await supervisor.activate()
-    assert await asyncio.to_thread(scanned.wait, 1)
+    try:
+        assert await asyncio.to_thread(scanned.wait, 1)
 
-    owns_lease = False
-    for handler in handlers.values():
-        handler.ready = True
-    supervisor.notify(*handlers)
-    for _ in range(100):
-        if supervisor._stop_task is not None:
-            break
-        await asyncio.sleep(0)
-    assert supervisor._stop_task is not None
-    await supervisor._stop_task
+        owns_lease = False
+        for handler in handlers.values():
+            handler.ready = True
+        supervisor.notify(*handlers)
+        await asyncio.wait_for(stop_started.wait(), 1)
+        assert supervisor._stop_task is not None
+        await asyncio.wait_for(asyncio.shield(supervisor._stop_task), 1)
+    finally:
+        await supervisor.stop()
     assert supervisor._registrations == {}
     assert processed == []


### PR DESCRIPTION
## Summary

Fix the test synchronization failure found by the post-merge CI verification of
#1882. Master run [33967925507](https://github.com/avibe-bot/avibe/actions/runs/33967925507)
failed only HFR-163 and its fail-closed aggregate: four of five work items had
completed when the test stopped the supervisor after 100 event-loop yields.

The real scanner runs on a thread executor, so a fixed number of event-loop
iterations cannot establish completion. A controlled 200-turn delay after each
real scan result reproduces premature assertions in HFR-163 and the related
HFR-162 backoff-entry and HFR-175 lease-loss waits.

Replace only those three positive waits with bounded, explicit events. Preserve
the original capacity, deadline, completion and shutdown assertions. The stop
observer calls the original stop-creation method, never substitutes shutdown.
Join the real supervisor even on assertion failures. No production changes.

## Scope And Evidence

- Files: tests/test_runtime_work_supervisor.py and docs/plans/ci-test-runtime.md.
- Scenario contracts: HFR-162, HFR-163, HFR-175, with all existing assertions retained.
- All 38 supervisor tests passed normally and with controlled delayed scan completion.
- The same delay fails all three original waits; it does not alter scan results.
- Ruff 0.4.9 and dependency compatibility passed.
- No dependency, timeout, shard selection, workflow or runtime changes.
- Requires #1882, already merged. Base: 1ec7842f113d5e31ba8a9d7db94947ec43f3c8e6.
- CI: require all existing 17 checks, exact-head bot PASS and zero unresolved threads.
- Residual integration: verify post-merge master CI separately before closing CI delivery.

## Known By Design

- The remaining fixed yields observe absence of extra work or same-loop callbacks;
  they are not used to prove completion of an off-loop scan.
- A one-second event timeout matches neighboring test synchronization. There are
  no sleeps added to production, automatic retries, assertion relaxations or skips.
- #1882 PR CI measured 6m24s; the failed master run is not a green timing sample.
- Review inventory starts with zero findings-bearing heads for this follow-up.
  #1882's five reviewed heads all passed with no review threads; its CI failures
  are not review findings. Scope was independently diagnosed before this patch.
