### PR TITLE
test(ci): await model dialog readiness

### DIFF
--- a/docs/plans/ci-model-picker-readiness.md
+++ b/docs/plans/ci-model-picker-readiness.md
@@ -1,0 +1,63 @@
+# Model Picker CI Readiness
+
+## Cause and Scope
+
+Master `616aa5df5` failed UI job `101333936578` in lint run `33976469074`:
+the picker title was present while the model request was still loading, but the
+test immediately queried a group that only exists after that request completes.
+The loading DOM contained a disabled search field and no candidate groups.
+
+The same test file had three instances of this class: waiting for the static
+title, an unchanged confirmation label, or a search field that exists while
+disabled. They originated in #1839 (`77c1fd8a4`), not the unrelated #1890 change
+whose master run exposed the race.
+
+The initial scope was the picker test and this record. During full local UI
+validation, the unchanged catalog test also failed at its title-to-row wait.
+Its loading DOM showed the same class: title present, no rows, disabled inputs.
+The orchestrator inspected the catalog consumer and all its asynchronous read
+boundaries before extending scope to `BackendModelCatalogDialog.test.tsx`.
+Product behavior, workflow gates, timeouts, dependencies, and test selection
+remain unchanged.
+
+A controlled 250 ms delay on the catalog and candidate reads reproduced twelve
+catalog failures: one title-to-row assertion, nine clicks on the still-disabled
+Add models button, and two attempts to type into still-disabled search inputs.
+The complete class is addressed with a local enabled-button query and explicit
+row/input readiness waits, not test reruns or implicit synchronization in render.
+Error and legacy-read tests retain their own readiness boundaries.
+
+## Invariant
+
+Assertions and interactions that consume candidate data must wait for its
+observable readiness, not for the dialog shell. The group test awaits its real
+group, the selection test awaits its candidate, and the search test awaits an
+enabled input. All original assertions remain.
+
+A deferred-response regression holds the real component in loading state,
+checks that the title and confirmation label already exist while search is
+disabled, then completes the request explicitly. It verifies the actual group
+and enabled search after completion. It uses no sleeps, retries, or fake timers.
+
+## Evidence
+
+- Before editing, the original eight tests passed with immediate responses.
+- An isolated in-memory mock with a 250 ms response delay reproduced exactly
+  the three premature waits; the group failure matched the archived CI failure.
+- Under that same controlled delay, readiness waits made all eight pass.
+- The final picker suite passed all nine cases normally and with that delay.
+- The catalog suite passed all 35 cases with controlled delayed reads, after
+  the original source failed twelve of its 34 cases under identical stimulus.
+- Both focused suites passed 44 cases. Full UI validation passed all 287 files
+  and 3816 cases; test typecheck, theme validation, and production build passed.
+- An AST assertion inventory retained all 207 original assertions across 39
+  test definitions (42 expanded cases). The locked-row query alone changes from
+  synchronous `getByText` to awaited `findByText`; no expected value changes.
+- A lint run concurrent with full UI tests observed the lint-integrity test's
+  deliberately invalid temporary source. That test removes it in `finally`.
+  Lint must run after that suite, as CI already does, not concurrently with it.
+- Exact-head review and CI results are recorded in the PR.
+
+The controlled delay is diagnostic stimulus, not a production or committed-test
+sleep. No model API calls or live user state are used. This fixes test ordering;
+it does not claim a production model-loading defect or a CI speedup.

