### PR TITLE
perf(regression): reuse builds and synchronize source incrementally

### DIFF
--- a/docs/plans/regression-incremental-updates.md
+++ b/docs/plans/regression-incremental-updates.md
@@ -1,0 +1,51 @@
+# Incremental Regression Updates
+
+## Goal
+
+Reduce repeated writes and contention on the local Incus VM disk without moving
+storage, changing resource limits, resetting product state, or restarting the
+host Avibe service.
+
+## Design
+
+- Use the existing base image's rsync through the Incus exec transport. Sync
+  changed source files and delete stale source, preserving excluded dependency
+  and runtime trees. Preserve executable modes and symlinks, but create files
+  as the service user rather than importing host ownership. Use rsync's normal
+  size/mtime quick check, not a full destination-content checksum pass.
+- Reuse the Show Runtime archive only when its receipt matches the resolved
+  upstream commit, target Node/platform and npm versions, build recipe, and
+  archive checksum. Build the exact resolved commit; atomically publish the
+  archive and publish its receipt last. Keep one artifact, not an unbounded
+  cache. Always run the existing runtime preparation/validation path.
+- Reuse the runner's file-lock mechanism for a shared heavy-I/O slot across
+  environments managed by the same primary checkout and daemon. Acquire it
+  before instance creation or stopping the target service, and hold it through
+  update/recovery. Base-image builds use the same slot. Other services remain
+  online; updates using older runners do not participate until updated.
+
+## Invariants and Verification
+
+- Repeating an unchanged sync preserves file inodes and timestamps. A changed
+  source tree converges including removals, modes, links, and directory/file
+  transitions; excluded trees are neither copied nor descended into.
+- Reuse requires both matching build inputs and matching artifact bytes.
+  Failed builds do not mark an artifact as current. Upstream changes between
+  resolution and fetch cannot silently select a different revision.
+- Different environments sharing the I/O slot cannot run heavy update phases
+  concurrently. Queued updates keep their existing service running. Exceptions
+  release locks after recovery; dry runs do not acquire locks.
+- Run focused unit/real-filesystem tests, then local Incus repeated updates and
+  health checks with existing state and pairing preserved. Verify source sync
+  statistics and Show Runtime reuse output; do not invent performance claims
+  from tests alone.
+
+## Status
+
+- [x] Inspect update lifecycle, existing exclusions, fingerprints, and locks.
+- [x] Implement the three optimizations and focused coverage (378 focused tests;
+  real macOS-to-Incus fixture: unchanged sync transfers zero file bytes, a single
+  edit transfers one file, Linux unchanged inode/mtime/ctime and ownership stay
+  intact, and obsolete source is removed).
+- [ ] Pass Codex review and expected CI through the managed delivery loop.
+- [ ] Merge and verify local Incus update/reuse and Models health.

--- a/docs/regression/README.md
+++ b/docs/regression/README.md
@@ -122,6 +122,11 @@ too. `--clean` remains an explicit full source reset, including generated files;
 it does not reset product state. If a tool deliberately changes source while
 preserving both its size and timestamp, use `--clean` to force replacement.
 
+Environment files are different from reusable caches: host `.env` and `.env.*`
+entries are never sent, and stale entries in the receiver's source directories
+are deleted during normal synchronization. Excluded runtime/dependency trees
+remain outside this cleanup boundary.
+
 Show Runtime resolves the upstream commit on each update, but builds only when
 that commit, the target Node/platform/npm versions, the build recipe, or the
 archive checksum changes. The archive and its build receipt are kept together

--- a/docs/regression/README.md
+++ b/docs/regression/README.md
@@ -55,6 +55,12 @@ environments for project testing.
 
 ## Setup
 
