### PR TITLE
fix(ci): stabilize tool bootstrap and expose upgrade failures

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -144,13 +144,15 @@ jobs:
         with:
           python-version: "3.12"
 
-      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
+      # Exact setup-uv versions still fetch a remote manifest on a cold runner.
+      - name: Install pinned uv
+        run: |
+          python -m pip install --disable-pip-version-check --only-binary=:all: --no-deps uv==0.12.10
+
+      - uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25  # v5
         with:
-          enable-cache: true
-          save-cache: false
-          cache-dependency-glob: |
-            pyproject.toml
-            uv.lock
+          path: ~/.cache/uv
+          key: ${{ runner.os }}-${{ runner.arch }}-ci-uv-0.12.10-py3.12-${{ hashFiles('pyproject.toml', 'uv.lock') }}
 
       - name: Install package and test deps
         # Install the declared dev group instead of a hand-listed set so test
@@ -190,11 +192,14 @@ jobs:
         with:
           python-version: "3.12.12"
 
-      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
+      - name: Install pinned uv
+        run: |
+          python -m pip install --disable-pip-version-check --only-binary=:all: --no-deps uv==0.9.18
+
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5
         with:
-          version: "0.9.18"
-          enable-cache: true
-          cache-dependency-glob: scripts/memory_runtime/uv.lock
+          path: ~/.cache/uv
+          key: ${{ runner.os }}-${{ runner.arch }}-ci-memory-uv-0.9.18-py3.12.12-${{ hashFiles('scripts/memory_runtime/uv.lock') }}
 
       - name: Provision pinned Memory Runtime
         run: uv sync --frozen --project scripts/memory_runtime
@@ -236,13 +241,14 @@ jobs:
         with:
           python-version: "3.12"
 
-      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
+      - name: Install pinned uv
+        run: |
+          python -m pip install --disable-pip-version-check --only-binary=:all: --no-deps uv==0.12.10
+
+      - uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25  # v5
         with:
-          enable-cache: true
-          save-cache: false
-          cache-dependency-glob: |
-            pyproject.toml
-            uv.lock
+          path: ~/.cache/uv
+          key: ${{ runner.os }}-${{ runner.arch }}-ci-uv-0.12.10-py3.12-${{ hashFiles('pyproject.toml', 'uv.lock') }}
 
       - name: Install package and test deps
         run: uv pip install --system -e . --group dev
@@ -308,12 +314,14 @@ jobs:
         with:
           python-version: "3.12"
 
-      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
+      - name: Install pinned uv
+        run: |
+          python -m pip install --disable-pip-version-check --only-binary=:all: --no-deps uv==0.12.10
+
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5
         with:
-          enable-cache: true
-          cache-dependency-glob: |
-            pyproject.toml
-            uv.lock
+          path: ~/.cache/uv
+          key: ${{ runner.os }}-${{ runner.arch }}-ci-uv-0.12.10-py3.12-${{ hashFiles('pyproject.toml', 'uv.lock') }}
 
       - name: Install package and test dependencies
         run: |

