### PR TITLE
feat(prompt): add persistent agent working principles

### DIFF
--- a/core/prompt_registry.py
+++ b/core/prompt_registry.py
@@ -73,6 +73,7 @@ class PromptModule:
 # prompt structure changes, never because filesystem enumeration changed.
 PROMPT_MODULES: tuple[PromptModule, ...] = (
     PromptModule("base-capabilities-intro", "Base Capabilities Intro", "base-capabilities-intro.md", trailing_newlines=2),
+    PromptModule("agent-working-principles", "Agent Working Principles", "agent-working-principles.md", trailing_newlines=2),
     PromptModule("base-capabilities-body", "Base Capabilities Body", "base-capabilities.md", trailing_newlines=1),
     PromptModule("codex-generated-images", "Codex-generated images", "codex-generated-images.md", leading_newlines=1, trailing_newlines=1, placeholders=("example_uri",)),
     PromptModule("show-pages-prompt", "Show Pages Prompt", "show-pages.md", leading_newlines=1, trailing_newlines=1),

--- a/core/prompts/agent-working-principles.md
+++ b/core/prompts/agent-working-principles.md
@@ -1,0 +1,10 @@
+You are a long-lived AGI that exercises independent judgment and takes responsibility for long-term outcomes.
+
+- **Understand the goal.** Start with the real-world change the user wants. Use context to identify necessary implicit needs, and distinguish discussion, investigation, and execution.
+- **Exercise independent judgment.** Reason from facts, constraints, and causal relationships. Proactively identify problems and recommend solutions. Treat feedback as new evidence and revise your judgment around the original goal.
+- **Take initiative.** Do everything within your capabilities to gather information, complete necessary steps, and act. When facing major trade-offs, irreversible risks, or genuine ambiguity about direction, seek confirmation with a recommendation.
+- **Reason and choose.** Understand problems through first principles. Choose solutions using Occam’s razor. Seek the smallest complete solution.
+- **Follow through.** Continue while the goal remains unmet and a viable path exists. When repeatedly blocked, revisit assumptions and root causes; when necessary, step back from local details and reconsider the approach from a higher-level perspective. When waiting, define the conditions for resuming; when unable to proceed, explain the blocker.
+- **Verify and communicate.** Confirm outcomes with practical evidence appropriate to the task. Distinguish facts, inferences, and unverified claims. Lead with the conclusion, and clearly explain implications, key trade-offs, and decisions requiring the user’s input.
+
+Weigh these principles against the actual context and the user’s preferences, without taking any one principle to an extreme.

--- a/core/system_prompt_injection.py
+++ b/core/system_prompt_injection.py
@@ -26,6 +26,8 @@ logger = logging.getLogger(__name__)
 #   health. Runtime policy belongs in the enforcing layer, not in its description.
 # - Keep every generated collection deterministic, including Agent and Skill order.
 # - Required built-in Skill routing is unconditional; installation guarantees it.
+# - Working principles are a static, unconditional prefix before Session and
+#   capability details; never gate them on a backend, Skill, or Turn.
 # - Author all injected prose in the registry. Production text and debug JSON
 #   must consume the same ordered rendered blocks; Studio never assembles prose.
 
@@ -217,7 +219,10 @@ def build_system_prompt_blocks(
         skill.name == "use-avibe-vault" for skill in advertisable_skills
     )
 
-    blocks = [render_prompt_block("base-capabilities-intro")]
+    blocks = [
+        render_prompt_block("base-capabilities-intro"),
+        render_prompt_block("agent-working-principles"),
+    ]
     if context is not None:
         blocks.append(render_prompt_block("session-start-prompt", default_session_id=_extract_default_session_id(context)))
         correction = build_forked_session_correction_prompt(context)

--- a/tests/test_prompt_render_export.py
+++ b/tests/test_prompt_render_export.py
@@ -70,6 +70,10 @@ def test_export_reconstructs_production_text_with_source_for_every_block(monkeyp
 
     assert result["text"] == production
     assert "".join(block["text"] for block in result["blocks"]) == production
+    principles = prompt_text("agent-working-principles")
+    assert production.count(principles) == 1
+    assert production.index(principles) < production.index(prompt_text("base-capabilities-body"))
+    assert [block["text"] for block in result["blocks"] if block["id"] == "agent-working-principles"] == [principles]
     catalog = {module.id: module for module in PROMPT_MODULES}
     for block in result["blocks"]:
         assert block["source_path"] == catalog[block["id"]].source_path
@@ -81,6 +85,28 @@ def test_export_reconstructs_production_text_with_source_for_every_block(monkeyp
         assert "- skill-00: Description skill-00" in production
     assert ("## Personal Memory" in production) == memory
     assert ("preferences.md" in production) != memory
+
+
+@pytest.mark.parametrize("backend", ["claude", "codex", "opencode"])
+def test_working_principles_remain_without_session_skills_or_optional_capabilities(backend):
+    request = {
+        "backend": backend,
+        "options": {
+            "include_quick_replies": False,
+            "include_show_pages": False,
+            "include_codex_generated_images": False,
+            "include_context_guidance": False,
+        },
+    }
+    rendered = render_prompt_context(request)
+    blocks = rendered["blocks"]
+    if backend == "codex":
+        blocks = blocks[1:-1]
+    assert [block["id"] for block in blocks] == [
+        "base-capabilities-intro", "agent-working-principles", "base-capabilities-body",
+    ]
+    assert blocks[1]["text"] == prompt_text("agent-working-principles")
+    assert rendered == render_prompt_context(request)
 
 
 def test_exported_sources_cover_all_rendered_branches(monkeypatch):
@@ -284,13 +310,17 @@ def test_cli_localizes_invalid_context_files(monkeypatch, tmp_path, capsys, lang
     assert output.err == cli.i18n_t("debug.cli.error.promptExport", language, error=error) + "\n"
 
 
-def test_source_migration_preserves_injection_bytes(monkeypatch):
+def test_working_principles_addition_preserves_all_other_injection_bytes(monkeypatch):
     outputs = []
     for backend, memory, history, skill_mode in itertools.product(
         ("claude", "codex", "opencode"), (False, True), ("off", "managed", "self-managed"), ("empty", "manual", "pages"),
     ):
         _environment(monkeypatch, history, skill_mode)
-        outputs.append(render_prompt_context(_inputs(backend, memory, history, skill_mode))["text"])
+        rendered = render_prompt_context(_inputs(backend, memory, history, skill_mode))["text"]
+        principles = prompt_text("agent-working-principles")
+        assert rendered.count(principles) == 1
+        outputs.append(rendered.replace(principles, "", 1))
     digest = hashlib.sha256(json.dumps(outputs, ensure_ascii=False).encode()).hexdigest()
     # Captured from the pre-migration renderer at 928924dd82bb48c7eea67ff06ddd844d442cb2a1.
+    # Only the approved working-principles block may differ from that baseline.
     assert digest == "adbf608248e0b0a03d6646f57d31816cdb520c86113225e281b2aa007b100bc5"

--- a/tests/test_prompt_studio_catalog.py
+++ b/tests/test_prompt_studio_catalog.py
@@ -21,8 +21,9 @@ def test_every_prompt_markdown_file_has_one_stably_ordered_registry_entry() -> N
 
     assert len(registered) == len(set(registered))
     assert sorted(registered) == present
-    assert [module.id for module in PROMPT_MODULES[:3]] == [
+    assert [module.id for module in PROMPT_MODULES[:4]] == [
         "base-capabilities-intro",
+        "agent-working-principles",
         "base-capabilities-body",
         "codex-generated-images",
     ]


### PR DESCRIPTION
## Outcome

Add the owner-approved English working principles as an always-on Avibe System Prompt module. The prose is unchanged from the approved version (302 tokens with o200k_base).

## Scope

- Keep one authoritative Markdown source, registered as `agent-working-principles` and titled `Agent Working Principles` in Prompt Studio.
- Render it once immediately after the Avibe heading, before Session and capability details, for Claude, Codex, and OpenCode.
- Use the existing production renderer and `vibe debug prompt export` path. No new configuration, placeholders, conditional routing, or Studio-side source copy.
- Preserve every pre-existing prompt module and its byte boundaries.

## Evidence

- Unit/contract: 662 tests and 68 subtests passed across prompt export, capability injection, managed Skills, and all three backend adapters. One pre-existing raw-byte filename fixture is skipped on macOS.
- Rendering scenarios: 108 combinations of backend, Memory, Show history, and Skill catalog state include the new block once. Removing only that block reproduces the unchanged pre-existing golden digest.
- Minimal scenarios: all three backends retain the block without a Session, Skills, or optional capabilities.
- Cache stability: repeated rendering, a changed Turn message ID, and reversed Agent enumeration retain identical output when content is unchanged.
- Real CLI: exported JSON includes the new source-addressable block with the exact 1,665-character / 226-word approved source. Full-repository Ruff and `git diff --check` passed.
- Local tests used a task-local environment with inherited managed-Skill path bindings removed from the test process.

## Dependencies And Rollout

No PR or package dependency. This changes authored prompt content once at deployment; it adds no per-Turn cache churn. No live runtime or Studio cutover has been performed. After merge and updating the master-bound installation, the existing source refresh and backend prompt-delivery paths pick up the module. Model-behavior acceptance with live Agents remains a post-deployment observation, not a claim made by these rendering tests.
