### PR TITLE
perf(deps): inspect dependencies independently on demand

### DIFF
--- a/tests/test_dependency_inspection.py
+++ b/tests/test_dependency_inspection.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import asyncio
+import copy
+import itertools
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+import httpx
+
+from vibe import api
+
+
+GROUPS = (
+    ("askill",),
+    ("avault",),
+    ("show-runtime", "node"),
+    ("model-hub-engine",),
+    ("memory-package", "memory-runtime"),
+    ("tmux",),
+)
+
+
+@pytest.fixture
+def probes(monkeypatch):
+    import core.tmux_runtime as tmux_runtime
+
+    rows = {
+        dep: {
+            "id": dep,
+            "kind": "runtime",
+            "required": True,
+            "installed": False,
+            "status": "error",
+            "version": None,
+            "reason": "inspection_failed",
+            "action_class": "operator_only",
+        }
+        for dep in api.DEPENDENCY_IDS
+    }
+    rows["askill"].update(installed=True, status="unknown")
+    rows["avault"].update(installed=True, status="ready", version="0.1.6")
+    rows["model-hub-engine"].update(
+        installed=True, status="upgrade_required", version="v7.2.95", latest_version="v7.2.149"
+    )
+    rows["show-runtime"].update(installed=None, reason="runtime_install_inspection_failed")
+    rows["node"].update(installed=None)
+    rows["memory-package"].update(reason="memory_package_source_build", readiness="not_ready")
+    rows["memory-runtime"].update(reason="memory_runtime_preparation_import_timeout")
+    rows["tmux"].update(status="missing")
+    calls = []
+
+    def probe(group):
+        def read(**kwargs):
+            calls.append((group, kwargs))
+            result = [copy.deepcopy(rows[dep]) for dep in group]
+            return tuple(result) if len(result) > 1 else result[0]
+
+        return read
+
+    monkeypatch.setattr(api, "askill_update_status", probe(GROUPS[0]))
+    monkeypatch.setattr(api, "avault_status", probe(GROUPS[1]))
+    monkeypatch.setattr(api, "_show_runtime_dependencies_status", probe(GROUPS[2]))
+    monkeypatch.setattr(api, "_model_hub_engine_dependency_status", probe(GROUPS[3]))
+    monkeypatch.setattr(api, "_memory_dependencies_status", probe(GROUPS[4]))
+    monkeypatch.setattr(tmux_runtime, "tmux_status", probe(GROUPS[5]))
+    return calls
+
+
+@pytest.mark.parametrize("selection", itertools.product((False, True), repeat=len(api.DEPENDENCY_IDS)))
+def test_selective_checks_preserve_complete_rows_and_only_probe_their_owners(probes, selection):
+    assert {dep for group in GROUPS for dep in group} == set(api.DEPENDENCY_IDS)
+    requested = [dep for dep, selected in zip(api.DEPENDENCY_IDS, selection) if selected]
+    complete = api.dependencies_status()
+    probes.clear()
+
+    result = api.dependencies_status(dependency_ids=requested)
+
+    assert result == {"ok": True, "deps": [row for row in complete["deps"] if row["id"] in requested]}
+    assert [group for group, _ in probes] == [group for group in GROUPS if set(group).intersection(requested)]
+
+
+def test_coupled_rows_share_one_offline_inspection_and_duplicate_ids_do_not_repeat_it(probes):
+    result = api.dependencies_status(
+        offline=True,
+        dependency_ids=["memory-runtime", "show-runtime", "memory-package", "node", "memory-runtime"],
+    )
+    assert [row["id"] for row in result["deps"]] == ["show-runtime", "memory-package", "memory-runtime", "node"]
+    assert probes == [(GROUPS[2], {"offline": True}), (GROUPS[4], {"offline": True})]
+
+
+def test_invalid_ids_are_rejected_before_any_probe(probes):
+    with pytest.raises(ValueError, match="Unknown dependencies"):
+        api.dependencies_status(dependency_ids=["askill", "not-a-dependency"])
+    assert probes == []
+
+
+def test_slow_check_cannot_hold_an_unrelated_dependency_request(monkeypatch, probes):
+    entered, release = threading.Event(), threading.Event()
+
+    def slow(**_kwargs):
+        entered.set()
+        assert release.wait(5)
+        return {"installed": True, "status": "ready", "version": "0.1.15"}
+
+    monkeypatch.setattr(api, "askill_update_status", slow)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        pending = executor.submit(api.dependencies_status, dependency_ids=["askill"])
+        try:
+            assert entered.wait(2)
+            ready = executor.submit(api.dependencies_status, dependency_ids=["avault"])
+            assert ready.result(timeout=2)["deps"][0]["status"] == "ready"
+            assert not pending.done()
+        finally:
+            release.set()
+        assert pending.result(timeout=2)["deps"][0]["version"] == "0.1.15"
+
+
+@pytest.mark.parametrize("query", ["id=avault", "id=memory-package&id=memory-runtime", ""])
+def test_http_selection_reaches_the_shared_status_owner(monkeypatch, tmp_path, query):
+    from vibe.ui_server import app
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    calls = []
+
+    def inspect(**kwargs):
+        calls.append(kwargs)
+        return {"ok": True, "deps": []}
+
+    monkeypatch.setattr(api, "dependencies_status", inspect)
+    response = app.test_client().get(f"/api/dependencies?{query}")
+    assert response.status_code == 200
+    expected = {"dependency_ids": [part.removeprefix("id=") for part in query.split("&")]} if query else {}
+    assert calls == [expected]
+
+
+def test_http_rejects_invalid_selection_before_inspecting(monkeypatch, tmp_path):
+    from vibe.ui_server import app
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    monkeypatch.setattr(api, "dependencies_status", lambda **_kwargs: pytest.fail("Unexpected probe"))
+    response = app.test_client().get("/api/dependencies?id=avault&id=unknown")
+    assert response.status_code == 400
+    assert response.get_json() == {"ok": False, "error": "unknown_dependency"}
+
+
+@pytest.mark.asyncio
+async def test_http_serves_completed_dependency_while_another_probe_is_blocked(monkeypatch, tmp_path, probes):
+    from vibe.ui_server import app
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    entered, release = threading.Event(), threading.Event()
+
+    def slow(**_kwargs):
+        entered.set()
+        assert release.wait(10)
+        return {"installed": True, "status": "ready", "version": "0.1.15"}
+
+    monkeypatch.setattr(api, "askill_update_status", slow)
+    transport = httpx.ASGITransport(app=app, client=("127.0.0.1", 12345))
+    async with httpx.AsyncClient(transport=transport, base_url="http://localhost") as client:
+        pending = asyncio.create_task(client.get("/api/dependencies?id=askill"))
+        try:
+            assert await asyncio.to_thread(entered.wait, 3)
+            fast = await asyncio.wait_for(client.get("/api/dependencies?id=avault"), timeout=3)
+            assert fast.status_code == 200
+            assert fast.json()["deps"][0]["id"] == "avault"
+            assert not pending.done()
+        finally:
+            release.set()
+            slow_result = await asyncio.wait_for(pending, timeout=3)
+        assert slow_result.status_code == 200

--- a/ui/src/components/settings/SettingsDependenciesPage.test.tsx
+++ b/ui/src/components/settings/SettingsDependenciesPage.test.tsx
@@ -1,11 +1,12 @@
 /* @vitest-environment jsdom */
 
