### PR TITLE
fix(regression): isolate archive recipe exits from login hooks

### DIFF
--- a/scripts/incus_regression.py
+++ b/scripts/incus_regression.py
@@ -2359,7 +2359,7 @@ def restart_and_verify(runner: Runner, target: RegressionTarget, *, remote: str 
 
 def show_runtime_archive_script() -> str:
     """Build one exact upstream revision, or reuse its verified local artifact."""
-    return textwrap.dedent(r'''
+    script = textwrap.dedent(r'''
         set -euo pipefail
         if [ "${VIBE_SHOW_RUNTIME_SOURCE:-}" != "archive" ]; then exit 0; fi
         : "${VIBE_SHOW_RUNTIME_ARCHIVE_PATH:?VIBE_SHOW_RUNTIME_ARCHIVE_PATH is required for archive runtime source}"
@@ -2413,6 +2413,8 @@ def show_runtime_archive_script() -> str:
         mv -f -- "$receipt_temp" "$receipt"
         printf 'Show Runtime archive built from %s.\n' "$revision"
     ''').strip()
+    # Early exits must not run the service user's login-shell logout hooks.
+    return "(\n" + script + "\n)"
 
 
 def prepare_show_runtime(runner: Runner, target: RegressionTarget, *, remote: str | None) -> None:

--- a/tests/test_incus_regression.py
+++ b/tests/test_incus_regression.py
@@ -5000,8 +5000,9 @@ def show_archive_builder(tmp_path, monkeypatch):
         "upstream=https://github.com/avibe-bot/vibe-show-runtime.git", "upstream=" + shlex.quote(str(upstream)),
     )
 
-    def run(recipe=None, *, check=True):
-        return subprocess.run(["bash", "-c", recipe or script], check=check, capture_output=True, text=True)
+    def run(recipe=None, *, check=True, login=False):
+        options = ["--noprofile", "--norc", "--login"] if login else []
+        return subprocess.run(["bash", *options, "-c", recipe or script], check=check, capture_output=True, text=True)
 
     return run, commit, archive, build_log, script
 
@@ -5026,6 +5027,34 @@ def test_show_archive_reuses_verified_artifact_without_rewriting(show_archive_bu
     assert "reusing verified build" in result.stdout
     assert all(write_identity(path) == identity for path, identity in before.items())
     assert log.read_text().splitlines() == ["ci", "run build", "run bundle:vibe-remote"]
+
+
+@pytest.mark.parametrize("outcome", ["cache-hit", "non-archive", "build-failure"])
+def test_show_archive_recipe_does_not_exit_the_login_shell(show_archive_builder, tmp_path, monkeypatch, outcome):
+    run, commit, _archive, _log, _script = show_archive_builder
+    run()
+    home = tmp_path / "login-home"
+    home.mkdir()
+    logout_log = tmp_path / "logout.log"
+    (home / ".bash_logout").write_text('printf "logout\\n" >> "$LOGOUT_LOG"\nfalse\n')
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("LOGOUT_LOG", str(logout_log))
+    # Reproduce Ubuntu's failing noninteractive clear_console logout hook.
+    assert run("set -euo pipefail; exit 0", check=False, login=True).returncode != 0
+    assert logout_log.read_text() == "logout\n"
+    logout_log.unlink()
+    if outcome == "non-archive":
+        monkeypatch.setenv("VIBE_SHOW_RUNTIME_SOURCE", "manifest-cache")
+    elif outcome == "build-failure":
+        commit("revision whose build fails")
+        monkeypatch.setenv("FAIL_BUILD", "1")
+
+    result = run(check=False, login=True)
+
+    assert result.returncode == (19 if outcome == "build-failure" else 0)
+    assert not logout_log.exists()
+    if outcome == "cache-hit":
+        assert "reusing verified build" in result.stdout
 
 
 @pytest.mark.parametrize("change", ["revision", "node", "npm", "recipe", "missing", "corrupt", "receipt"])


### PR DESCRIPTION
## Summary

Fix the cache-hit integration failure found while verifying #1890 on the existing local Incus master.

The archive recipe runs through a noninteractive Bash login shell. Its successful early exit, combined with errexit, invokes Ubuntu's .bash_logout; clear_console fails without a terminal and converts the successful cache hit into exit status 1. Execute the recipe in a subshell so its exits remain local, while preserving login initialization and strict failure propagation.

## Evidence

- Real local Incus reproduction: true under strict mode returns 0; explicit exit 0 under strict mode returns 1, with the trace ending in the stock clear_console logout hook; the same exit inside a subshell returns 0. No system shell configuration was modified.
- 384 related tests pass, including real Bash login-shell tests with a deliberately failing logout hook for cache-hit, non-archive, and build-failure outcomes. The fixture first proves that an unisolated successful exit fails. Real build failure remains status 19.
- Ruff and whitespace checks pass. No dependency, UI, or state-schema changes.
- Scenario IDs: not applicable; this changes the development regression runner.
- Integration completed after guarded squash merge at 1ee2e1973: two normal runner updates of the existing local Incus master both succeeded. The earlier failed #1890 update is not counted.

## Post-Merge Integration

- Current-head explicit Codex pass and all 17 CI checks passed; all exact-head lint runs succeeded, zero unresolved threads, CLEAN at the guarded merge.
- First follow-up update transferred 5 changed files with 23,844 unmatched bytes and reused the verified Show archive. Python/UI dependency installs were skipped; UI rebuilt for intervening main-branch UI test changes.
- Unchanged second update transferred 0 files and 0 file-content bytes (128,843-byte file list). Python dependencies, UI dependencies, UI build, and Show archive build were all reused. Strict runtime preparation and service readiness completed normally.
- Actual update commands contain no recursive ownership change. Source rsync excludes runtime, worktree, dependency, cache, and build-output trees; this is not a whole-disk scan. The shared I/O slot was verified across worktrees during the earlier integration run.
- Existing environment file identity, ownership, and write timestamps were preserved. Pairing remains true; both model source IDs and all unrelated owner-file hashes were preserved. Archive, receipt, sampled unchanged source, and dependency identities/write timestamps were unchanged across the repeated update.
- Models engine v7.2.149: 10/10 healthy samples after the first update and 20/20 after the second. One initial source-list probe returned HTTP 503 shortly after first-update readiness; subsequent independent checks recovered before repeating the acceptance probe. This transient is retained in the results, not counted as healthy. No claim is made that update optimizations eliminate unrelated HDD pressure.
- No host Avibe service changes, VM resource/disk moves, state resets, pairing resets, or system logout-file edits were performed.

## Dependencies

Requires #1890, already merged. This branch starts at its merged master commit.

## Known By Design

- The parent remains a login shell. This does not disable user logout hooks globally, modify .bash_logout, or turn off strict error checking.
- Archive inputs and packaging are unchanged; the existing verified build receipt remains valid, avoiding a redundant rebuild.
- Host Avibe service, shared VM resources, other instances, and unrelated working changes remain untouched.
