### PR TITLE
fix(memory): accept sender names at sidecar capture boundary

### DIFF
--- a/avibe_memory/sidecar.py
+++ b/avibe_memory/sidecar.py
@@ -341,7 +341,17 @@ def _validate_add(
     if not _valid_session(payload.get("session_id")) or not isinstance(messages, list) or len(messages) != 1:
         return "add"
     message = messages[0]
-    if not isinstance(message, dict) or set(message) != {"sender_id", "role", "timestamp", "content"}:
+    required_fields = {"sender_id", "role", "timestamp", "content"}
+    if (
+        not isinstance(message, dict)
+        or not required_fields <= set(message) <= required_fields | {"sender_name"}
+    ):
+        return "add"
+    if "sender_name" in message and (
+        not isinstance(message["sender_name"], str)
+        or not message["sender_name"].strip()
+        or len(message["sender_name"]) > 128
+    ):
         return "add"
     if (
         not _valid_principal(message.get("sender_id"))

--- a/docs/plans/memory-sender-name-sidecar-403.md
+++ b/docs/plans/memory-sender-name-sidecar-403.md
@@ -1,0 +1,33 @@
+# Sender-name sidecar request contract
+
+Follow-up to #1885, merged as `2f92bd009f13`. The installed
+`3.0.15rc1+pr1885.fa13e5411` producer sends `messages[].sender_name`, but its
+sidecar guard permits exactly the four older fields. New captures receive
+HTTP 403 even though health and historical reads succeed. The mismatch is
+also present in base commit `16ca51b64`.
+
+## Change contract
+
+Accept an optional nonblank string `sender_name` of at most 128 characters,
+matching the producer's normalized name bound. Keep required fields, unknown
+field rejection, identity checks, and content validation unchanged. Older
+requests without names remain valid. Do not strip names or bypass the guard.
+
+## Evidence
+
+- Unit: valid Unicode names, length boundaries, user/Agent owner IDs, plain
+  and structured content, malformed names, and scope-preservation cases.
+- Contract/scenario: MEMORY-SEARCH-019 now runs actual automatic and explicit
+  capture payloads through the real sidecar request guard, in both UI languages,
+  before acknowledging them through a mocked transport. Local Web, Cloud Web,
+  Slack, and Agent-owned captures retain identity and original text.
+- Red/green: both scenario variants fail against the unchanged guard before
+  applying the fix. All tests use test-owned state and mocked provider egress.
+- Residual manual: deploy an approved normal package, then verify a new Web
+  capture's add response and processed record. Deployment, host restart, and
+  recovery/replay of previously rejected messages are not part of this PR.
+
+## Scope
+
+No credential changes, schema changes, old-memory rewriting, automatic replay,
+or failure-history redesign. A healthy runtime alone is not a capture verdict.

--- a/tests/test_memory_everos.py
+++ b/tests/test_memory_everos.py
@@ -73,13 +73,15 @@ def _sidecar_transport(handler):
     return patch("avibe_memory.everos.httpx.AsyncHTTPTransport", return_value=httpx.MockTransport(handler))
 
 
-def test_sender_name_crosses_automatic_and_explicit_capture_http_boundary(tmp_path) -> None:
+@pytest.mark.parametrize("language", ["en", "zh"])
+def test_sender_name_crosses_automatic_and_explicit_capture_http_boundary(tmp_path, language) -> None:
     """MEMORY-SEARCH-019: accepted source identity survives named provider capture."""
     from types import SimpleNamespace
 
     from avibe_memory.capture_adapter import EnabledMemoryAdapter
     from avibe_memory.module import MIN_FREE_DISK_BYTES, MemoryModule
     from avibe_memory.types import CaptureRequest
+    from avibe_memory.sidecar import _request_rejection
     from core.controller import Controller
     from core.handlers.message_handler import memory_turn_event
     from modules.im.base import MessageContext
@@ -90,6 +92,7 @@ def test_sender_name_crosses_automatic_and_explicit_capture_http_boundary(tmp_pa
     def handler(request):
         payload = json.loads(request.content)
         if request.url.path.endswith("/add"):
+            assert _request_rejection(request.method, request.url.path, request.content) is None
             requests.append(payload)
         return httpx.Response(200, json={"request_id": "synthetic", "data": {"status": "accumulated"}})
 
@@ -103,7 +106,7 @@ def test_sender_name_crosses_automatic_and_explicit_capture_http_boundary(tmp_pa
             disk_free_bytes=lambda: MIN_FREE_DISK_BYTES, effective_home=tmp_path,
         )
         controller = Controller.__new__(Controller)
-        controller.config = SimpleNamespace(memory=SimpleNamespace(enabled=True), language="en")
+        controller.config = SimpleNamespace(memory=SimpleNamespace(enabled=True), language=language)
         controller.memory_runtime = SimpleNamespace(available=True, module=module)
         bound_users = SimpleNamespace(
             maybe_reload=lambda: None,
@@ -144,7 +147,8 @@ def test_sender_name_crosses_automatic_and_explicit_capture_http_boundary(tmp_pa
             ))
             await module.wait_writer_idle_for_tests()
             messages = [payload["messages"][0] for payload in requests]
-            names = ["User", "User", "User", "小王 Élodie 🌱", "小王 Élodie 🌱", "Agent"]
+            web_name = "用户" if language == "zh" else "User"
+            names = [web_name, web_name, web_name, "小王 Élodie 🌱", "小王 Élodie 🌱", "Agent"]
             assert {message["sender_id"]: message["sender_name"] for message in messages} == dict(
                 zip([*expected_owners, principal + "-agent"], names)
             )

--- a/tests/test_memory_sidecar.py
+++ b/tests/test_memory_sidecar.py
@@ -420,6 +420,79 @@ def test_sidecar_guard_allows_derived_principals_and_memory_scope() -> None:
     assert _request_rejection("POST", "/unrelated", b"{}") == "route"
 
 
+@pytest.mark.parametrize("sender_name", ["用户", "User", "小王 Élodie 🌱", "名" * 128])
+@pytest.mark.parametrize("owner_suffix", ["", "-agent"])
+@pytest.mark.parametrize("structured_content", [False, True])
+def test_sidecar_guard_accepts_sender_name_capture_contract(
+    sender_name: str, owner_suffix: str, structured_content: bool
+) -> None:
+    payload = {
+        "session_id": SESSION_ID,
+        "app_id": "avibe",
+        "project_id": PROJECT,
+        "messages": [
+            {
+                "sender_id": f"u-{'1' * 32}{owner_suffix}",
+                "sender_name": sender_name,
+                "role": "user",
+                "timestamp": 1_725_000_001_234,
+                "content": [{"type": "text", "text": "测试"}] if structured_content else "测试",
+            }
+        ],
+    }
+    assert _request_rejection(
+        "POST", "/api/v2/memory/add", json.dumps(payload).encode()
+    ) is None
+
+
+@pytest.mark.parametrize("sender_name", [None, False, 12, [], {}, "", "  ", "名" * 129])
+def test_sidecar_guard_rejects_invalid_sender_name(sender_name: object) -> None:
+    payload = {
+        "session_id": SESSION_ID,
+        "app_id": "avibe",
+        "project_id": PROJECT,
+        "messages": [
+            {
+                "sender_id": f"u-{'1' * 32}",
+                "sender_name": sender_name,
+                "role": "user",
+                "timestamp": 1_725_000_001_234,
+                "content": "text",
+            }
+        ],
+    }
+    assert _request_rejection(
+        "POST", "/api/v2/memory/add", json.dumps(payload).encode()
+    ) == "add"
+
+
+@pytest.mark.parametrize("change", [
+    {"unexpected": "field"},
+    {"sender_id": "owner-1"},
+    {"role": "assistant"},
+    {"timestamp": True},
+])
+def test_sidecar_sender_name_does_not_relax_capture_scope(change: dict) -> None:
+    payload = {
+        "session_id": SESSION_ID,
+        "app_id": "avibe",
+        "project_id": PROJECT,
+        "messages": [
+            {
+                "sender_id": f"u-{'1' * 32}",
+                "sender_name": "用户",
+                "role": "user",
+                "timestamp": 1_725_000_001_234,
+                "content": "text",
+                **change,
+            }
+        ],
+    }
+    assert _request_rejection(
+        "POST", "/api/v2/memory/add", json.dumps(payload).encode()
+    ) == "add"
+
+
 def test_sidecar_guard_accepts_large_everos_request_body() -> None:
     payload = {
         "session_id": SESSION_ID,


### PR DESCRIPTION
## Capability
Restore named Memory capture after #1885 (already merged). The producer sends messages[].sender_name but the sidecar still requires exactly the older four fields, returning HTTP 403 before EverOS receives the capture. Health and historical reads can remain green during this failure.

## Change contract
- Accept optional nonblank sender_name strings up to the producer-normalized 128-character limit.
- Preserve required fields, unknown-field rejection, identity/role/timestamp checks, and content confinement.
- Requests without sender_name remain compatible. No credentials, schemas, old memories, or automatic replay are changed.

## Evidence layers
- Unit: Unicode/boundary names, user and Agent owner IDs, string/structured content, malformed inputs, and scope preservation.
- Contract/scenario: MEMORY-SEARCH-019 now passes actual automatic and explicit capture HTTP payloads through the real sidecar guard in English and Chinese, covering local Web, Cloud Web, Slack, and Agent capture. Both variants fail before this fix.
- Local validation: 201 tests passed across test_memory_sidecar.py, test_memory_everos.py, and test_memory_adapter.py; Ruff and git diff --check passed.
- Residual manual: approved package deployment followed by new live capture and processing-record verification. No current service restart/deployment performed. Previously rejected messages are not automatically recovered.

Follow-up to #1885; based on latest master, no unmerged dependency. Root-cause and acceptance contract: docs/plans/memory-sender-name-sidecar-403.md.