-import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { SettingsDependenciesPage } from './SettingsDependenciesPage';
+import type { DependenciesResult, DependencyReadOptions, MemoryStatusResult } from '@/context/ApiContext';
 
 const api = vi.hoisted(() => ({
   getMemoryStatus: vi.fn(),
@@ -47,6 +48,16 @@ const dependency = (overrides = {}) => ({
   ...overrides,
 });
 
+const stubDependencies = (response: DependenciesResult) => {
+  api.listDependencies.mockImplementation(async ({ ids }: DependencyReadOptions = {}) => ({
+    ...response,
+    deps: (ids ?? response.deps.map((dep) => dep.id)).map((id) => (
+      response.deps.find((dep) => dep.id === id)
+      ?? { id, kind: 'runtime', required: null, installed: null, version: null, status: 'unknown', action_class: 'none' }
+    )),
+  }));
+};
+
 const renderPage = () => render(
   <MemoryRouter>
     <SettingsDependenciesPage />
@@ -54,7 +65,7 @@ const renderPage = () => render(
 );
 
 beforeEach(() => {
-  api.listDependencies.mockResolvedValue({ ok: true, deps: [dependency()] });
+  stubDependencies({ ok: true, deps: [dependency()] });
   api.getMemoryStatus.mockResolvedValue({
     status: 'ok',
     state: 'disabled',
@@ -72,7 +83,7 @@ afterEach(() => {
 
 describe('SettingsDependenciesPage Show Runtime status', () => {
   it('renders inspection failure without authorizing install or repair', async () => {
-    api.listDependencies.mockResolvedValue({
+    stubDependencies({
       ok: true,
       deps: [dependency({
         id: 'show-runtime',
@@ -94,7 +105,7 @@ describe('SettingsDependenciesPage Show Runtime status', () => {
   });
 
   it('keeps a proven absence installable', async () => {
-    api.listDependencies.mockResolvedValue({
+    stubDependencies({
       ok: true,
       deps: [dependency({
         id: 'show-runtime',
@@ -114,7 +125,7 @@ describe('SettingsDependenciesPage Show Runtime status', () => {
 
 describe('SettingsDependenciesPage Model Hub engine', () => {
   it('shows the installed and pinned CPA versions and offers the update action', async () => {
-    api.listDependencies.mockResolvedValue({
+    stubDependencies({
       ok: true,
       deps: [dependency({
         id: 'model-hub-engine',
@@ -137,7 +148,90 @@ describe('SettingsDependenciesPage Model Hub engine', () => {
   });
 });
 
+describe('SettingsDependenciesPage independent checks', () => {
+  it('shows completed checks and permits their actions while another check waits', async () => {
+    stubDependencies({ ok: true, deps: [dependency({ id: 'avault' })] });
+    const read = api.listDependencies.getMockImplementation()!;
+    let finish!: (value: DependenciesResult) => void;
+    const slow = new Promise<DependenciesResult>((resolve) => { finish = resolve; });
+    api.listDependencies.mockImplementation((options: DependencyReadOptions) => (
+      options.ids?.includes('askill') ? slow : read(options)
+    ));
+    renderPage();
+
+    expect(await screen.findByText('settings.dependencies.statusReady · v1.0.0')).toBeTruthy();
+    expect(screen.getByText('settings.dependencies.checking')).toBeTruthy();
+    await userEvent.click(screen.getByRole('button', { name: 'settings.dependencies.reinstall' }));
+    await waitFor(() => expect(api.installDependency).toHaveBeenCalledWith('avault'));
+    expect(api.listDependencies).toHaveBeenLastCalledWith({ ids: ['avault'], signal: expect.any(AbortSignal) });
+    await act(async () => finish({ ok: true, deps: [dependency({ id: 'askill', status: 'unknown' })] }));
+    expect(screen.queryByText('settings.dependencies.checking')).toBeNull();
+  });
+
+  it('shows an unknown CLI version as a warning, never ready', async () => {
+    stubDependencies({ ok: true, deps: [dependency({ id: 'askill', status: 'unknown', version: null })] });
+    renderPage();
+    const badges = await screen.findAllByText('settings.dependencies.statusUnknown');
+    expect(badges.every((badge) => badge.className.includes('text-gold-ink'))).toBe(true);
+    expect(screen.queryByText(/settings.dependencies.statusReady/)).toBeNull();
+  });
+
+  it('keeps stored failure evidence, blocks actions and retries only the failed check', async () => {
+    const dep = dependency({ id: 'model-hub-engine', status: 'error', reason: 'engine_install_failed' });
+    stubDependencies({ ok: true, deps: [dep] });
+    const read = api.listDependencies.getMockImplementation()!;
+    renderPage();
+    expect(await screen.findByText('errors.engine_install_failed')).toBeTruthy();
+    api.listDependencies.mockImplementation((options: DependencyReadOptions) => (
+      options.ids?.includes(dep.id) ? Promise.reject(new Error('offline')) : read(options)
+    ));
+    await userEvent.click(screen.getByRole('button', { name: 'settings.dependencies.recheckAll' }));
+    const retry = await screen.findByRole('button', { name: 'settings.dependencies.recheck' });
+    expect(screen.getByText('errors.engine_install_failed')).toBeTruthy();
+    expect((screen.getByRole('button', { name: 'settings.dependencies.repair' }) as HTMLButtonElement).disabled).toBe(true);
+    expect(api.installDependency).not.toHaveBeenCalled();
+    api.listDependencies.mockImplementation(read);
+    api.listDependencies.mockClear();
+    await userEvent.click(retry);
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'settings.dependencies.recheck' })).toBeNull());
+    expect(api.listDependencies).toHaveBeenCalledTimes(1);
+    expect(api.listDependencies).toHaveBeenCalledWith({ ids: [dep.id], signal: expect.any(AbortSignal) });
+  });
+
+  it('does not present an old healthy inspection as current after a failed refresh', async () => {
+    stubDependencies({ ok: true, deps: [dependency({ id: 'avault' })] });
+    const read = api.listDependencies.getMockImplementation()!;
+    renderPage();
+    expect(await screen.findByText('settings.dependencies.statusReady · v1.0.0')).toBeTruthy();
+    api.listDependencies.mockImplementation((options: DependencyReadOptions) => (
+      options.ids?.includes('avault') ? Promise.reject(new Error('offline')) : read(options)
+    ));
+    await userEvent.click(screen.getByRole('button', { name: 'settings.dependencies.recheckAll' }));
+    await screen.findByRole('button', { name: 'settings.dependencies.recheck' });
+    expect(screen.queryByText(/settings.dependencies.statusReady/)).toBeNull();
+    expect((screen.getByRole('button', { name: 'settings.dependencies.reinstall' }) as HTMLButtonElement).disabled).toBe(true);
+  });
+});
+
 describe('SettingsDependenciesPage Memory runtime', () => {
+  it('does not let an older sidecar read override the current repair guard', async () => {
+    let finish!: (value: MemoryStatusResult) => void;
+    api.getMemoryStatus.mockImplementationOnce(() => new Promise((resolve) => { finish = resolve; }));
+    renderPage();
+    const repair = await screen.findByRole('button', { name: 'settings.dependencies.repair' });
+    expect((repair as HTMLButtonElement).disabled).toBe(true);
+    const running = {
+      status: 'ok', state: 'running', reason: null,
+      source: { status: 'unavailable', observed_at: null, reason: null }, health: null,
+    } as MemoryStatusResult;
+    api.getMemoryStatus.mockResolvedValue(running);
+    await userEvent.click(screen.getByRole('button', { name: 'settings.dependencies.recheckAll' }));
+    await screen.findByText('settings.dependencies.memoryRuntimeDisableBeforeRepair');
+    await act(async () => finish({ ...running, state: 'disabled' }));
+    expect((repair as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.getByText('settings.dependencies.memoryRuntimeDisableBeforeRepair')).toBeTruthy();
+  });
+
   it.each([false, null, true])(
     'presents source management neutrally without claiming installation or readiness (%s)',
     async (installed) => {
@@ -151,7 +245,7 @@ describe('SettingsDependenciesPage Memory runtime', () => {
         version: null,
         reason: 'memory_package_source_build',
       }));
-      api.listDependencies.mockResolvedValue({ ok: true, deps: [row] });
+      stubDependencies({ ok: true, deps: [row] });
       api.getMemoryStatus.mockRejectedValue(new Error('Status is unavailable'));
       renderPage();
 
@@ -176,7 +270,7 @@ describe('SettingsDependenciesPage Memory runtime', () => {
     'memory_package_artifact_unavailable',
     'memory_runtime_install_failed',
   ])('keeps the actual runtime failure visible next to a source-managed package: %s', async (reason) => {
-    api.listDependencies.mockResolvedValue({
+    stubDependencies({
       ok: true,
       deps: [
         dependency({
@@ -203,7 +297,7 @@ describe('SettingsDependenciesPage Memory runtime', () => {
     'memory_package_metadata_ambiguous',
     'memory_package_install_failed',
   ])('does not reclassify a different package failure: %s', async (reason) => {
-    api.listDependencies.mockResolvedValue({
+    stubDependencies({
       ok: true,
       deps: [dependency({
         id: 'memory-package',
@@ -222,7 +316,7 @@ describe('SettingsDependenciesPage Memory runtime', () => {
   });
 
   it('routes repairable Python package bootstrap through its own dependency action', async () => {
-    api.listDependencies.mockResolvedValue({
+    stubDependencies({
       ok: true,
       deps: [dependency({
         id: 'memory-package',
@@ -241,7 +335,7 @@ describe('SettingsDependenciesPage Memory runtime', () => {
   });
 
   it('hides package bootstrap while Memory is not required', async () => {
-    api.listDependencies.mockResolvedValue({
+    stubDependencies({
       ok: true,
       deps: [dependency({
         id: 'memory-package',
@@ -259,7 +353,7 @@ describe('SettingsDependenciesPage Memory runtime', () => {
   });
 
   it('keeps explicit package repair available while disabled', async () => {
-    api.listDependencies.mockResolvedValue({
+    stubDependencies({
       ok: true,
       deps: [dependency({
         id: 'memory-package',
@@ -312,7 +406,7 @@ describe('SettingsDependenciesPage Memory runtime', () => {
   });
 
   it('renders a persisted preparation reason on initial page load', async () => {
-    api.listDependencies.mockResolvedValue({
+    stubDependencies({
       ok: true,
       deps: [dependency({
         installed: false,

--- a/ui/src/components/settings/SettingsDependenciesPage.tsx
+++ b/ui/src/components/settings/SettingsDependenciesPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
@@ -31,6 +31,7 @@ import {
   memoryRuntimeSidecarRunning,
 } from './SettingsDependenciesPage.logic';
 import { errorMessage } from '@/lib/errorMessage';
+import { useDependencyChecks } from './useDependencyChecks';
 
 // Mirrors design.pen "vibe-remote — Settings · Dependencies": one card per
 // required local runtime (icon tile + name/REQUIRED + detail + status pill +
@@ -44,8 +45,8 @@ type DepMeta = { icon: LucideIcon; tileCls: string; iconCls: string };
 const DEP_META: Record<string, DepMeta> = {
   askill: { icon: WandSparkles, tileCls: 'bg-mint-soft', iconCls: 'text-mint-ink' },
   avault: { icon: KeyRound, tileCls: 'bg-gold-soft', iconCls: 'text-gold-ink' },
-  'model-hub-engine': { icon: Network, tileCls: 'bg-mint-soft', iconCls: 'text-mint-ink' },
   'show-runtime': { icon: LayoutDashboard, tileCls: 'bg-cyan-soft', iconCls: 'text-cyan-ink' },
+  'model-hub-engine': { icon: Network, tileCls: 'bg-mint-soft', iconCls: 'text-mint-ink' },
   'memory-package': { icon: Brain, tileCls: 'bg-gold-soft', iconCls: 'text-gold-ink' },
   'memory-runtime': { icon: Brain, tileCls: 'bg-violet-soft', iconCls: 'text-violet-ink' },
   tmux: { icon: SquareTerminal, tileCls: 'bg-surface-3', iconCls: 'text-foreground' },
@@ -57,27 +58,22 @@ export const SettingsDependenciesPage: React.FC = () => {
   const api = useApi();
   const { showToast } = useToast();
 
-  const [deps, setDeps] = useState<DependencyItem[] | null>(null);
+  const { checks, refresh: refreshDependencies, checking } = useDependencyChecks(api.listDependencies);
   const [busy, setBusy] = useState<string | null>(null);
   const [memoryStatus, setMemoryStatus] = useState<MemoryStatusResult | null>(null);
   const [memoryStatusLoaded, setMemoryStatusLoaded] = useState(false);
-
-  const refreshDependencies = useCallback(async () => {
-    try {
-      const res = await api.listDependencies();
-      setDeps(res.deps ?? []);
-    } catch {
-      setDeps([]);
-    }
-  }, [api]);
+  const memoryRequest = useRef(0);
 
   const refreshMemoryStatus = useCallback(async () => {
+    const request = ++memoryRequest.current;
+    setMemoryStatusLoaded(false);
     try {
-      setMemoryStatus(await api.getMemoryStatus());
+      const status = await api.getMemoryStatus();
+      if (request === memoryRequest.current) setMemoryStatus(status);
     } catch {
-      setMemoryStatus(null);
+      if (request === memoryRequest.current) setMemoryStatus(null);
     } finally {
-      setMemoryStatusLoaded(true);
+      if (request === memoryRequest.current) setMemoryStatusLoaded(true);
     }
   }, [api]);
 
@@ -87,6 +83,7 @@ export const SettingsDependenciesPage: React.FC = () => {
 
   useEffect(() => {
     void refreshAll();
+    return () => { memoryRequest.current += 1; };
   }, [refreshAll]);
 
   // A closed backend reason/message is often a snake_case token (e.g.
@@ -118,10 +115,11 @@ export const SettingsDependenciesPage: React.FC = () => {
           : localizedFailure(res),
         res.ok ? 'success' : 'error'
       );
-      await refreshAll();
     } catch (e) {
       showToast(errorMessage(e) || t('settings.dependencies.installFailed'), 'error');
     } finally {
+      if (dep.id.startsWith('memory-')) void refreshMemoryStatus();
+      await refreshDependencies(dep.id);
       setBusy(null);
     }
   };
@@ -132,6 +130,7 @@ export const SettingsDependenciesPage: React.FC = () => {
     // of the generic "not installed" fallback.
     if (d.status === 'unsupported') return t('settings.dependencies.statusUnsupported');
     if (d.status === 'error') return t('settings.dependencies.statusError');
+    if (d.status === 'unknown') return t('settings.dependencies.statusUnknown');
     if (d.status === 'not_required') return t('settings.dependencies.statusNotRequired');
     if (!d.installed) return t('settings.dependencies.statusMissing');
     if (d.status === 'upgrade_required') {
@@ -146,6 +145,7 @@ export const SettingsDependenciesPage: React.FC = () => {
     if (memoryPackageIsSourceManaged(d)) return 'secondary';
     if (d.status === 'not_required') return 'secondary';
     if (d.status === 'error') return 'destructive';
+    if (d.status === 'unknown') return 'warning';
     if (d.status === 'unsupported' || d.status === 'upgrade_required') return 'warning';
     return d.installed ? 'success' : 'destructive';
   };
@@ -169,29 +169,70 @@ export const SettingsDependenciesPage: React.FC = () => {
       title={t('settings.dependenciesTitle')}
       subtitle={t('settings.dependenciesSubtitle')}
       actions={
-        <Button variant="secondary" size="sm" onClick={() => void refreshAll()}>
+        <Button variant="secondary" size="sm" disabled={checking || busy !== null} onClick={() => void refreshAll()}>
           <RefreshCw className="size-3.5" />
           {t('settings.dependencies.recheckAll')}
         </Button>
       }
     >
-      {deps === null ? (
-        <div className="text-sm text-muted">{t('common.loading')}</div>
-      ) : (
         <div className="flex flex-col gap-3.5">
           <div className="flex items-center gap-3 rounded-xl border border-mint/30 bg-mint/[0.08] px-5 py-3.5">
             <ShieldCheck className="size-4 shrink-0 text-mint-ink" />
             <span className="text-[13px] leading-snug text-foreground">{t('settings.dependencies.autoBanner')}</span>
           </div>
 
-          {deps.map((d) => {
-            const meta = DEP_META[d.id] ?? DEP_META.node;
+          {Object.entries(DEP_META).map(([id, meta]) => {
+            const check = checks[id];
+            const d = check.data;
+            const checkFailure = check.error
+              ? t(`settings.dependencies.${check.error === 'timeout' ? 'checkTimeout' : 'checkFailed'}`)
+              : null;
+            const retryCheck = check.error && !check.checking ? (
+              <Button
+                variant="secondary"
+                size="icon"
+                className="size-8"
+                title={t('settings.dependencies.recheck')}
+                aria-label={t('settings.dependencies.recheck')}
+                disabled={busy !== null}
+                onClick={() => void refreshDependencies(id)}
+              >
+                <RefreshCw className="size-3.5" />
+              </Button>
+            ) : null;
+            const checkProgress = check.checking ? (
+              <Loader2
+                className="size-3.5 shrink-0 animate-spin text-muted"
+                aria-label={t('settings.dependencies.checking')}
+              />
+            ) : null;
+            if (!d) {
+              return (
+                <SettingsResourceRow
+                  key={id}
+                  icon={meta.icon}
+                  tileClassName={meta.tileCls}
+                  iconClassName={meta.iconCls}
+                  title={t(`settings.dependencies.items.${id}.label`)}
+                  detail={t(`settings.dependencies.items.${id}.detail`)}
+                  actions={
+                    <>
+                      {checkProgress}
+                      <Badge variant={check.error ? 'destructive' : 'secondary'} className="font-mono">
+                        {checkFailure || t('settings.dependencies.checking')}
+                      </Badge>
+                      {retryCheck}
+                    </>
+                  }
+                />
+              );
+            }
             const installing = busy === d.id;
             const showAction = dependencyHasInstallAction(d);
             const isMemoryRuntime = d.id === 'memory-runtime';
             const sidecarRunning = isMemoryRuntime && memoryRuntimeSidecarRunning(memoryStatus);
             const repairBlockedBySidecar = isMemoryRuntime && (!memoryStatusLoaded || sidecarRunning);
-            const dependencyOperationBusy = busy !== null;
+            const dependencyOperationBusy = busy !== null || check.checking || check.error !== null;
             const sourceManaged = memoryPackageIsSourceManaged(d);
             const notice = sourceManaged
               ? t('settings.dependencies.memoryPackageSourceManaged')
@@ -229,9 +270,11 @@ export const SettingsDependenciesPage: React.FC = () => {
                 }
                 actions={
                   <>
-                    <Badge variant={statusVariant(d)} className="font-mono">
-                      {statusText(d)}
+                    {checkProgress}
+                    <Badge variant={check.error ? 'destructive' : statusVariant(d)} className="font-mono">
+                      {checkFailure || statusText(d)}
                     </Badge>
+                    {retryCheck}
                     {isMemoryRuntime && d.installed && (
                       <Button asChild variant="secondary" size="xs">
                         <Link to="/settings/memory">
@@ -259,7 +302,13 @@ export const SettingsDependenciesPage: React.FC = () => {
                     )}
                   </>
                 }
-                footer={notice ? (
+                footer={checkFailure ? (
+                  <div role="alert" className="border-t border-destructive/30 pt-3 text-[11px] leading-snug text-destructive-ink">
+                    {checkFailure}
+                    {persistedFailure && <div className="mt-1">{persistedFailure}</div>}
+                    {notice && <div className="mt-1 text-muted">{notice}</div>}
+                  </div>
+                ) : notice ? (
                   <div className="border-t border-border pt-3 text-[11px] leading-snug text-muted">
                     {notice}
                   </div>
@@ -292,7 +341,6 @@ export const SettingsDependenciesPage: React.FC = () => {
             }
           />
         </div>
-      )}
     </SettingsPageShell>
   );
 };

--- a/ui/src/components/settings/SettingsMemoryPage.test.tsx
+++ b/ui/src/components/settings/SettingsMemoryPage.test.tsx
@@ -159,6 +159,13 @@ afterEach(() => {
 });
 
 describe('SettingsMemoryPage', () => {
+  it('inspects only the Memory dependency owner', async () => {
+    renderPage();
+    await waitFor(() => expect(api.listDependencies).toHaveBeenCalledWith({
+      ids: ['memory-package', 'memory-runtime'],
+    }));
+  });
+
   it('directs disabled Memory to the explicit package bootstrap when missing', async () => {
     api.getMemorySettings.mockResolvedValue({ ...settings, enabled: false });
     api.listDependencies.mockResolvedValue({

--- a/ui/src/components/settings/SettingsMemoryPage.tsx
+++ b/ui/src/components/settings/SettingsMemoryPage.tsx
@@ -91,7 +91,7 @@ export const SettingsMemoryPage: React.FC = () => {
 
   const loadDependency = useCallback(async () => {
     try {
-      const res = await api.listDependencies();
+      const res = await api.listDependencies({ ids: ['memory-package', 'memory-runtime'] });
       const memoryPackage = res.deps?.find((item) => item.id === 'memory-package');
       const memoryRuntime = res.deps?.find((item) => item.id === 'memory-runtime');
       if (memoryPackage?.action_class === 'repairable' && memoryPackage.installed !== true) {

--- a/ui/src/components/settings/useDependencyChecks.test.tsx
+++ b/ui/src/components/settings/useDependencyChecks.test.tsx
@@ -1,0 +1,101 @@
+/* @vitest-environment jsdom */
+
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { DependenciesResult, DependencyItem, DependencyReadOptions } from '@/context/ApiContext';
+import { DEPENDENCY_CHECK_GROUPS, useDependencyChecks } from './useDependencyChecks';
+
+const row = (id: string, overrides: Partial<DependencyItem> = {}): DependencyItem => ({
+  id, kind: 'runtime', required: true, installed: true, status: 'ready', version: '1.2.3', ...overrides,
+});
+const ready = ({ ids = [] }: DependencyReadOptions = {}): DependenciesResult => ({
+  ok: true, deps: ids.map((id) => row(id)),
+});
+const deferred = () => {
+  let resolve!: (value: DependenciesResult) => void;
+  const promise = new Promise<DependenciesResult>((done) => { resolve = done; });
+  return { promise, resolve };
+};
+
+afterEach(cleanup);
+
+describe('independent dependency checks', () => {
+  it('publishes completed groups while another group is still waiting', async () => {
+    const slow = deferred();
+    const read = vi.fn(async (options: DependencyReadOptions = {}) => (
+      options.ids?.includes('askill') ? slow.promise : ready(options)
+    ));
+    const { result } = renderHook(() => useDependencyChecks(read));
+
+    act(() => { void result.current.refresh(); });
+    await waitFor(() => expect(result.current.checks.avault.data?.status).toBe('ready'));
+    expect(result.current.checks.askill).toEqual({ data: null, checking: true, error: null });
+    for (const ids of DEPENDENCY_CHECK_GROUPS) {
+      expect(read).toHaveBeenCalledWith({ ids, signal: expect.any(AbortSignal) });
+    }
+    expect(read).toHaveBeenCalledTimes(DEPENDENCY_CHECK_GROUPS.length);
+
+    await act(async () => slow.resolve(ready({ ids: ['askill'] })));
+    expect(result.current.checking).toBe(false);
+  });
+
+  it('rechecks only the owner of a repaired dependency and rejects an older result', async () => {
+    const old = deferred();
+    const read = vi.fn(async (options: DependencyReadOptions = {}) => ready(options));
+    const { result } = renderHook(() => useDependencyChecks(read));
+    read.mockImplementationOnce(() => old.promise);
+    act(() => { void result.current.refresh('memory-runtime'); });
+    const oldSignal = read.mock.calls[0][0]?.signal;
+
+    await act(async () => result.current.refresh('memory-runtime'));
+    expect(oldSignal?.aborted).toBe(true);
+    const current = result.current.checks['memory-runtime'];
+    expect(read.mock.calls.map(([options]) => options?.ids)).toEqual([
+      ['memory-package', 'memory-runtime'], ['memory-package', 'memory-runtime'],
+    ]);
+
+    await act(async () => old.resolve({
+      ok: true,
+      deps: ['memory-package', 'memory-runtime'].map((id) => row(id, { installed: false, status: 'error' })),
+    }));
+    expect(result.current.checks['memory-runtime']).toEqual(current);
+  });
+
+  it('keeps prior raw failure evidence when the latest inspection fails', async () => {
+    const source = Object.freeze(row('memory-package', {
+      installed: false, status: 'error', readiness: 'not_ready', action_class: 'operator_only',
+      reason: 'memory_package_source_build',
+    }));
+    const failure = Object.freeze(row('memory-runtime', {
+      installed: false, status: 'error', reason: 'memory_runtime_preparation_import_timeout',
+    }));
+    const read = vi.fn().mockResolvedValue({ ok: true, deps: [source, failure] });
+    const { result } = renderHook(() => useDependencyChecks(read));
+    await act(async () => result.current.refresh('memory-runtime'));
+    read.mockRejectedValue(new Error('unavailable'));
+    await act(async () => result.current.refresh('memory-runtime'));
+    expect(result.current.checks['memory-package']).toEqual({ data: source, checking: false, error: 'failed' });
+    expect(result.current.checks['memory-runtime']).toEqual({ data: failure, checking: false, error: 'failed' });
+  });
+
+  it.each([{ ok: false, deps: [] }, { ok: true, deps: [] }, { ok: true, deps: [row('memory-package')] }])(
+    'never treats an incomplete group response as checked: %j', async (response) => {
+      const { result } = renderHook(() => useDependencyChecks(vi.fn().mockResolvedValue(response)));
+      await act(async () => result.current.refresh('memory-runtime'));
+      for (const id of ['memory-package', 'memory-runtime']) {
+        expect(result.current.checks[id]).toEqual({ data: null, checking: false, error: 'failed' });
+      }
+    },
+  );
+
+  it('cancels every owned request on unmount', async () => {
+    const slow = deferred();
+    const read = vi.fn((_options?: DependencyReadOptions) => slow.promise);
+    const { result, unmount } = renderHook(() => useDependencyChecks(read));
+    act(() => { void result.current.refresh(); });
+    unmount();
+    for (const [options] of read.mock.calls) expect(options?.signal?.aborted).toBe(true);
+    await act(async () => slow.resolve({ ok: true, deps: [] }));
+  });
+});

--- a/ui/src/components/settings/useDependencyChecks.ts
+++ b/ui/src/components/settings/useDependencyChecks.ts
@@ -1,0 +1,74 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import type { DependenciesResult, DependencyItem, DependencyReadOptions } from '@/context/ApiContext';
+import { isApiFetchDeadlineAbort } from '@/lib/apiFetch';
+
+// Coupled rows use one inspection, including its failure evidence.
+export const DEPENDENCY_CHECK_GROUPS = [
+  ['askill'],
+  ['avault'],
+  ['show-runtime', 'node'],
+  ['model-hub-engine'],
+  ['memory-package', 'memory-runtime'],
+  ['tmux'],
+] as const;
+
+export type DependencyCheck = {
+  data: DependencyItem | null;
+  checking: boolean;
+  error: 'failed' | 'timeout' | null;
+};
+
+type ReadDependencies = (options?: DependencyReadOptions) => Promise<DependenciesResult>;
+
+export function useDependencyChecks(read: ReadDependencies) {
+  const [checks, setChecks] = useState<Record<string, DependencyCheck>>(() => Object.fromEntries(
+    DEPENDENCY_CHECK_GROUPS.flatMap((ids) => ids.map((id) => [
+      id, { data: null, checking: true, error: null },
+    ])),
+  ));
+  const requests = useRef(new Map<string, AbortController>());
+
+  useEffect(() => {
+    const active = requests.current;
+    return () => {
+      for (const request of active.values()) request.abort();
+      active.clear();
+    };
+  }, []);
+
+  const refresh = useCallback(async (dependencyId?: string) => {
+    const groups = DEPENDENCY_CHECK_GROUPS.filter((ids) => (
+      dependencyId === undefined || ids.some((id) => id === dependencyId)
+    ));
+    await Promise.all(groups.map(async (ids) => {
+      const key = ids[0];
+      requests.current.get(key)?.abort();
+      const controller = new AbortController();
+      requests.current.set(key, controller);
+      const update = (change: (previous: DependencyCheck, id: string) => DependencyCheck) => {
+        setChecks((previous) => {
+          if (requests.current.get(key) !== controller || controller.signal.aborted) return previous;
+          return { ...previous, ...Object.fromEntries(ids.map((id) => [id, change(previous[id], id)])) };
+        });
+      };
+      update((previous) => ({ ...previous, checking: true }));
+      try {
+        const result = await read({ ids, signal: controller.signal });
+        if (!result.ok || !Array.isArray(result.deps) || ids.some((id) => !result.deps.some((dep) => dep.id === id))) {
+          throw new Error('Incomplete dependency inspection');
+        }
+        const byId = new Map(result.deps.map((dep) => [dep.id, dep]));
+        update((_previous, id) => ({ data: byId.get(id)!, checking: false, error: null }));
+      } catch (error) {
+        update((previous) => ({
+          ...previous,
+          checking: false,
+          error: isApiFetchDeadlineAbort(error) ? 'timeout' : 'failed',
+        }));
+      }
+    }));
+  }, [read]);
+
+  return { checks, refresh, checking: Object.values(checks).some((check) => check.checking) };
+}

--- a/ui/src/components/ui/vault-secret-form.test.tsx
+++ b/ui/src/components/ui/vault-secret-form.test.tsx
@@ -1,0 +1,22 @@
+/* @vitest-environment jsdom */
+
+import { cleanup, render, waitFor } from '@testing-library/react';
+import { afterEach, expect, it, vi } from 'vitest';
+import { VaultSecretForm } from './vault-secret-form';
+
+const api = vi.hoisted(() => ({
+  listDependencies: vi.fn(async () => ({ ok: true, deps: [] })),
+  listVaultSecrets: vi.fn(async () => ({ secrets: [] })),
+  listSkills: vi.fn(async () => ({ skills: [] })),
+  createVaultSecret: vi.fn(),
+}));
+vi.mock('@/context/ApiContext', () => ({ useApi: () => api }));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+afterEach(cleanup);
+
+it('checks only avault when the secret form opens, without creating a secret', async () => {
+  render(<VaultSecretForm onCancel={vi.fn()} onCreated={vi.fn()} />);
+  await waitFor(() => expect(api.listDependencies).toHaveBeenCalledWith({ ids: ['avault'] }));
+  expect(api.listDependencies).toHaveBeenCalledTimes(1);
+  expect(api.createVaultSecret).not.toHaveBeenCalled();
+});

--- a/ui/src/components/ui/vault-secret-form.tsx
+++ b/ui/src/components/ui/vault-secret-form.tsx
@@ -209,7 +209,7 @@ export const VaultSecretForm: React.FC<{
     let alive = true;
     setCheckingAvault(true);
     api
-      .listDependencies()
+      .listDependencies({ ids: ['avault'] })
       .then((res) => {
         if (!alive) return;
         setAvaultDep(res.deps.find((dep) => dep.id === 'avault') ?? null);

--- a/ui/src/context/ApiContext.dependencies.test.tsx
+++ b/ui/src/context/ApiContext.dependencies.test.tsx
@@ -12,20 +12,34 @@ vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => k
 
 import { ApiProvider, useApi } from './ApiContext';
 import { isApiFetchDeadlineAbort } from '../lib/apiFetch';
+import { DEPENDENCY_CHECK_GROUPS } from '../components/settings/useDependencyChecks';
 
 beforeEach(() => { apiFetch.mockReset(); });
 afterEach(() => { cleanup(); vi.useRealTimers(); });
 
 describe('dependency inspection transport', () => {
-  it('encodes selected IDs and preserves full inspection for callers without options', async () => {
-    apiFetch.mockImplementation(async () => new Response(JSON.stringify({ ok: true, deps: [] })));
-    const { result } = renderHook(useApi, { wrapper: ApiProvider });
-    await result.current.listDependencies({ ids: ['memory-package', 'memory-runtime'] });
-    await result.current.listDependencies();
-    expect(apiFetch.mock.calls.map(([path]) => path)).toEqual([
-      '/api/dependencies?id=memory-package&id=memory-runtime', '/api/dependencies',
-    ]);
-  });
+  it.each([true, false])(
+    'preserves each requested group and the default full check (URLSearchParams.size available: %s)',
+    async (sizeAvailable) => {
+      const prototype = URLSearchParams.prototype;
+      const size = Object.getOwnPropertyDescriptor(prototype, 'size');
+      try {
+        if (!sizeAvailable) {
+          Reflect.deleteProperty(prototype, 'size');
+          expect('size' in new URLSearchParams()).toBe(false);
+        }
+        apiFetch.mockImplementation(async () => new Response(JSON.stringify({ ok: true, deps: [] })));
+        const { result } = renderHook(useApi, { wrapper: ApiProvider });
+        for (const ids of DEPENDENCY_CHECK_GROUPS) await result.current.listDependencies({ ids });
+        await result.current.listDependencies();
+        expect(apiFetch.mock.calls.map(([path]) => new URL(path, 'http://localhost').searchParams.getAll('id')))
+          .toEqual([...DEPENDENCY_CHECK_GROUPS, []]);
+        expect(apiFetch).toHaveBeenLastCalledWith('/api/dependencies', { signal: expect.any(AbortSignal) });
+      } finally {
+        if (size) Object.defineProperty(prototype, 'size', size);
+      }
+    },
+  );
 
   it.each(['fetch', 'body'] as const)('bounds the complete %s phase with one deadline', async (phase) => {
     const { result } = renderHook(useApi, { wrapper: ApiProvider });

--- a/ui/src/context/ApiContext.dependencies.test.tsx
+++ b/ui/src/context/ApiContext.dependencies.test.tsx
@@ -1,0 +1,59 @@
+/* @vitest-environment jsdom */
+
+import { cleanup, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const apiFetch = vi.hoisted(() => vi.fn());
+vi.mock('../lib/apiFetch', async (loadOriginal) => ({
+  ...await loadOriginal<typeof import('../lib/apiFetch')>(), apiFetch,
+}));
+vi.mock('./ToastContext', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+
+import { ApiProvider, useApi } from './ApiContext';
+import { isApiFetchDeadlineAbort } from '../lib/apiFetch';
+
+beforeEach(() => { apiFetch.mockReset(); });
+afterEach(() => { cleanup(); vi.useRealTimers(); });
+
+describe('dependency inspection transport', () => {
+  it('encodes selected IDs and preserves full inspection for callers without options', async () => {
+    apiFetch.mockImplementation(async () => new Response(JSON.stringify({ ok: true, deps: [] })));
+    const { result } = renderHook(useApi, { wrapper: ApiProvider });
+    await result.current.listDependencies({ ids: ['memory-package', 'memory-runtime'] });
+    await result.current.listDependencies();
+    expect(apiFetch.mock.calls.map(([path]) => path)).toEqual([
+      '/api/dependencies?id=memory-package&id=memory-runtime', '/api/dependencies',
+    ]);
+  });
+
+  it.each(['fetch', 'body'] as const)('bounds the complete %s phase with one deadline', async (phase) => {
+    const { result } = renderHook(useApi, { wrapper: ApiProvider });
+    vi.useFakeTimers();
+    apiFetch.mockImplementation((_path: string, { signal }: RequestInit) => {
+      const waiting = () => new Promise((_resolve, reject) => {
+        signal!.addEventListener('abort', () => reject(signal!.reason), { once: true });
+      });
+      return phase === 'fetch' ? waiting() : Promise.resolve({ ok: true, json: waiting });
+    });
+    const outcome = result.current.listDependencies().catch((error: unknown) => error);
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(isApiFetchDeadlineAbort(await outcome)).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('honors caller cancellation without labeling it a timeout', async () => {
+    const { result } = renderHook(useApi, { wrapper: ApiProvider });
+    vi.useFakeTimers();
+    apiFetch.mockImplementation((_path: string, { signal }: RequestInit) => new Promise((_resolve, reject) => {
+      signal!.addEventListener('abort', () => reject(signal!.reason), { once: true });
+    }));
+    const caller = new AbortController();
+    const outcome = result.current.listDependencies({ ids: ['askill'], signal: caller.signal })
+      .catch((error: unknown) => error);
+    caller.abort();
+    expect(await outcome).toBe(caller.signal.reason);
+    expect(isApiFetchDeadlineAbort(await outcome)).toBe(false);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useContext, useEffect, useMemo, useRef } from 're
 import { useTranslation } from 'react-i18next';
 import { useToast } from './ToastContext';
 import type { AgentSupply } from '../components/settings/models/types';
-import { apiFetch, recoverRemoteAuthFromSessionProbe } from '../lib/apiFetch';
+import { apiFetch, recoverRemoteAuthFromSessionProbe, withApiDeadline } from '../lib/apiFetch';
 import { isAuthorizationSensitiveReadPath } from '../lib/authorizationCache';
 import type { TurnActivityGroupWire } from '../lib/agentActivity';
 import type { AgentGraphParams, AgentGraphResult, AgentGraphVisibility } from '../lib/agentGraph';
@@ -574,7 +574,7 @@ export type ApiContextType = {
   getFirstBindCode: () => Promise<any>;
   detectCli: (binary: string) => Promise<any>;
   installAgent: (name: string) => Promise<InstallResult>;
-  listDependencies: () => Promise<DependenciesResult>;
+  listDependencies: (options?: DependencyReadOptions) => Promise<DependenciesResult>;
   installDependency: (dep: string) => Promise<InstallResult>;
   getMemorySettings: () => Promise<MemorySettingsResult>;
   saveMemorySettings: (patch: MemorySettingsPatch) => Promise<MemorySettingsResult>;
@@ -1889,7 +1889,7 @@ export type DependencyItem = {
   version: string | null;
   latest_version?: string | null;
   has_update?: boolean;
-  status: 'ready' | 'not_required' | 'missing' | 'upgrade_required' | 'unsupported' | 'error';
+  status: 'ready' | 'not_required' | 'missing' | 'upgrade_required' | 'unsupported' | 'error' | 'unknown';
   readiness?: 'ready' | 'not_required' | 'not_ready' | 'memory_requirement_unreadable';
   action_class?: 'none' | 'repairable' | 'operator_only';
   reason?: string | null;
@@ -1899,6 +1899,7 @@ export type DependencyItem = {
 };
 
 export type DependenciesResult = { ok: boolean; deps: DependencyItem[] };
+export type DependencyReadOptions = { ids?: readonly string[]; signal?: AbortSignal };
 
 // Current Memory contract: docs/MEMORY.md.
 // Keys are write-only: GET never returns a usable `api_key`, only `has_api_key`.
@@ -2739,9 +2740,13 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
 
   const getJson = async (
     path: string,
-    { handleError = true, expectedCodes }: { handleError?: boolean; expectedCodes?: readonly string[] } = {},
+    { handleError = true, expectedCodes, signal }: {
+      handleError?: boolean;
+      expectedCodes?: readonly string[];
+      signal?: AbortSignal;
+    } = {},
   ) => {
-    const res = await apiFetch(path);
+    const res = await (signal ? apiFetch(path, { signal }) : apiFetch(path));
     if (!res.ok && handleError) {
       await handleApiError(res, path, { expectedCodes });
     }
@@ -3729,7 +3734,12 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     getFirstBindCode: () => getJson('/api/setup/first-bind-code'),
     detectCli: (binary) => getJson(`/api/cli/detect?binary=${encodeURIComponent(binary)}`),
     installAgent: (name) => startAndPollAgentInstall(name),
-    listDependencies: () => getJson('/api/dependencies'),
+    listDependencies: ({ ids, signal } = {}) => {
+      const params = new URLSearchParams();
+      for (const id of ids ?? []) params.append('id', id);
+      const path = `/api/dependencies${params.size ? `?${params}` : ''}`;
+      return withApiDeadline(15_000, signal, (requestSignal) => getJson(path, { signal: requestSignal }));
+    },
     installDependency: (dep) => startAndPollDependencyInstall(dep),
     // handleError: false — every route returns closed `{status:'failed',error}` bodies (never a
     // thrown ApiError/toast) so the Memory page can render its own inline state per code.

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -3737,7 +3737,8 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     listDependencies: ({ ids, signal } = {}) => {
       const params = new URLSearchParams();
       for (const id of ids ?? []) params.append('id', id);
-      const path = `/api/dependencies${params.size ? `?${params}` : ''}`;
+      const query = params.toString();
+      const path = `/api/dependencies${query ? `?${query}` : ''}`;
       return withApiDeadline(15_000, signal, (requestSignal) => getJson(path, { signal: requestSignal }));
     },
     installDependency: (dep) => startAndPollDependencyInstall(dep),

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -382,6 +382,11 @@
     "dependencies": {
       "autoBanner": "Avibe installs and updates these for you. Re-check, repair, or update manually below.",
       "recheckAll": "Re-check all",
+      "recheck": "Re-check",
+      "checking": "Checking",
+      "checkFailed": "Check failed",
+      "checkTimeout": "Check timed out",
+      "statusUnknown": "Unknown",
       "required": "Required",
       "statusReady": "Ready",
       "statusDetected": "Detected",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -382,6 +382,11 @@
     "dependencies": {
       "autoBanner": "这些依赖由 Avibe 自动安装与更新。下面可手动重新检查、修复或更新。",
       "recheckAll": "全部重新检查",
+      "recheck": "重新检查",
+      "checking": "检查中",
+      "checkFailed": "检查失败",
+      "checkTimeout": "检查超时",
+      "statusUnknown": "未知",
       "required": "必装",
       "statusReady": "就绪",
       "statusDetected": "已检测",

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -9316,44 +9316,8 @@ def ensure_model_hub_engine_installed(
     }
 
 
-def dependencies_status(*, offline: bool = False) -> dict:
-    """Status of the required local runtime dependencies for the Dependencies
-    settings page: askill, local managed runtimes, and the shared Node.js
-    prerequisite. (Agent backend CLIs are managed on the Backends tab.)
-
-    Returns stable ids + machine-readable status only — display copy (label /
-    detail) is localized in the React page, not sent from here.
-    """
-    deps: list[dict] = []
-
-    a = askill_update_status(include_latest=False)
-    deps.append(
-        {
-            "id": "askill",
-            "kind": "tool",
-            "required": True,
-            "installed": a["installed"],
-            "version": a.get("version"),
-            "latest_version": a.get("latest_version"),
-            "has_update": a.get("has_update", False),
-            "status": a["status"],
-        }
-    )
-
-    av = avault_status()
-    deps.append(
-        {
-            "id": "avault",
-            "kind": "tool",
-            "required": True,
-            "installed": av["installed"],
-            "version": av.get("version"),
-            "latest_version": None,
-            "has_update": False,
-            "status": av["status"],
-        }
-    )
-
+def _show_runtime_dependencies_status(*, offline: bool) -> tuple[dict, dict]:
+    """Show Runtime and Node share one inspection and its failure evidence."""
     from core.show_runtime import ShowRuntimeManager, get_show_runtime_manager
 
     srt_manager = ShowRuntimeManager(offline=True) if offline else get_show_runtime_manager()
@@ -9370,46 +9334,20 @@ def dependencies_status(*, offline: bool = False) -> dict:
         if srt_status in {"ready", "missing"} or recovery_action == "repair"
         else "operator_only"
     )
-    deps.append(
-        {
-            "id": "show-runtime",
-            "kind": "runtime",
-            "required": True,
-            "installed": srt_installed,
-            "version": install.get("runtime_version"),
-            "latest_version": manifest.get("runtime_version"),
-            "has_update": bool(srt_installed is True and installed_matches_manifest is False),
-            "status": srt_status,
-            "action_class": action_class,
-            "reason": srt.get("reason"),
-            "download_error": srt.get("download_error"),
-            "inspection_error": srt.get("inspection_error"),
-        }
-    )
-
-    deps.append(_model_hub_engine_dependency_status())
-
-    memory_package, memory_runtime = _memory_dependencies_status(offline=offline)
-    deps.extend((memory_package, memory_runtime))
-
-    try:
-        from core.tmux_runtime import TmuxRuntimeManager, tmux_status
-
-        tmux = TmuxRuntimeManager(offline=True).status() if offline else tmux_status()
-    except Exception as exc:  # noqa: BLE001
-        tmux = {"installed": False, "version": None, "status": "missing", "reason": str(exc)}
-    deps.append(
-        {
-            "id": "tmux",
-            "kind": "tool",
-            "required": False,
-            "installed": bool(tmux.get("installed")),
-            "version": tmux.get("version"),
-            "status": "ready" if tmux.get("installed") else "missing",
-            "reason": tmux.get("reason"),
-            "download_error": tmux.get("download_error"),
-        }
-    )
+    runtime = {
+        "id": "show-runtime",
+        "kind": "runtime",
+        "required": True,
+        "installed": srt_installed,
+        "version": install.get("runtime_version"),
+        "latest_version": manifest.get("runtime_version"),
+        "has_update": bool(srt_installed is True and installed_matches_manifest is False),
+        "status": srt_status,
+        "action_class": action_class,
+        "reason": srt.get("reason"),
+        "download_error": srt.get("download_error"),
+        "inspection_error": srt.get("inspection_error"),
+    }
 
     # Node present but below the Show Runtime minimum (node_supported is False)
     # is not actually usable — don't show it green while runtime repair fails.
@@ -9422,18 +9360,91 @@ def dependencies_status(*, offline: bool = False) -> dict:
         if node_inspection_failed
         else bool(srt.get("node_available")) and srt.get("node_supported") is not False
     )
-    deps.append(
-        {
-            "id": "node",
-            "kind": "node",
-            "required": True,
-            "installed": node_ok,
-            "version": srt.get("node_version"),
-            "status": "error" if node_ok is None else "ready" if node_ok else "missing",
-        }
-    )
+    node = {
+        "id": "node",
+        "kind": "node",
+        "required": True,
+        "installed": node_ok,
+        "version": srt.get("node_version"),
+        "status": "error" if node_ok is None else "ready" if node_ok else "missing",
+    }
+    return runtime, node
 
-    return {"ok": True, "deps": deps}
+
+DEPENDENCY_IDS = (
+    "askill",
+    "avault",
+    "show-runtime",
+    "model-hub-engine",
+    "memory-package",
+    "memory-runtime",
+    "tmux",
+    "node",
+)
+
+
+def dependencies_status(*, offline: bool = False, dependency_ids: list[str] | None = None) -> dict:
+    """Inspect only the requested dependencies, preserving the full status contract.
+
+    Omitting ids keeps the synchronous, complete inspection used by Doctor.
+    Web consumers can request independent checks without waiting for unrelated
+    CLI probes. Coupled rows share their existing inspection; no health result
+    is cached or inferred from a different dependency.
+    """
+    requested = set(DEPENDENCY_IDS if dependency_ids is None else dependency_ids)
+    unknown = requested.difference(DEPENDENCY_IDS)
+    if unknown:
+        raise ValueError(f"Unknown dependencies: {', '.join(sorted(unknown))}")
+    deps: dict[str, dict] = {}
+    if "askill" in requested:
+        a = askill_update_status(include_latest=False)
+        deps["askill"] = {
+            "id": "askill",
+            "kind": "tool",
+            "required": True,
+            "installed": a["installed"],
+            "version": a.get("version"),
+            "latest_version": a.get("latest_version"),
+            "has_update": a.get("has_update", False),
+            "status": a["status"],
+        }
+    if "avault" in requested:
+        av = avault_status()
+        deps["avault"] = {
+            "id": "avault",
+            "kind": "tool",
+            "required": True,
+            "installed": av["installed"],
+            "version": av.get("version"),
+            "latest_version": None,
+            "has_update": False,
+            "status": av["status"],
+        }
+    if requested.intersection({"show-runtime", "node"}):
+        deps["show-runtime"], deps["node"] = _show_runtime_dependencies_status(offline=offline)
+    if "model-hub-engine" in requested:
+        deps["model-hub-engine"] = _model_hub_engine_dependency_status()
+    if requested.intersection({"memory-package", "memory-runtime"}):
+        deps["memory-package"], deps["memory-runtime"] = _memory_dependencies_status(offline=offline)
+    if "tmux" in requested:
+        try:
+            from core.tmux_runtime import TmuxRuntimeManager, tmux_status
+
+            tmux = TmuxRuntimeManager(offline=True).status() if offline else tmux_status()
+        except Exception as exc:  # noqa: BLE001
+            tmux = {"installed": False, "version": None, "status": "missing", "reason": str(exc)}
+        deps["tmux"] = {
+            "id": "tmux",
+            "kind": "tool",
+            "required": False,
+            "installed": bool(tmux.get("installed")),
+            "version": tmux.get("version"),
+            "status": "ready" if tmux.get("installed") else "missing",
+            "reason": tmux.get("reason"),
+            "download_error": tmux.get("download_error"),
+        }
+
+    return {"ok": True, "deps": [deps[dep] for dep in DEPENDENCY_IDS if dep in requested]}
 
 
 def _memory_runtime_dependency_status(memory_runtime: dict) -> str:

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -7906,7 +7906,12 @@ def get_dependencies():
     """Status of local tool, package, and managed-runtime dependencies."""
     from vibe import api
 
-    return jsonify(api.dependencies_status())
+    dependency_ids = request.args.getlist("id")
+    if not dependency_ids:
+        return jsonify(api.dependencies_status())
+    if any(dep not in api.DEPENDENCY_IDS for dep in dependency_ids):
+        return jsonify({"ok": False, "error": "unknown_dependency"}), 400
+    return jsonify(api.dependencies_status(dependency_ids=dependency_ids))
 
 
 @app.route("/api/dependencies/<dep>/install", methods=["POST"])


### PR DESCRIPTION
## Summary

- Inspect requested dependency IDs through the existing status owners. Omitting IDs preserves the synchronous full inspection used by Doctor and existing clients.
- Load the Dependencies page in six independent groups, sharing the Show/Node and Memory package/runtime inspections. Completed groups render and become usable without waiting for a slow CLI probe.
- Bound UI reads to 15 seconds, retain existing failure evidence, retry only the affected group, and reject superseded/unmounted responses. Installation refreshes only the affected group; Memory sidecar reads cannot overwrite newer repair guards.
- Inspect only Memory dependencies on the Memory page and only avault in the Vault form. Display an unknown CLI version as Unknown rather than Ready.

## Contract / Known By Design

- This change removes unrelated and serial waiting, not binary verification. No persistent health cache, added dependency, version-pin change, automatic install, or VM resource change.
- Raw status, readiness, installed values, failure reasons, backend repair admission, and existing authorization remain unchanged. The complete `memory-package/error/operator_only/memory_package_source_build` tuple stays neutral Source-managed; real failures remain visible.
- A request timeout is inspection failure, never evidence that a dependency is missing or healthy. Prior data is retained for diagnosis, but actions are disabled until the latest check succeeds.
- Each request uses the current status owner. Coupled rows share one inspection. Separate groups are not a globally atomic snapshot, just as the previous serial inspection was not atomic.
- Cancelling a browser read prevents stale UI updates; it does not interrupt Python work already running. Existing probe bounds still apply.
- No release, merge, deployment, Avibe restart, or data/pairing change is part of this PR.

## Validation

- Python unit/contract: 695 relevant tests passed across dependency inspection, local dependencies, UI install routes, CLI/Doctor, and Memory runtime-install scenarios. All 256 ID subsets preserve complete row projections and probe only their owners. A real ASGI route test confirms an unrelated request completes while askill is blocked.
- UI unit/component: all 3,813 tests passed. Includes partial results, per-owner refresh, timeout/body/caller cancellation, old-response rejection, persisted errors, unknown status, Memory repair guards, and scoped Memory/Vault consumers.
- Ruff, full UI lint baseline, theme validation, TypeScript and production build passed. Existing lint/build warnings are unchanged.
- Isolated Chromium acceptance: desktop/mobile, English/Chinese, pending/timeout/retry/unknown/error states. Seven rows rendered in about 1.2 seconds while askill was deliberately held. Timeout retry issued only the askill GET. No horizontal overflow or mutation requests; the Memory source hint and genuine runtime error both remained visible. One browser-extension `ethereum` injection error was unrelated to application code.
- Affected existing scenarios: MEMORY-RUNTIME-INSTALL-001/002/003, MEMORY-INDEP-021. No lifecycle scenario contract changes.
- Residual integration acceptance: deploy after explicit approval and measure cold/warm checks in the existing local Incus environment. Isolated browser timings are not a claim about production VM performance.

## Dependencies

None. Based on master; no unmerged PR dependency.