--- a/ui/src/components/settings/models/BackendModelCatalogDialog.test.tsx
+++ b/ui/src/components/settings/models/BackendModelCatalogDialog.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen, waitFor, within } from '@testing-library/react';
+import { act, cleanup, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { I18nextProvider } from 'react-i18next';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -54,6 +54,12 @@ const staleCandidates = (changed: Record<string, RouteHop[]>) => new ApiCallErro
  *  three on screen. */
 const confirmation = () => within(screen.getByRole('alert').parentElement as HTMLElement);
 
+const enabledAddModels = () => waitFor(() => {
+  const button = screen.getByRole('button', { name: 'Add models' }) as HTMLButtonElement;
+  expect(button.disabled).toBe(false);
+  return button;
+});
+
 const agent = (catalog: BackendModel[] | undefined, overrides: Partial<AgentSupply> = {}): AgentSupply => ({
   backend: 'claude',
   cli_present: true,
@@ -99,12 +105,30 @@ afterEach(async () => {
 });
 
 describe('BackendModelCatalogDialog', () => {
+  it('enables catalog controls only after the baseline read completes', async () => {
+    let finishRead!: (value: AgentSupply) => void;
+    const pendingRead = new Promise<AgentSupply>((resolve) => { finishRead = resolve; });
+    vi.spyOn(modelsApi, 'getAgentSources').mockReturnValue(pendingRead);
+    renderDialog();
+
+    expect(screen.getByRole('heading', { name: 'Claude Code models' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Add models' }).hasAttribute('disabled')).toBe(true);
+    expect((screen.getByLabelText('Search name or model ID') as HTMLInputElement).disabled).toBe(true);
+    expect(screen.queryByText('alpha')).toBeNull();
+
+    await act(async () => { finishRead(agent([model('alpha')])); });
+
+    expect(screen.getByRole('button', { name: 'Reorder alpha' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Add models' }).hasAttribute('disabled')).toBe(false);
+    expect((screen.getByLabelText('Search name or model ID') as HTMLInputElement).disabled).toBe(false);
+  });
+
   it('shows a locked row without any way to edit, remove, or reorder it', async () => {
     vi.spyOn(modelsApi, 'getAgentSources').mockResolvedValue(agent([locked, model('alpha')]));
     renderDialog();
 
     expect(await screen.findByRole('heading', { name: 'Claude Code models' })).toBeTruthy();
-    expect(screen.getByText('claude-default')).toBeTruthy();
+    expect(await screen.findByText('claude-default')).toBeTruthy();
     expect(screen.getByText('Default')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Reorder alpha' })).toBeTruthy();
     expect(screen.queryByRole('button', { name: 'Reorder claude-default' })).toBeNull();
@@ -184,7 +208,7 @@ describe('BackendModelCatalogDialog', () => {
     const putAgentModels = vi.spyOn(modelsApi, 'putAgentModels').mockResolvedValue(echoed);
     const { onSaved, onClose } = renderDialog();
 
-    await user.click(await screen.findByRole('button', { name: 'Add models' }));
+    await user.click(await enabledAddModels());
     await user.click(await screen.findByRole('checkbox', { name: /GLM 5\.2/ }));
     await user.click(screen.getByRole('button', { name: 'Add 1 model' }));
 
@@ -217,7 +241,7 @@ describe('BackendModelCatalogDialog', () => {
     const putAgentModels = vi.spyOn(modelsApi, 'putAgentModels').mockResolvedValue(agent([...catalog, model('added')]));
     renderDialog();
 
-    await user.click(await screen.findByRole('button', { name: 'Add models' }));
+    await user.click(await enabledAddModels());
     await user.click(await screen.findByRole('button', { name: 'Add custom model…' }));
     await user.type(screen.getByLabelText('Model'), 'added');
     await user.click(screen.getByRole('button', { name: 'Add model' }));
@@ -254,6 +278,7 @@ describe('BackendModelCatalogDialog', () => {
 
     await user.click(await screen.findByRole('button', { name: 'Remove Foo Air' }));
     await user.click(screen.getByRole('button', { name: 'Add models' }));
+    await waitFor(() => expect((screen.getByLabelText('Search models or providers') as HTMLInputElement).disabled).toBe(false));
     await user.type(await screen.findByLabelText('Search models or providers'), 'foo');
     await user.click(await screen.findByRole('button', { name: 'Add "foo" as a custom model…' }));
 
@@ -413,7 +438,7 @@ describe('BackendModelCatalogDialog', () => {
       .mockResolvedValue(agent([...catalog, model('glm-5.2')]));
     const { onSaved, onObserved } = renderDialog();
 
-    await user.click(await screen.findByRole('button', { name: 'Add models' }));
+    await user.click(await enabledAddModels());
     await user.click(await screen.findByRole('checkbox', { name: /Primary relay/ }));
     await user.click(screen.getByRole('button', { name: 'Add 1 model' }));
     await user.click(await screen.findByRole('button', { name: 'Save' }));
@@ -507,7 +532,8 @@ describe('BackendModelCatalogDialog', () => {
     ]));
     renderDialog();
 
-    await user.type(await screen.findByLabelText('Search name or model ID'), 'bright');
+    await waitFor(() => expect((screen.getByLabelText('Search name or model ID') as HTMLInputElement).disabled).toBe(false));
+    await user.type(screen.getByLabelText('Search name or model ID'), 'bright');
     expect(screen.queryByRole('button', { name: 'Reorder beta' })).toBeNull();
     expect(screen.getByRole('button', { name: 'Reorder Bright Alpha' }).hasAttribute('disabled')).toBe(true);
 
@@ -665,7 +691,7 @@ describe('BackendModelCatalogDialog', () => {
           vi.spyOn(modelsApi, 'getAgentModelCandidates')
             .mockResolvedValueOnce(offered({ providers: [shown] }))
             .mockResolvedValue(offered({ providers: [current] }));
-          await user.click(await screen.findByRole('button', { name: 'Add models' }));
+          await user.click(await enabledAddModels());
           await user.click(await screen.findByRole('checkbox', { name: /Primary relay/ }));
           await user.click(screen.getByRole('button', { name: 'Add 1 model' }));
           // On the added row itself: the refusal is about its suppliers, and
@@ -795,7 +821,7 @@ describe('BackendModelCatalogDialog', () => {
         .mockResolvedValue(agent([EDITED, model('beta')]));
       const { onSaved, onClose } = renderDialog();
 
-      await user.click(await screen.findByRole('button', { name: 'Add models' }));
+      await user.click(await enabledAddModels());
       await user.click(await screen.findByRole('checkbox', { name: /Primary relay/ }));
       await user.click(screen.getByRole('button', { name: 'Add 1 model' }));
       await widen(user, 'alpha');
@@ -845,7 +871,7 @@ describe('BackendModelCatalogDialog', () => {
         .mockResolvedValue(agent([...CATALOG, model('glm-5.2')]));
       const { onSaved } = renderDialog();
 
-      await user.click(await screen.findByRole('button', { name: 'Add models' }));
+      await user.click(await enabledAddModels());
       await user.click(await screen.findByRole('checkbox', { name: /GLM 5\.2/ }));
       await user.click(screen.getByRole('button', { name: 'Add 1 model' }));
       await user.click(await screen.findByRole('button', { name: 'Save' }));
@@ -943,7 +969,7 @@ describe('BackendModelCatalogDialog', () => {
         .mockResolvedValue(agent([...CATALOG, model('kimi-3')]));
       renderDialog();
 
-      await user.click(await screen.findByRole('button', { name: 'Add models' }));
+      await user.click(await enabledAddModels());
       await user.click(await screen.findByRole('checkbox', { name: /GLM 5\.2/ }));
       await user.click(screen.getByRole('checkbox', { name: /Kimi 3/ }));
       await user.click(screen.getByRole('button', { name: 'Add 2 models' }));
@@ -979,7 +1005,7 @@ describe('BackendModelCatalogDialog', () => {
         .mockResolvedValue(agent(CATALOG));
       renderDialog();
 
-      await user.click(await screen.findByRole('button', { name: 'Add models' }));
+      await user.click(await enabledAddModels());
       await user.click(await screen.findByRole('checkbox', { name: /Primary relay/ }));
       await user.click(screen.getByRole('button', { name: 'Add 1 model' }));
       await user.click(await screen.findByRole('button', { name: 'Save' }));
@@ -1017,7 +1043,7 @@ describe('BackendModelCatalogDialog', () => {
         .mockResolvedValue(agent(CATALOG));
       renderDialog();
 
-      await user.click(await screen.findByRole('button', { name: 'Add models' }));
+      await user.click(await enabledAddModels());
       await user.click(await screen.findByRole('checkbox', { name: /Primary relay/ }));
       await user.click(screen.getByRole('button', { name: 'Add 1 model' }));
       await user.click(await screen.findByRole('button', { name: 'Save' }));

--- a/ui/src/components/settings/models/BackendModelPickerDialog.test.tsx
+++ b/ui/src/components/settings/models/BackendModelPickerDialog.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen, waitFor, within } from '@testing-library/react';
+import { act, cleanup, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { I18nextProvider } from 'react-i18next';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -63,6 +63,33 @@ afterEach(() => {
 });
 
 describe('BackendModelPickerDialog', () => {
+  it('keeps the visible dialog unready until the candidate read completes', async () => {
+    const user = userEvent.setup();
+    let finishRead!: (value: BackendModelCandidates) => void;
+    const pendingRead = new Promise<BackendModelCandidates>((resolve) => { finishRead = resolve; });
+    vi.spyOn(modelsApi, 'getAgentModelCandidates').mockReturnValue(pendingRead);
+    const { onAdd } = renderPicker();
+
+    expect(screen.getByRole('heading', { name: 'Add Claude Code models' })).toBeTruthy();
+    expect(confirm().textContent).toBe('Add models');
+    expect(confirm().disabled).toBe(true);
+    expect((search() as HTMLInputElement).disabled).toBe(true);
+    expect(screen.queryByRole('group')).toBeNull();
+    expect(screen.queryByText('No model matches.')).toBeNull();
+    await user.type(search(), 'ignored while loading');
+    expect((search() as HTMLInputElement).value).toBe('');
+
+    await act(async () => {
+      finishRead(read({ builtin: [candidate('gpt-6', { origin: 'builtin' })] }));
+    });
+
+    expect(group(BUILT_IN).getByRole('checkbox', { name: 'gpt-6' })).toBeTruthy();
+    expect((search() as HTMLInputElement).disabled).toBe(false);
+    expect(confirm().textContent).toBe('Add models');
+    expect(confirm().disabled).toBe(true);
+    expect(onAdd).not.toHaveBeenCalled();
+  });
+
   it('shows each group as the server served it, and every row as what it can say', async () => {
     answers({
       builtin: [candidate('gpt-6', { origin: 'builtin' }), candidate('gpt-6-mini', { origin: 'builtin' })],
@@ -77,6 +104,7 @@ describe('BackendModelPickerDialog', () => {
     renderPicker();
 
     expect(await screen.findByRole('heading', { name: 'Add Claude Code models' })).toBeTruthy();
+    await screen.findByRole('group', { name: BUILT_IN });
     // A built-in row has nothing but an id, so the id is its label rather than a
     // sub-line under an empty one.
     expect(group(BUILT_IN).getAllByRole('checkbox').map((row) => row.textContent))
@@ -132,7 +160,8 @@ describe('BackendModelPickerDialog', () => {
     answers({ builtin: [candidate('gpt-6', { origin: 'builtin' })] });
     const { onAdd } = renderPicker();
 
-    await waitFor(() => expect(confirm().textContent).toBe('Add models'));
+    await screen.findByRole('checkbox', { name: 'gpt-6' });
+    expect(confirm().textContent).toBe('Add models');
     expect(confirm().disabled).toBe(true);
 
     await user.click(screen.getByRole('checkbox', { name: 'gpt-6' }));
@@ -185,7 +214,8 @@ describe('BackendModelPickerDialog', () => {
     answers({ builtin: [candidate('gpt-6', { origin: 'builtin' })] });
     const { onCustom } = renderPicker();
 
-    await user.type(await screen.findByLabelText('Search models or providers'), '  gemini-4  ');
+    await waitFor(() => expect((search() as HTMLInputElement).disabled).toBe(false));
+    await user.type(search(), '  gemini-4  ');
     expect(screen.getByText('No model matches.')).toBeTruthy();
     // The query is the id the user has already typed once. Asking for it again
     // in the next dialog would be this one forgetting.


### PR DESCRIPTION
## Summary

Fix premature model-dialog test actions by waiting for actual candidate/catalog
readiness. The picker title, confirmation label, search fields, and catalog Add
models button exist while reads are still pending; their presence is not readiness.

- Fix the three picker waits diagnosed from master UI failure
  [33976469074](https://github.com/avibe-bot/avibe/actions/runs/33976469074).
- During full UI validation, the unchanged catalog locked-row test failed for the
  same reason. A complete delayed-read probe identified twelve catalog cases in
  that class. Wait for real rows or enabled controls there too.
- Add explicit deferred-response loading/readiness regressions for both dialogs.

Scope: two model-dialog test files and `docs/plans/ci-model-picker-readiness.md`.
The orchestrator extended the initial picker-only scope after observing and
reproducing the adjacent catalog failure. No production, workflow, dependency,
timeout, runner, or test-selection changes.

## Evidence

- Controlled 250 ms response delay: original picker **3 failed / 5 passed**;
  fixed picker **9 passed**. Original catalog **12 failed / 22 passed**;
  fixed catalog **35 passed**. The delay is in disposable in-memory probes, not
  committed tests or production code.
- Focused suites: **44 passed**; full UI: **287 files / 3816 tests passed**.
- Test typecheck, theme validation, lint baseline and production build passed.
  Lint was checked after the test suite: an initial concurrent lint run saw the
  suite's deliberately invalid temporary integrity fixture, which was removed by
  the test's normal `finally` cleanup. CI already runs these sequentially.
- AST assertion inventory: all **207 original assertions across 39 definitions
  (42 expanded cases)** retained. One existing locked-row query becomes async;
  no expected value is weakened. The two deferred regressions add coverage.
- Affected existing scenario: `MH-MENU-COMPOSE-001`, plus catalog stale-candidate
  and guarded replay cases covered by their unchanged assertions.

## Known by Design / Dependencies

- No dependencies on unmerged work. Base: `616aa5df5` on master.
- This is test synchronization, not a product model-loading defect or a CI
  speedup claim. Original three picker waits date to #1839, not #1890.
- No fixed sleeps, retries, fake clocks or timeout changes in committed tests.
  Existing error/legacy paths remain separately tested; render helpers do not
  silently wait for successful data.
- No model credentials, inference, production state, service restarts or remote
  regression environments are involved. Live-model/manual UI acceptance is not
  required for this test-only change; full expected CI and bot review still gate it.

## Review Inventory

Initial head: zero findings-bearing reviewed heads. All future findings will be
classified by reviewed head and root cause before edits under the delivery loop.