--- a/docs/plans/ci-toolchain-and-upgrade-probe.md
+++ b/docs/plans/ci-toolchain-and-upgrade-probe.md
@@ -1,0 +1,67 @@
+# CI Toolchain and Upgrade Failure Evidence
+
+## Ordered Scope
+
+The owner approved stability diagnosis before further test preparation savings
+and, only after complete multi-run evidence, shard balancing. This first change
+owns CI tool installation and the missing evidence from the historical upgrade
+fixture. It does not declare the full optimization request complete.
+
+## Observations
+
+- At `2f7d9a21c5`, run `33998201417` failed before Python tests: setup-uv
+  could not fetch `astral-sh/versions/main/v1/uv.ndjson`.
+- Inspection of setup-uv `11f9893b081a58869d3b5fccaea48c9e9e46f990`
+  shows that exact versions bypass latest-version resolution but cold downloads
+  still call `getArtifact`, which fetches that manifest. Pinning alone would not
+  remove the observed dependency.
+- At `0abad3c5b8`, run `33996154247` passed all 21 distribution contracts,
+  then the real 3.0.13 upgrade fixture timed out waiting for split Memory.
+  Core upgraded to 9999.0.0, but the observed launcher still pointed to an
+  environment without avibe-memory. The fixture deleted the container without
+  reporting its background install state or service logs.
+- A local isolated probe used the SHA-256-verified published 3.0.13 wheel and
+  its real config API, then loaded the resulting file with source `67cb0bc313`.
+  The recovery warning concerns Model Hub; Memory remains enabled and required.
+  This rules out disabled Memory from that recovery as the explanation. It does
+  not establish why the failed CI installation did not complete.
+
+## Smallest Current Change
+
+- Install uv directly with Python's existing pip, exact versions and binary-only,
+  dependency-free package selection. Keep the known green 0.12.10 for core CI and
+  the existing 0.9.18 contract for the pinned Memory Runtime. This removes the
+  additional remote versions-manifest lookup, not every network dependency.
+- Replace setup-uv's implicit cache ownership with SHA-pinned actions/cache v5.
+  Unit shards and migration history only restore; installer runners and the
+  isolated Memory Runtime populate their respective caches. Keys retain OS,
+  architecture, Python, uv and dependency identities. No new application dependency.
+- On an upgrade fixture failure, print bounded tails of only its explicit runtime
+  logs and automatic Memory repair state before Docker cleanup. Do not print its
+  config or entire state directory, change the exit status, increase timeouts, or
+  retry the upgrade. Preserve the real released-wheel and service-start assertions.
+
+## Invariants and Validation
+
+All 17 gates, per-file isolation, 300-second watchdog, 20-minute shard bound,
+real migration and install coverage remain. Tool installation and required
+dependencies must fail closed. Native contracts cover command execution and
+failure evidence on success, failure and nonstandard exit codes.
+
+The old upgrade failure remains unexplained until reproducible evidence or the
+new runtime diagnostics identify its cause; a subsequent green run is not proof
+of a fix. Docker is unavailable on the local workstation, so the real container
+case must run in the unchanged installer CI gate. Further approved work will
+profile resource-access/CLI/update-checker setup before changing fixtures, and
+will not rebalance from runner variance alone.
+
+Local evidence: 55 workflow/shard/fixture/diagnostic contracts and 188 original
+installer/upgrade cases passed. Ruff 0.4.9, dependency consistency and whitespace
+checks passed; the actual binary-only pip install produced uv 0.12.10 in the
+private worktree environment. The Docker case is excluded locally, not removed
+from CI. The first new cache key is necessarily cold and must not be compared as
+though cache warmth were held constant.
+
+Integration inspection: master `2f92bd009` adds optional Memory sender-name
+propagation. Its producer, writer retry/downgrade consumer and tests were inspected;
+it does not overlap this four-file scope or change package-install admission.