+Source synchronization requires `rsync` on the operator machine and in the
+container. The regression base image already includes it; on a Linux operator
+machine, install the distribution's `rsync` package if needed. The macOS system
+rsync is supported. Transfers use Incus exec as the existing service user, not
+an SSH daemon or host ownership metadata.
+
 1. Configure the local Incus host.
 
    ```bash
@@ -107,6 +113,27 @@ The compatibility entry point now uses Incus by default:
 ```bash
 ./scripts/run_regression.sh
 ```
+
+Normal updates synchronize source incrementally using rsync's size/mtime quick
+check. Unchanged files are not rewritten; stale source is deleted. Excluded
+dependency/cache/runtime directories are pruned and preserved. `--no-build-ui`
+includes local `ui/dist` in synchronization, so stale assets are deleted there
+too. `--clean` remains an explicit full source reset, including generated files;
+it does not reset product state. If a tool deliberately changes source while
+preserving both its size and timestamp, use `--clean` to force replacement.
+
+Show Runtime resolves the upstream commit on each update, but builds only when
+that commit, the target Node/platform/npm versions, the build recipe, or the
+archive checksum changes. The archive and its build receipt are kept together
+in the regression cache. Network resolution failures remain errors, not silent
+permission to deploy a stale build. Runtime preparation and validation still run
+on every update.
+
+Updates and base-image builds from worktrees of the same primary checkout share
+one heavy-I/O slot per daemon. An update waits for that slot before creating an
+instance or stopping its existing service, and holds it through recovery if the
+update fails. Other environments keep serving while it waits. Old runner versions
+and independently cloned repositories do not participate in this shared lock.
 
 Direct runner commands:
 

--- a/scripts/incus_regression.py
+++ b/scripts/incus_regression.py
@@ -1687,7 +1687,7 @@ def sync_source(
     # rsync owns reconciliation, including deletions and type changes. Excluded
     # trees are protected on the receiver and pruned on both sides, not scanned
     # for checksums. Ownership is established by the receiving service user.
-    excludes = list(source_excludes(include_ui_dist=include_ui_dist)) + [".env", ".env.*"]
+    excludes = list(source_excludes(include_ui_dist=include_ui_dist))
     for current, dirs, _files in os.walk(repo_root, followlinks=False):
         for name in dirs[:]:
             path = Path(current) / name
@@ -1710,6 +1710,9 @@ def sync_source(
         shell.chmod(0o700)
         runner.run([
             "rsync", "-rltp", "--delete", "--stats",
+            # Hide secrets only on the sender. A receiver-side exclude would
+            # retain stale .env files that can change Vite's build environment.
+            "--filter=H .env", "--filter=H .env.*",
             *(f"--exclude={pattern}" for pattern in excludes),
             "--rsh", str(shell), "--", str(repo_root) + "/", f"incus:{SOURCE_DIR}/",
         ])

--- a/scripts/incus_regression.py
+++ b/scripts/incus_regression.py
@@ -19,14 +19,13 @@ import shutil
 import socket
 import subprocess
 import sys
-import tarfile
 import tempfile
 import textwrap
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Callable, Container, Iterable, Iterator, Sequence
+from typing import Callable, Container, Iterable, Sequence
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
@@ -412,6 +411,15 @@ def target_update_lock(repo_root: Path, remote: str | None, project: str, *, dry
             yield
         finally:
             fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+
+
+@contextmanager
+def regression_io_lock(repo_root: Path, remote: str | None, *, dry_run: bool):
+    """One heavy update per daemon across this checkout's regression environments."""
+    # This reserved lock name cannot collide with an avr-* environment project.
+    # Acquire before stopping a service, including while another environment builds.
+    with target_update_lock(repo_root, remote, "shared-io", dry_run=dry_run):
+        yield
 
 
 def target_run_in_flight(repo_root: Path, remote: str | None, project: str) -> bool:
@@ -1656,35 +1664,9 @@ def is_virtualenv_dir(path: Path) -> bool:
     return (path / "pyvenv.cfg").is_file()
 
 
-def iter_source_entries(repo_root: Path, *, include_ui_dist: bool = False) -> Iterator[tuple[Path, str]]:
-    """Yield ``(path, arcname)`` for everything that belongs in the source tar.
-
-    Excluded directories are pruned during the walk rather than filtered after
-    it: ``node_modules`` and a virtualenv together hold well over a hundred
-    thousand paths that would otherwise be stat'ed just to be discarded.
-    """
-    def walk(current: Path) -> Iterator[tuple[Path, str]]:
-        for entry in sorted(current.iterdir()):
-            relative = entry.relative_to(repo_root).as_posix()
-            if should_exclude(relative, include_ui_dist=include_ui_dist):
-                continue
-            is_dir = entry.is_dir() and not entry.is_symlink()
-            if is_dir and is_virtualenv_dir(entry):
-                continue
-            yield entry, relative
-            if is_dir:
-                yield from walk(entry)
-
-    yield from walk(repo_root)
-
-
-def build_source_tar(repo_root: Path, *, include_ui_dist: bool = False) -> bytes:
-    with tempfile.TemporaryFile() as fh:
-        with tarfile.open(fileobj=fh, mode="w") as tar:
-            for path, relative in iter_source_entries(repo_root, include_ui_dist=include_ui_dist):
-                tar.add(path, arcname=relative, recursive=False)
-        fh.seek(0)
-        return fh.read()
+def require_source_sync() -> None:
+    if shutil.which("rsync") is None:
+        raise RegressionError("Source sync requires rsync on the host (already included in the regression base image).")
 
 
 def sync_source(
@@ -1696,40 +1678,41 @@ def sync_source(
     clean: bool,
     include_ui_dist: bool = False,
 ) -> None:
+    if not runner.dry_run:
+        require_source_sync()
     quoted_source = shlex.quote(SOURCE_DIR)
     if clean:
         wipe = f"find {quoted_source} -mindepth 1 -maxdepth 1 -exec rm -rf {{}} +"
-    else:
-        # Everything stale still goes, but the UI dependency tree and its build
-        # output stay: they are the ~470 MB that a full wipe forces ``npm ci``
-        # and ``npm run build`` to recreate on every update whether or not the
-        # front end changed. Whether they are still valid is a fingerprint
-        # question, answered in update_dependencies_and_build.
-        #
-        # Preservation covers only what the archive does not carry. ``tar``
-        # extracts over what is already there and never deletes, so keeping a
-        # directory the host also ships would leave the files the host deleted
-        # -- a stable-name public asset, a manifest -- served alongside the new
-        # bundle. Whatever the archive supplies has to end up equal to the
-        # host's copy, which means the old one goes first. Which of these the
-        # archive supplies is read off the exclusion table rather than restated
-        # here, so the two cannot drift.
-        quoted_ui = shlex.quote(f"{SOURCE_DIR}/ui")
-        keep = " ".join(
-            f"! -name {shlex.quote(name)}"
-            for name in UI_NON_SOURCE_DIRS
-            if should_exclude(f"ui/{name}", include_ui_dist=include_ui_dist)
-        )
-        wipe = (
-            f"find {quoted_source} -mindepth 1 -maxdepth 1 ! -name ui -exec rm -rf {{}} + && "
-            f"if [ -d {quoted_ui} ]; then find {quoted_ui} -mindepth 1 -maxdepth 1 {keep} -exec rm -rf {{}} +; fi"
-        )
-    runner.run(root_exec(target, f"mkdir -p {quoted_source} && {wipe}", remote=remote))
-    tar_bytes = b"" if runner.dry_run else build_source_tar(repo_root, include_ui_dist=include_ui_dist)
-    runner.run(
-        tenant_exec(target, f"tar --no-same-owner -C {quoted_source} -xf -", remote=remote),
-        input_bytes=tar_bytes,
+        runner.run(root_exec(target, f"mkdir -p {quoted_source} && {wipe}", remote=remote))
+    # rsync owns reconciliation, including deletions and type changes. Excluded
+    # trees are protected on the receiver and pruned on both sides, not scanned
+    # for checksums. Ownership is established by the receiving service user.
+    excludes = list(source_excludes(include_ui_dist=include_ui_dist)) + [".env", ".env.*"]
+    for current, dirs, _files in os.walk(repo_root, followlinks=False):
+        for name in dirs[:]:
+            path = Path(current) / name
+            relative = path.relative_to(repo_root).as_posix()
+            if should_exclude(relative, include_ui_dist=include_ui_dist) or path.is_symlink():
+                dirs.remove(name)
+            elif is_virtualenv_dir(path):
+                # Arbitrarily named host virtualenvs must not be shipped.
+                excludes.append("/" + re.sub(r"([\\*?\[\]])", r"\\\1", relative))
+                dirs.remove(name)
+    transport = incus(
+        "exec", remote_ref(remote, target.instance), "--mode", "non-interactive",
+        "--", "sudo", "-H", "-u", SERVICE_USER, "--",
+        project=target.project,
     )
+    with tempfile.TemporaryDirectory(prefix="avibe-rsync-") as temporary:
+        shell = Path(temporary) / "transport"
+        # rsync supplies a host placeholder before the remote server argv.
+        shell.write_text('#!/bin/sh\nshift\nexec ' + shlex.join(transport) + ' "$@"\n', encoding="utf-8")
+        shell.chmod(0o700)
+        runner.run([
+            "rsync", "-rltp", "--delete", "--stats",
+            *(f"--exclude={pattern}" for pattern in excludes),
+            "--rsh", str(shell), "--", str(repo_root) + "/", f"incus:{SOURCE_DIR}/",
+        ])
 
 
 def stop_service_for_update(runner: Runner, target: RegressionTarget, *, remote: str | None) -> None:
@@ -2371,6 +2354,64 @@ def restart_and_verify(runner: Runner, target: RegressionTarget, *, remote: str 
     )
 
 
+def show_runtime_archive_script() -> str:
+    """Build one exact upstream revision, or reuse its verified local artifact."""
+    return textwrap.dedent(r'''
+        set -euo pipefail
+        if [ "${VIBE_SHOW_RUNTIME_SOURCE:-}" != "archive" ]; then exit 0; fi
+        : "${VIBE_SHOW_RUNTIME_ARCHIVE_PATH:?VIBE_SHOW_RUNTIME_ARCHIVE_PATH is required for archive runtime source}"
+        archive="$VIBE_SHOW_RUNTIME_ARCHIVE_PATH"
+        receipt="$archive.build-key"
+        upstream=https://github.com/avibe-bot/vibe-show-runtime.git
+        revision=$(git ls-remote --exit-code "$upstream" HEAD | cut -f1)
+        [[ "$revision" =~ ^[0-9a-f]{40}$ ]]
+        node_identity=$(node -p 'JSON.stringify({platform:process.platform,arch:process.arch,versions:process.versions})')
+        npm_version=$(npm --version)
+        build_key=$(
+          printf '%s\n' 'avibe-regression-show-build-v1' "$upstream" "$revision" "$node_identity" "$npm_version" |
+            sha256sum | cut -d' ' -f1
+        )
+        if [ -f "$archive" ] && [ -f "$receipt" ]; then
+          digest=$(sha256sum "$archive" | cut -d' ' -f1)
+          if [ "$(cat "$receipt")" = "$build_key $digest" ]; then
+            printf 'Show Runtime archive unchanged (%s); reusing verified build.\n' "$revision"
+            exit 0
+          fi
+        fi
+        build_dir=$(mktemp -d)
+        archive_temp=
+        receipt_temp=
+        cleanup() {
+          rm -rf -- "$build_dir"
+          if [ -n "$archive_temp" ]; then rm -f -- "$archive_temp"; fi
+          if [ -n "$receipt_temp" ]; then rm -f -- "$receipt_temp"; fi
+        }
+        trap cleanup EXIT
+        git init --quiet "$build_dir/runtime"
+        (
+          cd "$build_dir/runtime"
+          git remote add origin "$upstream"
+          git fetch --depth 1 origin "$revision"
+          git checkout --quiet --detach FETCH_HEAD
+          [ "$(git rev-parse HEAD)" = "$revision" ]
+          npm ci
+          npm run build
+          npm run bundle:vibe-remote
+        )
+        set -- "$build_dir"/runtime/dist/vibe-show-runtime-node-*.tgz
+        [ "$#" -eq 1 ] && [ -f "$1" ]
+        mkdir -p -- "$(dirname "$archive")"
+        archive_temp=$(mktemp "$archive.XXXXXX")
+        receipt_temp=$(mktemp "$receipt.XXXXXX")
+        install -m 0644 "$1" "$archive_temp"
+        digest=$(sha256sum "$archive_temp" | cut -d' ' -f1)
+        printf '%s %s\n' "$build_key" "$digest" > "$receipt_temp"
+        mv -f -- "$archive_temp" "$archive"
+        mv -f -- "$receipt_temp" "$receipt"
+        printf 'Show Runtime archive built from %s.\n' "$revision"
+    ''').strip()
+
+
 def prepare_show_runtime(runner: Runner, target: RegressionTarget, *, remote: str | None) -> None:
     build_timeout = show_runtime_build_timeout()
     source_result = runner.run(
@@ -2383,25 +2424,7 @@ def prepare_show_runtime(runner: Runner, target: RegressionTarget, *, remote: st
     runner.run(
         tenant_exec(
             target,
-            f"""
-set -euo pipefail
-{runtime_env_exports}
-if [ "${{VIBE_SHOW_RUNTIME_SOURCE:-}}" = "archive" ]; then
-  : "${{VIBE_SHOW_RUNTIME_ARCHIVE_PATH:?VIBE_SHOW_RUNTIME_ARCHIVE_PATH is required for archive runtime source}}"
-  build_dir=$(mktemp -d)
-  trap 'rm -rf "$build_dir"' EXIT
-  git clone --depth 1 https://github.com/avibe-bot/vibe-show-runtime.git "$build_dir/runtime"
-  (
-    cd "$build_dir/runtime"
-    npm ci
-    npm run build
-    npm run bundle:vibe-remote
-  )
-  set -- "$build_dir"/runtime/dist/vibe-show-runtime-node-*.tgz
-  [ "$#" -eq 1 ] && [ -f "$1" ]
-  install -D -m 0644 "$1" "$VIBE_SHOW_RUNTIME_ARCHIVE_PATH"
-fi
-""".strip(),
+            runtime_env_exports + "\n" + show_runtime_archive_script(),
             remote=remote,
         ),
         timeout=build_timeout,
@@ -2452,6 +2475,11 @@ def cmd_init_host(args: argparse.Namespace) -> int:
 def cmd_build_base(args: argparse.Namespace) -> int:
     if not args.dry_run:
         require_incus()
+    with regression_io_lock(current_repo_root(), args.remote, dry_run=args.dry_run):
+        return build_base_image(args)
+
+
+def build_base_image(args: argparse.Namespace) -> int:
     runner = Runner(dry_run=args.dry_run)
     runner.run(incus("delete", remote_ref(args.remote, args.temp_instance), "--force"), check=False)
     runner.run(
@@ -2540,6 +2568,7 @@ def cmd_up(args: argparse.Namespace) -> int:
     show_runtime_build_timeout()
     if not args.dry_run:
         require_incus()
+        require_source_sync()
     metadata = WorktreeMetadata(repo_root, args.remote)
     # The lock comes before the row, because the lock is what says a run holds
     # this slug: `reconcile` prunes a reservation whose lock nobody holds, so a
@@ -2554,7 +2583,10 @@ def cmd_up(args: argparse.Namespace) -> int:
     runner = Runner(dry_run=args.dry_run)
     reservation: WorktreeReservation | None = None
     stopped_service_target: RegressionTarget | None = None
-    with target_update_lock(repo_root, args.remote, lock_project, dry_run=args.dry_run):
+    with (
+        target_update_lock(repo_root, args.remote, lock_project, dry_run=args.dry_run),
+        regression_io_lock(repo_root, args.remote, dry_run=args.dry_run),
+    ):
         try:
             with metadata.locked(dry_run=args.dry_run):
                 target = resolve_target(args, repo_root, dry_run=args.dry_run, slug=slug)

--- a/tests/test_incus_regression.py
+++ b/tests/test_incus_regression.py
@@ -2,15 +2,14 @@ from __future__ import annotations
 
 import argparse
 import contextlib
-import io
 import importlib.util
 import json
 import os
 import shlex
+import shutil
 import stat
 import subprocess
 import sys
-import tarfile
 from collections.abc import Sequence
 from pathlib import Path
 
@@ -891,13 +890,13 @@ def test_root_build_output_is_excluded_without_capturing_ui_dist() -> None:
     assert not incus_regression.should_exclude("vibe/dist_helpers.py")
 
 
-def test_source_tar_drops_a_virtualenv_whatever_it_is_named(tmp_path: Path) -> None:
+def test_source_sync_drops_a_virtualenv_whatever_it_is_named(tmp_path: Path, monkeypatch) -> None:
     """Virtualenvs are recognised by ``pyvenv.cfg``, not by a list of names.
 
     They hold host-native binaries that are useless inside the container, and
     the repository has carried both ``venv`` and ``.venv`` at the same time.
     """
-    for name in ("venv", ".venv", "env", "tools/sandbox"):
+    for name in ("venv", ".venv", "env", "tools/sandbox", "tools/[virtual]*env"):
         root = tmp_path / name
         (root / "lib").mkdir(parents=True)
         (root / "pyvenv.cfg").write_text("home = /usr\n", encoding="utf-8")
@@ -905,19 +904,17 @@ def test_source_tar_drops_a_virtualenv_whatever_it_is_named(tmp_path: Path) -> N
     (tmp_path / "vibe").mkdir()
     (tmp_path / "vibe" / "cli.py").write_text("print('ok')\n", encoding="utf-8")
 
-    with tarfile.open(fileobj=io.BytesIO(incus_regression.build_source_tar(tmp_path))) as tar:
-        names = set(tar.getnames())
+    names = copied_source_names(monkeypatch, tmp_path)
 
     assert "vibe/cli.py" in names
     assert not [name for name in names if "pyvenv.cfg" in name or "libpython" in name]
 
 
-def test_source_tar_keeps_a_plain_directory_that_merely_looks_like_a_virtualenv(tmp_path: Path) -> None:
+def test_source_sync_keeps_a_plain_directory_that_merely_looks_like_a_virtualenv(tmp_path: Path, monkeypatch) -> None:
     (tmp_path / "env").mkdir()
     (tmp_path / "env" / "settings.py").write_text("DEBUG = False\n", encoding="utf-8")
 
-    with tarfile.open(fileobj=io.BytesIO(incus_regression.build_source_tar(tmp_path))) as tar:
-        assert "env/settings.py" in tar.getnames()
+    assert "env/settings.py" in copied_source_names(monkeypatch, tmp_path)
 
 
 def write_ui_builder_stage(root: Path, *, external: Sequence[str] = ()) -> None:
@@ -1026,23 +1023,18 @@ def test_declaring_nothing_outside_ui_is_an_answer_but_an_unreadable_stage_is_no
         incus_regression.ui_external_build_inputs(tmp_path)
 
 
-def test_source_tar_excludes_regression_secret_file(tmp_path: Path) -> None:
+def test_source_sync_excludes_regression_secret_file(tmp_path: Path, monkeypatch) -> None:
     (tmp_path / ".env.regression").write_text("OPENAI_API_KEY=secret\n", encoding="utf-8")
     (tmp_path / "vibe").mkdir()
     (tmp_path / "vibe" / "ui_server.py").write_text("print('ok')\n", encoding="utf-8")
 
-    payload = incus_regression.build_source_tar(tmp_path)
-    with tarfile.open(fileobj=io.BytesIO(payload), mode="r") as archive:
-        names = set(archive.getnames())
-        ui_server = archive.extractfile("vibe/ui_server.py")
-        assert ui_server is not None
-        content = ui_server.read()
+    names = copied_source_names(monkeypatch, tmp_path)
 
     assert ".env.regression" not in names
-    assert b"print('ok')" in content
+    assert "vibe/ui_server.py" in names
 
 
-def test_source_tar_excludes_all_local_env_files(tmp_path: Path) -> None:
+def test_source_sync_excludes_all_local_env_files(tmp_path: Path, monkeypatch) -> None:
     (tmp_path / ".env.e2e").write_text("SECRET=1\n", encoding="utf-8")
     (tmp_path / ".env.preview.local").write_text("SECRET=2\n", encoding="utf-8")
     (tmp_path / "ui").mkdir()
@@ -1050,23 +1042,19 @@ def test_source_tar_excludes_all_local_env_files(tmp_path: Path) -> None:
     (tmp_path / "vibe").mkdir()
     (tmp_path / "vibe" / "ui_server.py").write_text("print('ok')\n", encoding="utf-8")
 
-    payload = incus_regression.build_source_tar(tmp_path)
-    with tarfile.open(fileobj=io.BytesIO(payload), mode="r") as archive:
-        names = set(archive.getnames())
+    names = copied_source_names(monkeypatch, tmp_path)
 
     assert ".env.e2e" not in names
     assert ".env.preview.local" not in names
     assert "ui/.env.local" not in names
 
 
-def test_source_tar_can_include_existing_ui_dist_when_build_is_skipped(tmp_path: Path) -> None:
+def test_source_sync_can_include_existing_ui_dist_when_build_is_skipped(tmp_path: Path, monkeypatch) -> None:
     (tmp_path / "ui" / "dist" / "assets").mkdir(parents=True)
     (tmp_path / "ui" / "dist" / "index.html").write_text("<html></html>\n", encoding="utf-8")
     (tmp_path / "ui" / "dist" / "assets" / "app.js").write_text("console.log('ok')\n", encoding="utf-8")
 
-    payload = incus_regression.build_source_tar(tmp_path, include_ui_dist=True)
-    with tarfile.open(fileobj=io.BytesIO(payload), mode="r") as archive:
-        names = set(archive.getnames())
+    names = copied_source_names(monkeypatch, tmp_path, include_ui_dist=True)
 
     assert "ui/dist/index.html" in names
     assert "ui/dist/assets/app.js" in names
@@ -1095,13 +1083,16 @@ def test_sync_source_clears_stale_files_even_without_clean(tmp_path: Path) -> No
     incus_regression.sync_source(RecordingRunner(), target, tmp_path, remote=None, clean=False)
 
     joined = "\n".join(" ".join(command) for command in commands)
-    assert f"find {incus_regression.SOURCE_DIR} -mindepth 1 -maxdepth 1 ! -name ui -exec rm -rf" in joined
-    assert f"find {incus_regression.SOURCE_DIR}/ui -mindepth 1 -maxdepth 1 " in joined
+    assert "rsync -rltp --delete --stats" in joined
+    assert "rm -rf" not in joined
+    assert "--checksum" not in joined
     for kept in incus_regression.UI_NON_SOURCE_DIRS:
-        assert f"! -name {kept}" in joined
+        assert f"--exclude=ui/{kept}" in joined or f"--exclude={kept}" in joined
 
 
-def test_source_sync_writes_as_service_user_and_preserves_unshipped_trees(tmp_path: Path) -> None:
+def test_source_sync_writes_as_service_user_and_preserves_unshipped_trees(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
     source = tmp_path / "source"
     deployed = tmp_path / "deployed"
     source.mkdir()
@@ -1117,25 +1108,11 @@ def test_source_sync_writes_as_service_user_and_preserves_unshipped_trees(tmp_pa
         for name in incus_regression.UI_NON_SOURCE_DIRS
         for path in (deployed / "ui" / name).rglob("*")
     }
-    archive_commands = []
+    transport = local_source_sync(monkeypatch, source, deployed)
 
-    class LocalRunner:
-        dry_run = False
-
-        def run(self, command, **kwargs):
-            shell_index = command.index("-lc") + 1
-            script = command[shell_index].replace(incus_regression.SOURCE_DIR, str(deployed))
-            if "input_bytes" in kwargs:
-                archive_commands.append(command)
-                # Only the generated extraction runs locally, inside the fixture root.
-                script = script[script.index("tar --no-same-owner"):]
-            return subprocess.run(["bash", "-c", script], input=kwargs.get("input_bytes"), check=True)
-
-    target = incus_regression.RegressionTarget("master", "master", "avr-master", "avibe-master", 15130, "127.0.0.1", 5123)
-    incus_regression.sync_source(LocalRunner(), target, source, remote=None, clean=False)
-
-    assert len(archive_commands) == 1
-    assert ["sudo", "-H", "-u", "avibe"] == archive_commands[0][archive_commands[0].index("sudo"):][:4]
+    assert ["sudo", "-H", "-u", "avibe"] == list(transport[transport.index("sudo"):][:4])
+    assert transport[transport.index("--mode") + 1] == "non-interactive"
+    assert "-T" not in transport  # Incus rejects -T together with --mode.
     assert (deployed / "ui" / "entry.js").read_text() == "new source"
     assert stat.S_IMODE((deployed / "tool").stat().st_mode) == 0o755
     assert (deployed / "tool-link").readlink() == Path("tool")
@@ -1144,53 +1121,55 @@ def test_source_sync_writes_as_service_user_and_preserves_unshipped_trees(tmp_pa
     assert all(path.lstat().st_ctime_ns == before.st_ctime_ns for path, before in preserved.items())
 
 
-def test_sync_source_without_clean_keeps_every_ui_non_source_dir(tmp_path: Path) -> None:
+def test_sync_source_without_clean_keeps_every_ui_non_source_dir(tmp_path: Path, monkeypatch) -> None:
     """A sync must leave ui/node_modules and ui/dist for the fingerprints to judge.
 
     Deleting them makes ``npm ci`` and ``npm run build`` unconditional, which is
     the single largest cost of an update whose front end did not change.
     """
-    script = run_sync_wipe(tmp_path, clean=False)
+    source = tmp_path / "source"
+    deployed = tmp_path / "deployed"
+    source.mkdir()
+    seed_source_tree(deployed)
+    local_source_sync(monkeypatch, source, deployed)
 
-    assert sorted(p.name for p in (tmp_path / "ui").iterdir()) == sorted(incus_regression.UI_NON_SOURCE_DIRS)
-    assert not (tmp_path / "stale.py").exists()
-    assert not (tmp_path / "stale-dir").exists()
-    assert not (tmp_path / "ui" / "src").exists()
-    assert script  # the wipe really ran rather than silently matching nothing
+    assert sorted(p.name for p in (deployed / "ui").iterdir()) == sorted(incus_regression.UI_NON_SOURCE_DIRS)
+    assert not (deployed / "stale.py").exists()
+    assert not (deployed / "stale-dir").exists()
+    assert not (deployed / "ui" / "src").exists()
 
 
-def test_sync_source_with_clean_wipes_the_ui_dirs_too(tmp_path: Path) -> None:
-    run_sync_wipe(tmp_path, clean=True)
+def test_sync_source_with_clean_wipes_the_ui_dirs_too(tmp_path: Path, monkeypatch) -> None:
+    source = tmp_path / "source"
+    deployed = tmp_path / "deployed"
+    source.mkdir()
+    seed_source_tree(deployed)
+    local_source_sync(monkeypatch, source, deployed, clean=True)
 
-    assert list(tmp_path.iterdir()) == []
+    assert list(deployed.iterdir()) == []
 
 
 @pytest.mark.parametrize("include_ui_dist", [False, True])
-def test_a_sync_only_preserves_what_its_own_archive_does_not_ship(tmp_path: Path, include_ui_dist: bool) -> None:
-    """Preservation is for what the sync does not carry; equality is for what it does.
+def test_a_sync_only_preserves_what_it_does_not_ship(tmp_path: Path, include_ui_dist: bool, monkeypatch) -> None:
+    """Preservation is for what the sync does not carry; equality is for what it does."""
+    source = tmp_path / "source"
+    deployed = tmp_path / "deployed"
+    seed_source_tree(source)
+    seed_source_tree(deployed)
+    names = copied_source_names(monkeypatch, source, include_ui_dist=include_ui_dist)
+    shipped = {name for name in incus_regression.UI_NON_SOURCE_DIRS if f"ui/{name}" in names}
 
-    ``tar`` extracts over what is already there and never deletes, so preserving
-    a directory the archive also ships leaves whatever the host deleted -- a
-    renamed chunk, a dropped public asset -- served next to the new bundle. Both
-    sides are read out of the real code: the shipped set from the archive the
-    same call would send, the preserved set from the wipe command it emits. A
-    change to either one alone breaks this.
-    """
-    seed_source_tree(tmp_path)
-    with tarfile.open(
-        fileobj=io.BytesIO(incus_regression.build_source_tar(tmp_path, include_ui_dist=include_ui_dist))
-    ) as tar:
-        shipped = {name for name in incus_regression.UI_NON_SOURCE_DIRS if f"ui/{name}" in tar.getnames()}
-
-    script = run_sync_wipe(tmp_path, clean=False, include_ui_dist=include_ui_dist)
-    preserved = {name for name in incus_regression.UI_NON_SOURCE_DIRS if f"! -name {name}" in script}
+    for name in incus_regression.UI_NON_SOURCE_DIRS:
+        (source / "ui" / name / "marker").unlink()
+    local_source_sync(monkeypatch, source, deployed, include_ui_dist=include_ui_dist)
+    preserved = {name for name in incus_regression.UI_NON_SOURCE_DIRS if (deployed / "ui" / name / "marker").exists()}
 
     assert preserved == set(incus_regression.UI_NON_SOURCE_DIRS) - shipped
-    assert shipped or not include_ui_dist  # the archive really carries ui/dist in that mode
+    assert shipped or not include_ui_dist
     for name in shipped:
-        assert not (tmp_path / "ui" / name).exists(), f"ui/{name} survived a sync that overwrites it"
+        assert not (deployed / "ui" / name / "marker").exists(), f"ui/{name} kept stale source"
     for name in preserved:
-        assert (tmp_path / "ui" / name / "marker").exists(), f"ui/{name} was wiped for the build to recreate"
+        assert (deployed / "ui" / name / "marker").exists(), f"ui/{name} was wiped for the build to recreate"
 
 
 def seed_source_tree(source_root: Path) -> None:
@@ -1204,52 +1183,130 @@ def seed_source_tree(source_root: Path) -> None:
         (source_root / "ui" / name / "marker").write_text("x", encoding="utf-8")
 
 
-def run_sync_wipe(source_root: Path, *, clean: bool, include_ui_dist: bool = False) -> str:
-    """Run sync_source's wipe command against a real directory tree.
+def copied_source_names(monkeypatch, source: Path, **options) -> set[str]:
+    deployed = source.with_name(source.name + "-copy")
+    deployed.mkdir()
+    local_source_sync(monkeypatch, source, deployed, **options)
+    return {path.relative_to(deployed).as_posix() for path in deployed.rglob("*")}
 
-    The wipe is a shell one-liner, so asserting on its text only proves we
-    wrote what we meant to write. Executing it against a populated tree is what
-    proves it deletes the stale files and keeps the expensive ones.
-    """
-    seed_source_tree(source_root)
 
-    commands: list[list[str]] = []
+def local_source_sync(monkeypatch, source: Path, deployed: Path, **options) -> tuple[str, ...]:
+    """Exercise real rsync and its argv transport, replacing only Incus itself."""
+    transports = []
 
-    class RecordingRunner:
-        dry_run = True
+    def local_transport(*args, **kwargs):
+        transports.append(args)
+        return ["env"]
 
-        def run(self, command, **kwargs):
-            commands.append(command)
-            return subprocess.CompletedProcess(command, 0)
+    with monkeypatch.context() as patch:
+        patch.setattr(incus_regression, "SOURCE_DIR", str(deployed))
+        patch.setattr(incus_regression, "incus", local_transport)
+        patch.setattr(incus_regression, "root_exec", lambda target, command, **kw: ["bash", "-c", command])
+        target = incus_regression.RegressionTarget("master", "master", "avr-master", "avibe-master", 15130, "127.0.0.1", 5123)
+        incus_regression.sync_source(
+            incus_regression.Runner(), target, source, remote=None,
+            clean=options.pop("clean", False), **options,
+        )
+    return transports[0]
 
-    target = incus_regression.RegressionTarget(
-        target="master",
-        slug="master",
-        project="avr-master",
-        instance="avibe-master",
-        host_port=15130,
-        ui_host="127.0.0.1",
-        ui_port=5123,
-    )
-    incus_regression.sync_source(
-        RecordingRunner(),
-        target,
-        source_root,
-        remote=None,
-        clean=clean,
-        include_ui_dist=include_ui_dist,
-    )
 
-    script = next(
-        command[-1]
-        for command in commands
-        if command[-1].startswith("mkdir -p") and "-exec rm -rf" in command[-1]
-    )
-    subprocess.run(
-        ["bash", "-lc", script.replace(incus_regression.SOURCE_DIR, str(source_root))],
-        check=True,
-    )
-    return script
+def test_repeated_source_sync_leaves_unchanged_files_untouched(tmp_path, monkeypatch):
+    source, deployed = tmp_path / "source", tmp_path / "deployed"
+    source.mkdir()
+    deployed.mkdir()
+    (source / "unchanged.py").write_text("same source\n")
+    (source / "changed.py").write_text("before\n")
+    local_source_sync(monkeypatch, source, deployed)
+    def file_identity(path):
+        value = path.stat()
+        return value.st_ino, value.st_mtime_ns, value.st_size
+
+    before = {path.name: file_identity(path) for path in deployed.iterdir()}
+    local_source_sync(monkeypatch, source, deployed)
+    assert all(file_identity(path) == before[path.name] for path in deployed.iterdir())
+    (source / "changed.py").write_text("after, with new contents\n")
+    local_source_sync(monkeypatch, source, deployed)
+    assert (deployed / "changed.py").read_text() == "after, with new contents\n"
+    assert file_identity(deployed / "unchanged.py") == before["unchanged.py"]
+
+
+def test_source_sync_prunes_virtualenv_and_protects_symlink_targets(tmp_path, monkeypatch):
+    source, deployed, outside = (tmp_path / name for name in ("source", "deployed", "outside"))
+    for directory in (source, deployed, outside):
+        directory.mkdir()
+    (outside / "sentinel").write_text("do not change")
+    (deployed / "package").symlink_to(outside, target_is_directory=True)
+    (source / "package").mkdir()
+    (source / "package" / "new.py").write_text("new")
+    (source / "custom-env").mkdir()
+    (source / "custom-env" / "pyvenv.cfg").write_text("home = test")
+    (source / "custom-env" / "private").write_text("not source")
+    (source / ".env.regression").write_text("not source")
+    local_source_sync(monkeypatch, source, deployed)
+    assert (deployed / "package" / "new.py").read_text() == "new"
+    assert not (deployed / "package").is_symlink()
+    assert list(outside.iterdir()) == [outside / "sentinel"]
+    assert (outside / "sentinel").read_text() == "do not change"
+    assert not (deployed / "custom-env").exists()
+    assert not (deployed / ".env.regression").exists()
+
+
+@pytest.mark.parametrize("initial,updated", [("file", "directory"), ("directory", "file"), ("file", "link"), ("link", "file")])
+def test_source_sync_converges_type_changes(tmp_path, monkeypatch, initial, updated):
+    source, deployed = tmp_path / "source", tmp_path / "deployed"
+    source.mkdir()
+    deployed.mkdir()
+
+    def make(kind):
+        entry = source / "entry"
+        if kind == "file":
+            entry.write_text("source contents")
+        elif kind == "directory":
+            entry.mkdir()
+            (entry / "child").write_text("child contents")
+        else:
+            entry.symlink_to("link-target")
+
+    make(initial)
+    local_source_sync(monkeypatch, source, deployed)
+    if initial == "directory":
+        shutil.rmtree(source / "entry")
+    else:
+        (source / "entry").unlink()
+    make(updated)
+    local_source_sync(monkeypatch, source, deployed)
+    entry = deployed / "entry"
+    if updated == "file":
+        assert not entry.is_symlink()
+        assert entry.read_text() == "source contents"
+    elif updated == "directory":
+        assert (entry / "child").read_text() == "child contents"
+    else:
+        assert entry.readlink() == Path("link-target")
+
+
+def test_io_slot_serializes_environments_and_releases_after_failure(tmp_path, monkeypatch):
+    monkeypatch.setattr(incus_regression, "git_common_root", lambda root: tmp_path)
+    with pytest.raises(RuntimeError, match="update failed"):
+        with incus_regression.regression_io_lock(tmp_path / "branch-a", None, dry_run=False):
+            with pytest.raises(incus_regression.RegressionError, match="Another run holds"):
+                with incus_regression.target_update_lock(
+                    tmp_path / "branch-b", None, "shared-io", dry_run=False, blocking=False,
+                ):
+                    pytest.fail("overlapping heavy update")
+            # Independent daemon slots do not contend.
+            with incus_regression.regression_io_lock(tmp_path, "other-daemon", dry_run=False):
+                pass
+            raise RuntimeError("update failed")
+    with incus_regression.target_update_lock(tmp_path, None, "shared-io", dry_run=False, blocking=False):
+        pass
+
+
+def test_io_slot_dry_run_has_no_lock_file(tmp_path, monkeypatch):
+    monkeypatch.setattr(incus_regression, "git_common_root", lambda root: tmp_path)
+    with incus_regression.regression_io_lock(tmp_path, None, dry_run=True):
+        pass
+    assert not (tmp_path / ".runtime").exists()
 
 
 def test_ui_public_assets_are_part_of_source_fingerprint(tmp_path: Path) -> None:
@@ -3335,6 +3392,16 @@ def test_up_stops_old_service_before_mutating_runtime(tmp_path: Path, monkeypatc
     env_file = tmp_path / ".env.regression"
     env_file.write_text("OPENAI_API_KEY=set\n", encoding="utf-8")
 
+    @contextlib.contextmanager
+    def io_slot(*args, **kwargs):
+        calls.append("io_slot_acquired")
+        try:
+            yield
+        finally:
+            calls.append("io_slot_released")
+
+    monkeypatch.setattr(incus_regression, "regression_io_lock", io_slot)
+
     class ExistingRunner:
         def __init__(self, *, dry_run=False):
             self.dry_run = dry_run
@@ -3397,7 +3464,8 @@ def test_up_stops_old_service_before_mutating_runtime(tmp_path: Path, monkeypatc
     )
 
     assert incus_regression.cmd_up(args) == 0
-    assert calls[:4] == [
+    assert calls[:5] == [
+        "io_slot_acquired",
         "ensure_project_and_instance",
         "stop_service_for_update",
         "write_runtime_env",
@@ -3408,6 +3476,7 @@ def test_up_stops_old_service_before_mutating_runtime(tmp_path: Path, monkeypatc
     assert calls.index("sync_source") < calls.index("update_dependencies_and_build")
     assert calls.index("normalize_runtime_config") < calls.index("restart_and_verify")
     assert calls.index("prepare_show_runtime") < calls.index("restart_and_verify")
+    assert calls[-1] == "io_slot_released"
 
 
 def test_up_preserves_runtime_env_when_existing_target_has_no_env_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -3676,7 +3745,7 @@ def test_up_reserves_worktree_port_under_both_locks_that_protect_it(tmp_path: Pa
 
     assert incus_regression.cmd_up(args) == 0
 
-    assert calls[:3] == ["target_lock_enter", "mapping_lock_enter", "reserve_worktree_metadata"]
+    assert calls[:4] == ["target_lock_enter", "target_lock_enter", "mapping_lock_enter", "reserve_worktree_metadata"]
     # The reservation and the completion stamp are two writes, and `up` releases
     # the mapping lock between them, so the mapping's own writer has to take it.
     # Both depths are asserted for every write: whoever performs it, no write to
@@ -3691,7 +3760,7 @@ def test_up_reserves_worktree_port_under_both_locks_that_protect_it(tmp_path: Pa
     assert "updated_at" in mapping
     # The lock is named before the row exists, so it is asserted against the row:
     # a lock on any other name would be held while a different environment built.
-    assert locked == [mapping["project"]]
+    assert locked == [mapping["project"], "shared-io"]
 
 
 @pytest.mark.parametrize("holds_project", [False, True], ids=["daemon-empty", "daemon-holds-project"])
@@ -4782,7 +4851,7 @@ def test_prepare_show_runtime_builds_archive_and_retries_from_fresh_install(
         def run(self, command, **kwargs):
             joined = " ".join(command)
             commands.append(joined)
-            if "git clone --depth 1" in joined:
+            if "git fetch --depth 1" in joined:
                 build_timeouts.append(kwargs.get("timeout"))
             if "vibe runtime prepare --strict" in joined:
                 self.prepare_attempts += 1
@@ -4805,12 +4874,13 @@ def test_prepare_show_runtime_builds_archive_and_retries_from_fresh_install(
     incus_regression.prepare_show_runtime(RecordingRunner(), target, remote=None)
 
     joined = "\n".join(commands)
-    assert "git clone --depth 1 https://github.com/avibe-bot/vibe-show-runtime.git" in joined
+    assert "git ls-remote --exit-code" in joined
+    assert 'git fetch --depth 1 origin "$revision"' in joined
     assert "npm run bundle:vibe-remote" in joined
-    assert 'install -D -m 0644 "$1" "$VIBE_SHOW_RUNTIME_ARCHIVE_PATH"' in joined
+    assert 'install -m 0644 "$1" "$archive_temp"' in joined
     assert build_timeouts == [expected_timeout]
-    build_command = next(command for command in commands if "git clone --depth 1" in command)
-    assert build_command.index("VIBE_SHOW_RUNTIME_ARCHIVE_PATH is required") < build_command.index("git clone")
+    build_command = next(command for command in commands if "git fetch --depth 1" in command)
+    assert build_command.index("VIBE_SHOW_RUNTIME_ARCHIVE_PATH is required") < build_command.index("git fetch")
     assert joined.count("vibe runtime prepare --strict") == 2
     assert "rm -rf ~/.avibe/runtime/show-runtime/prebuilt/current" in joined
     assert "vibe runtime status --json" in joined
@@ -4846,6 +4916,135 @@ def test_prepare_show_runtime_retry_keeps_the_npm_cache() -> None:
     joined = "\n".join(commands)
     assert "_cacache" not in joined
     assert "npm cache clean" not in joined
+
+
+@pytest.fixture
+def show_archive_builder(tmp_path, monkeypatch):
+    """Use a real local Git upstream and hermetic build tools, without network."""
+    upstream = tmp_path / "upstream"
+    upstream.mkdir()
+    git = shutil.which("git")
+    assert git
+
+    def commit(contents):
+        (upstream / "source").write_text(contents)
+        subprocess.run([git, "-C", str(upstream), "add", "source"], check=True, capture_output=True)
+        subprocess.run([
+            git, "-C", str(upstream), "-c", "user.name=Test", "-c", "user.email=test@example.invalid",
+            "-c", "commit.gpgsign=false", "commit", "-m", "fixture",
+        ], check=True, capture_output=True)
+
+    subprocess.run([git, "init", "--quiet", str(upstream)], check=True)
+    commit("first version")
+    binaries = tmp_path / "bin"
+    binaries.mkdir()
+    build_log = tmp_path / "build.log"
+    monkeypatch.setenv("PATH", str(binaries) + os.pathsep + os.environ["PATH"])
+    monkeypatch.setenv("BUILD_LOG", str(build_log))
+    monkeypatch.setenv("NODE_ID", "node-platform-arch-version")
+    monkeypatch.setenv("NPM_ID", "10.0.0")
+    monkeypatch.setenv("VIBE_SHOW_RUNTIME_SOURCE", "archive")
+    archive = tmp_path / "cache" / "runtime.tgz"
+    monkeypatch.setenv("VIBE_SHOW_RUNTIME_ARCHIVE_PATH", str(archive))
+    (binaries / "node").write_text('#!/bin/sh\nprintf "%s\\n" "$NODE_ID"\n')
+    (binaries / "npm").write_text(
+        f"#!{sys.executable}\n"
+        "import os, pathlib, subprocess, sys\n"
+        "if sys.argv[1:] == ['--version']:\n"
+        "    print(os.environ['NPM_ID']); sys.exit(0)\n"
+        "with open(os.environ['BUILD_LOG'], 'a') as log: log.write(' '.join(sys.argv[1:]) + '\\n')\n"
+        "if os.environ.get('FAIL_BUILD'): sys.exit(19)\n"
+        "if sys.argv[1:] == ['run', 'bundle:vibe-remote']:\n"
+        "    pathlib.Path('dist').mkdir(exist_ok=True)\n"
+        "    pathlib.Path('dist/vibe-show-runtime-node-test.tgz').write_bytes(\n"
+        f"        subprocess.check_output([{git!r}, 'rev-parse', 'HEAD']))\n"
+    )
+    for binary in binaries.iterdir():
+        binary.chmod(0o700)
+    script = incus_regression.show_runtime_archive_script().replace(
+        "upstream=https://github.com/avibe-bot/vibe-show-runtime.git", "upstream=" + shlex.quote(str(upstream)),
+    )
+
+    def run(recipe=None, *, check=True):
+        return subprocess.run(["bash", "-c", recipe or script], check=check, capture_output=True, text=True)
+
+    return run, commit, archive, build_log, script
+
+
+def test_show_archive_reuses_verified_artifact_without_rewriting(show_archive_builder):
+    run, _commit, archive, log, _script = show_archive_builder
+    run()
+    before = archive.stat()
+    receipt_before = Path(str(archive) + ".build-key").stat()
+    result = run()
+    assert "reusing verified build" in result.stdout
+    assert archive.stat() == before
+    assert Path(str(archive) + ".build-key").stat() == receipt_before
+    assert log.read_text().splitlines() == ["ci", "run build", "run bundle:vibe-remote"]
+
+
+@pytest.mark.parametrize("change", ["revision", "node", "npm", "recipe", "missing", "corrupt", "receipt"])
+def test_show_archive_rebuilds_when_reuse_proof_changes(show_archive_builder, monkeypatch, change):
+    run, commit, archive, log, script = show_archive_builder
+    run()
+    if change == "revision":
+        commit("second version")
+    elif change == "node":
+        monkeypatch.setenv("NODE_ID", "different-node-platform")
+    elif change == "npm":
+        monkeypatch.setenv("NPM_ID", "11.0.0")
+    elif change == "recipe":
+        script = script.replace("show-build-v1", "show-build-v2")
+    elif change == "missing":
+        archive.unlink()
+    elif change == "corrupt":
+        archive.write_bytes(b"corrupt artifact")
+    else:
+        Path(str(archive) + ".build-key").write_text("invalid receipt")
+    result = run(script)
+    assert "archive built from" in result.stdout
+    assert log.read_text().splitlines().count("ci") == 2
+    assert "reusing verified build" in run(script).stdout
+
+
+def test_show_archive_failed_build_keeps_previous_artifact_and_receipt(show_archive_builder, monkeypatch):
+    run, commit, archive, _log, _script = show_archive_builder
+    run()
+    receipt = Path(str(archive) + ".build-key")
+    before = archive.read_bytes(), receipt.read_bytes()
+    commit("new version which fails to build")
+    monkeypatch.setenv("FAIL_BUILD", "1")
+    assert run(check=False).returncode != 0
+    assert (archive.read_bytes(), receipt.read_bytes()) == before
+    monkeypatch.delenv("FAIL_BUILD")
+    assert "archive built from" in run().stdout
+
+
+def test_show_archive_builds_resolved_commit_when_upstream_head_moves(show_archive_builder):
+    run, commit, archive, _log, script = show_archive_builder
+    run()
+    resolved_revision = archive.read_text().strip()
+    commit("head moved after resolution")
+    archive.unlink()
+    script = script.replace(
+        'revision=$(git ls-remote --exit-code "$upstream" HEAD | cut -f1)',
+        "revision=" + resolved_revision,
+    )
+    assert "archive built from" in run(script).stdout
+    assert archive.read_text().strip() == resolved_revision
+    assert "archive built from" in run().stdout
+    assert archive.read_text().strip() != resolved_revision
+
+
+@pytest.mark.parametrize("probe", ["revision", "node_identity", "npm_version"])
+def test_show_archive_does_not_reuse_when_an_input_cannot_be_resolved(show_archive_builder, probe):
+    run, _commit, archive, _log, script = show_archive_builder
+    run()
+    before = archive.read_bytes()
+    lines = script.splitlines()
+    script = "\n".join(f"{probe}=$(false)" if line.startswith(probe + "=") else line for line in lines)
+    assert run(script, check=False).returncode != 0
+    assert archive.read_bytes() == before
 
 
 @pytest.mark.parametrize("legacy_source", ["github", "github-source", "GitHub-Source"])
@@ -4887,7 +5086,7 @@ def test_retired_runtime_source_is_recognized_by_product_and_regression(
 
     joined = "\n".join(commands)
     assert "cat > /etc/avibe-regression.env" not in joined
-    assert "git clone --depth 1 https://github.com/avibe-bot/vibe-show-runtime.git" in joined
+    assert 'git fetch --depth 1 origin "$revision"' in joined
     assert joined.count("VIBE_SHOW_RUNTIME_SOURCE=archive") == 4
     archive_path = f"{incus_regression.SERVICE_HOME}/.cache/avibe-regression/vibe-show-runtime-node.tgz"
     assert joined.count(f"VIBE_SHOW_RUNTIME_ARCHIVE_PATH={archive_path}") == 4

--- a/tests/test_incus_regression.py
+++ b/tests/test_incus_regression.py
@@ -1049,6 +1049,41 @@ def test_source_sync_excludes_all_local_env_files(tmp_path: Path, monkeypatch) -
     assert "ui/.env.local" not in names
 
 
+@pytest.mark.parametrize("shape", ["file", "directory", "symlink"])
+def test_source_sync_removes_stale_environment_entries_but_preserves_runtime_trees(tmp_path, monkeypatch, shape):
+    source, deployed, outside = (tmp_path / name for name in ("source", "deployed", "outside"))
+    for root in (source, deployed, outside):
+        root.mkdir()
+    sentinel = outside / "sentinel"
+    sentinel.write_text("not deployed source")
+    obsolete = [".env", "ui/.env.local", "nested/source/.env.preview.local"]
+    for relative in obsolete:
+        host = source / relative
+        host.parent.mkdir(parents=True, exist_ok=True)
+        host.write_text("host-only fixture secret")
+        receiver = deployed / relative
+        receiver.parent.mkdir(parents=True, exist_ok=True)
+        if shape == "directory":
+            receiver.mkdir()
+            (receiver / "old-secret").write_text("old fixture secret")
+        elif shape == "symlink":
+            receiver.symlink_to(outside, target_is_directory=True)
+        else:
+            receiver.write_text("old fixture secret")
+    protected = [deployed / "ui/node_modules/pkg/.env", deployed / ".runtime/.env.local"]
+    for path in protected:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("runtime-owned fixture")
+    before = {path: path.stat().st_ctime_ns for path in [sentinel, *protected]}
+
+    local_source_sync(monkeypatch, source, deployed)
+
+    assert all(not os.path.lexists(deployed / relative) for relative in obsolete)
+    assert all((source / relative).read_text() == "host-only fixture secret" for relative in obsolete)
+    assert all(path.stat().st_ctime_ns == timestamp for path, timestamp in before.items())
+    assert sentinel.read_text() == "not deployed source"
+
+
 def test_source_sync_can_include_existing_ui_dist_when_build_is_skipped(tmp_path: Path, monkeypatch) -> None:
     (tmp_path / "ui" / "dist" / "assets").mkdir(parents=True)
     (tmp_path / "ui" / "dist" / "index.html").write_text("<html></html>\n", encoding="utf-8")

--- a/tests/test_incus_regression.py
+++ b/tests/test_incus_regression.py
@@ -5009,12 +5009,22 @@ def show_archive_builder(tmp_path, monkeypatch):
 def test_show_archive_reuses_verified_artifact_without_rewriting(show_archive_builder):
     run, _commit, archive, log, _script = show_archive_builder
     run()
-    before = archive.stat()
-    receipt_before = Path(str(archive) + ".build-key").stat()
+    receipt = Path(str(archive) + ".build-key")
+
+    def write_identity(path):
+        value = path.stat()
+        return (value.st_dev, value.st_ino, value.st_mode, value.st_uid, value.st_gid,
+                value.st_size, value.st_mtime_ns, value.st_ctime_ns)
+
+    # Reading to verify a cache hit may advance atime on Linux relatime mounts.
+    # Make that eligible even when the two builds run in the same clock tick.
+    for path in (archive, receipt):
+        value = path.stat()
+        os.utime(path, ns=(value.st_mtime_ns - 172_800_000_000_000, value.st_mtime_ns))
+    before = {path: write_identity(path) for path in (archive, receipt)}
     result = run()
     assert "reusing verified build" in result.stdout
-    assert archive.stat() == before
-    assert Path(str(archive) + ".build-key").stat() == receipt_before
+    assert all(write_identity(path) == identity for path, identity in before.items())
     assert log.read_text().splitlines() == ["ci", "run build", "run bundle:vibe-remote"]
 
 

--- a/tests/test_incus_regression_supervisor.py
+++ b/tests/test_incus_regression_supervisor.py
@@ -93,7 +93,7 @@ def test_preserved_custom_archive_path_cannot_split_build_and_supervisor(
 
     incus_regression.prepare_show_runtime(RecordingRunner(), target, remote=None)
 
-    build_command = next(command for command in commands if "git clone --depth 1" in command)
+    build_command = next(command for command in commands if "git fetch --depth 1" in command)
     assert custom_path not in build_command
     assert f"export VIBE_SHOW_RUNTIME_ARCHIVE_PATH={supervisor_path}" in build_command
 


### PR DESCRIPTION
## Summary

Reduce regression update disk work without moving storage or changing VM resources:

- Replace full source tar/wipe/extract with rsync over Incus exec as the service user. Delete stale source, retain excluded caches/runtime trees, and remove the obsolete tar implementation.
- Reuse the Show Runtime archive only when the resolved upstream commit, target Node/platform/npm versions, build recipe, and archive checksum match. Fetch the exact resolved revision and publish the receipt last, after an atomic archive replacement.
- Serialize updates and base-image builds across this checkout's environments before instance creation or service shutdown. Keep the shared slot through failure recovery.

## Evidence

- Unit/contract: 381 focused tests covering the runner, shell wrapper, supervisor, and state preparation; real-filesystem rsync tests and local-Git/fake-build-tool cache tests. Existing recovery and state-preservation tests remain covered.
- Real local Incus fixture: macOS system rsync to Linux receiver passed. Unchanged sync transferred 0 file bytes; a single changed file transferred 22 bytes; deleted source disappeared. Unchanged Linux inode/mtime/ctime, service ownership, executable modes, symlinks, and virtualenv exclusion were verified.
- Review follow-up: sender-only environment filters exclude host secrets while deleting stale receiver source environment entries (files, directories, and symlinks). Runtime/dependency trees remain protected; real local Incus verification passed.
- CI follow-up: the cache-reuse test now distinguishes reads from writes. It deliberately ages atime and asserts unchanged inode, size, ownership, nanosecond mtime and ctime, avoiding Linux relatime false failures without weakening the no-rewrite contract.
- Ruff and whitespace checks pass. No UI code or additional Python/npm dependencies.
- Scenario IDs: not applicable; this changes the development regression runner, not a cataloged product/auth flow.
- Residual integration: after the current-head review/CI gate, update the existing local master without resets or env replacement; repeat the update to verify build reuse, transfer statistics, state/pairing, and Models health. A network-dependent full base-image rebuild is not part of this task.

## Dependencies

None. Based on master after #1887. Rsync is already present in the base image; the operator-side requirement is now documented and checked before stopping a service.

## Known By Design

- Source change detection uses rsync's normal size/mtime quick check, not a full destination-content checksum scan. Changes preserving size and timestamp at protocol precision require explicit `--clean` replacement.
- The I/O slot coordinates worktrees of one primary checkout, separately per daemon authority. Older runners and independent clones do not participate. This does not change Incus resource limits or throttle running services.
- Upstream resolution is still required on cache hits. A failed lookup is an update error, never a silent stale-runtime fallback.
- Runtime preparation/validation still runs on every update. Only building an unchanged archive is skipped.
- Host Avibe service and unrelated working-tree changes are out of scope and untouched.