--- a/tests/e2e/test_upgrade_command.py
+++ b/tests/e2e/test_upgrade_command.py
@@ -26,6 +26,29 @@ INITIAL_RELEASE_WHEEL_SHA256 = "994adbfd23228ea387f0479db8a4efe0ef121847bd04efa5
 TEST_RELEASE_VERSION = "9999.0.0"
 
 _UPGRADE_WAIT_HELPERS = r"""
+report_upgrade_failure() {
+    local exit_code="$1"
+    local relative_path
+    if [ "$exit_code" -eq 0 ]; then
+        return 0
+    fi
+
+    printf 'Upgrade fixture failed (exit %s); isolated runtime diagnostics:\n' "$exit_code" >&2
+    for relative_path in \
+        state/memory-package-auto-repair.json \
+        runtime/ui_stderr.log runtime/ui_stdout.log \
+        runtime/service_stderr.log runtime/service_stdout.log \
+        logs/vibe_remote.log; do
+        printf '\n--- %s ---\n' "$relative_path" >&2
+        if [ -f "$AVIBE_HOME/$relative_path" ]; then
+            tail -c 32768 "$AVIBE_HOME/$relative_path" >&2 || true
+        else
+            printf 'not created\n' >&2
+        fi
+    done
+    return "$exit_code"
+}
+
 resolve_vibe_runtime() {
     local launcher_var="$1"
     local resolved_var="$2"
@@ -257,6 +280,34 @@ def test_upgrade_wait_reports_the_last_observation_on_exhaustion(
     assert last_observation in result.stderr
 
 
+@pytest.mark.parametrize("exit_code", [0, 1, 7])
+def test_upgrade_failure_trap_preserves_exit_and_bounded_runtime_evidence(tmp_path, exit_code):
+    state = tmp_path / "state"
+    state.mkdir()
+    (state / "memory-package-auto-repair.json").write_text('{"reason":"memory_package_install_failed"}')
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    (runtime / "ui_stderr.log").write_text("discarded-prefix" + "x" * 32768 + "startup-failure")
+    config = tmp_path / "config"
+    config.mkdir()
+    (config / "config.json").write_text("do-not-print-config")
+    result = _run_upgrade_wait_helper(
+        f"export AVIBE_HOME={shlex.quote(str(tmp_path))}\n"
+        "trap 'report_upgrade_failure $?' EXIT\n"
+        f"(exit {exit_code}) && echo fixture-success"
+    )
+    assert result.returncode == exit_code
+    if exit_code:
+        assert "memory_package_install_failed" in result.stderr
+        assert "startup-failure" in result.stderr
+        assert "not created" in result.stderr
+        assert "discarded-prefix" not in result.stderr
+        assert "do-not-print-config" not in result.stderr
+        assert len(result.stderr) < 34000
+    else:
+        assert result.stderr == ""
+
+
 @pytest.mark.integration
 def test_memory_indep_026_upgrade_command_bridges_released_3_0_13_generation():
     """The released bundled-Memory upgrader converges onto the split package pair."""
@@ -307,6 +358,7 @@ def test_memory_indep_026_upgrade_command_bridges_released_3_0_13_generation():
                 "curl -LsSf https://astral.sh/uv/install.sh | sh",
                 'export PATH="$HOME/.local/bin:$PATH"',
                 'export AVIBE_HOME="$HOME/.avibe-upgrade-test"',
+                "trap 'report_upgrade_failure $?' EXIT",
                 "VIBE_INSTALL_SKIP_NODE=1 VIBE_INSTALL_SKIP_SHOW_RUNTIME=1 "
                 f"AVIBE_INSTALL_PACKAGE_SPEC=/fixtures/{initial_wheel_path.name} bash /work/install.sh",
                 'export PATH="$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin"',

--- a/tests/test_ci_pipeline.py
+++ b/tests/test_ci_pipeline.py
@@ -5,6 +5,7 @@ import io
 import json
 import os
 from pathlib import Path
+import shlex
 import shutil
 import subprocess
 import sys
@@ -18,6 +19,59 @@ ROOT = Path(__file__).resolve().parents[1]
 
 def _jobs() -> dict:
     return yaml.safe_load((ROOT / ".github/workflows/lint.yml").read_text())["jobs"]
+
+
+def test_ci_uv_installation_is_exact_and_cache_ownership_is_preserved():
+    owners = {
+        name: job for name, job in _jobs().items()
+        if any(step.get("run", "").startswith("uv ") for step in job["steps"])
+    }
+    assert set(owners) == {
+        "unit-test-shards", "migration-release-guard", "install-upgrade-shards", "memory-insight-contract",
+    }
+    cache_keys = {}
+    for name, job in owners.items():
+        steps = job["steps"]
+        install, = [step for step in steps if step.get("name") == "Install pinned uv"]
+        version = "0.9.18" if name == "memory-insight-contract" else "0.12.10"
+        assert shlex.split(install["run"]) == [
+            "python", "-m", "pip", "install", "--disable-pip-version-check",
+            "--only-binary=:all:", "--no-deps", f"uv=={version}",
+        ]
+        assert not install.get("if") and not install.get("continue-on-error")
+        assert any(step.get("uses", "").startswith("actions/setup-python@") for step in steps[:steps.index(install)])
+        assert not any(step.get("uses", "").startswith("astral-sh/setup-uv@") for step in steps)
+        cache, = [step for step in steps if step.get("uses", "").startswith("actions/cache")]
+        action = "actions/cache/restore" if name in {"unit-test-shards", "migration-release-guard"} else "actions/cache"
+        assert cache["uses"] == f"{action}@caa296126883cff596d87d8935842f9db880ef25"
+        assert cache["with"]["path"] == "~/.cache/uv"
+        key = cache["with"]["key"]
+        assert "${{ runner.os }}-${{ runner.arch }}" in key and f"uv-{version}-py3.12" in key
+        dependencies = "'scripts/memory_runtime/uv.lock'" if name == "memory-insight-contract" else "'pyproject.toml', 'uv.lock'"
+        assert f"hashFiles({dependencies})" in key
+        cache_keys[name] = key
+        first_consumer = next(step for step in steps if step.get("run", "").startswith("uv "))
+        assert steps.index(install) < steps.index(cache) < steps.index(first_consumer)
+    assert len({cache_keys[name] for name in owners if name != "memory-insight-contract"}) == 1
+    assert cache_keys["memory-insight-contract"] != cache_keys["install-upgrade-shards"]
+
+
+@pytest.mark.parametrize("exit_code", [0, 1, 7])
+def test_ci_tool_install_command_propagates_failure(tmp_path, exit_code):
+    binary = tmp_path / "bin"
+    binary.mkdir()
+    python = binary / "python"
+    python.write_text(f"#!/bin/sh\nprintf '%s\\n' \"$@\"\nexit {exit_code}\n")
+    python.chmod(0o755)
+    for job in _jobs().values():
+        for step in job["steps"]:
+            if step.get("name") == "Install pinned uv":
+                result = subprocess.run(
+                    [shutil.which("bash"), "-e", "-c", step["run"]], cwd=tmp_path,
+                    env={**os.environ, "PATH": str(binary)}, capture_output=True, text=True,
+                )
+                assert result.returncode == exit_code
+                assert "--only-binary=:all:" in result.stdout
 
 
 def _run_isolated_unit_files(tmp_path: Path, sources: dict[str, str], *, timeout: str = "15"):


### PR DESCRIPTION
## Summary

Remove a demonstrated CI bootstrap failure path and preserve the evidence needed
to diagnose an intermittent historical upgrade timeout. This is the first stage
of the owner's approved stability -> repeated test preparation -> measured shard
review order, not a claim that the full optimization request is complete.

Scope: `.github/workflows/lint.yml`, `tests/test_ci_pipeline.py`,
`tests/e2e/test_upgrade_command.py`, and
`docs/plans/ci-toolchain-and-upgrade-probe.md`. No application behavior change.

## Diagnosis and Change

- Run 33998201417 at 2f7d9a21c5 failed in setup-uv before tests while fetching
  `uv.ndjson`. The pinned v8.3.2 source fetches this manifest even with an exact
  version on cold runners. Install exact binary-only uv packages through existing
  pip instead; keep core CI at the observed green 0.12.10 and Memory Runtime at
  its existing 0.9.18. SHA-pinned actions/cache v5 preserves separate cache keys,
  restore-only unit/history jobs, and installer/Memory writers.
- Run 33996154247 at 0abad3c5b8 timed out in MEMORY-INDEP-026 after the core
  upgrade. It did not retain background repair state or service logs before
  deleting the container. An EXIT trap now emits bounded, explicit test-runtime
  evidence on failure without changing the original exit, wait or assertions.
- A real, hash-verified 3.0.13 wheel config probe rules out the visible Model Hub
  recovery warning disabling Memory: the new core still projects Memory required.
  The historic timeout's remaining cause is **not yet established**.

## Evidence

- 55 workflow, shard, isolation and diagnostic contracts passed.
- 188 original installer/upgrade unit cases passed.
- After integrating master 2f92bd009 (#1885), 113 workflow, upgrade-helper and
  Memory adapter/writer cases passed; producer/consumer changes independently inspected.
- Real binary-only pip installation verified uv 0.12.10 in a private environment.
- Ruff 0.4.9, pip consistency and whitespace checks passed.
- Docker is unavailable locally. The unchanged real released-wheel upgrade and
  all 21 distribution contracts remain mandatory in the installer CI job.

## Gates and Known by Design

- All 17 existing checks, six shards, test selection, isolation, real migrations,
  Memory/Windows/package verification, 300-second per-file and 20-minute outer
  bounds, and fail-closed aggregates stay intact. No retries or longer waits.
- A new cache identity is initially cold; compare actual CI timings honestly.
- Exact tool selection removes a manifest dependency, not all network dependencies.
- Config and the full state directory are not printed. The log tail applies only
  to the synthetic, isolated Docker fixture, which has no production credentials.
- No dependencies on unmerged PRs. No release/install/service operations requested.
- Initial review inventory: zero findings-bearing heads. Full current-head review,
  every matching lint run, all whole-PR threads and CLEAN integration gate required.

After stability verification, continue profiling ACL/CLI/update-checker preparation
before choosing a bounded fixture change; do not rebalance from runner variance.
