### PR TITLE
perf(ci): reuse private raw schemas for store tests

### DIFF
--- a/docs/plans/ci-store-preparation.md
+++ b/docs/plans/ci-store-preparation.md
@@ -1,0 +1,88 @@
+# CI Store Preparation
+
+## Scope Decision
+
+The owner's sequence is stability diagnosis, proven repeated preparation, then
+multi-run measured shard review. PR #1901 delivered the bounded tool bootstrap
+and upgrade-failure evidence changes. Its historical upgrade timeout remains
+unexplained; a subsequent passing scenario does not establish its root cause.
+
+This follow-up changes only opt-in test preparation in `tests/conftest.py`,
+`tests/test_ci_test_fixtures.py`, `tests/test_resource_access_service.py`,
+`tests/test_cli_task_command.py`, `tests/test_update_checker_platforms.py`, and
+this plan. No production, workflow, dependency, timeout, selection, or runner
+count changes. Do not expand the global AST-based template opt-in heuristic.
+
+## Evidence and Hypothesis
+
+Read-only local profiles on source 16ca51b64's test bodies found:
+
+- Resource access: 72 cases; 57 migration calls consumed 15.1 of 20.7 seconds.
+- CLI: 169 cases; 175 migration calls consumed 24.2 of 33.3 seconds. Parser
+  construction consumed 2.9 seconds and is not this iteration's target.
+- Update checker: 35 cases; 31 migration calls consumed 10.8 of 18.7 seconds.
+  Actual settings saves consumed about 0.1 seconds.
+
+Profiled totals are not comparable to unprofiled speedup measurements. PR #1901
+CI ran 405 files in 6m53s; ACL/CLI/update checker took 27.03/61.75/41.42 seconds.
+Runner contention is not an established cause of differences across runs.
+
+Reuse the existing exclusive private-copy factory with a lazily created,
+closed/checkpointed raw Alembic-head template. This differs from the existing
+fully imported default-state template: no importer markers or default agents
+are pre-seeded. Original store constructors, data migrations, JSON imports,
+business calls, and assertions remain real and unchanged.
+
+## Contracts
+
+- Whole schema fingerprint, all initial rows, and persisted SQLite pragmas
+  equal a freshly migrated database; copied databases pass integrity checks.
+- A template is immutable after publication and each target is an exclusive
+  new file under that test's temporary directory. Mutations do not cross copies.
+- Only explicit ordinary preparation sites opt in. First-bootstrap tests and
+  the resource reader's migration/config persistence boundary remain real.
+- Legacy contexts are still seeded and converted by the original data migration;
+  replacing their empty schema preparation does not replace the tested conversion.
+- All original assertions and selected tests remain; real migration and installer
+  gates remain mandatory. No retries, sleeps, shortened histories, or fake clocks.
+
+## Validation and Delivery
+
+Before pushing, compare original assertion ASTs, run the three full consumer
+modules, fixture/workflow/shard contracts, real migration and importer coverage,
+Ruff and dependency consistency checks. Measure unprofiled before/after locally
+and parse every CI file metric and authoritative Finished exit exactly once.
+Require exact-head bot PASS, every expected check and matching lint run successful,
+zero whole-PR unresolved threads, and CLEAN independent scope/integration before
+guarded merge. Verify merged-source master CI separately. Initial review inventory
+is zero findings-bearing heads. No shard rebalance from a single noisy sample.
+
+## Local Results
+
+Same private Python environment, unprofiled whole-file pytest runs:
+
+| Consumer | Cases | Original | Prepared |
+| --- | ---: | ---: | ---: |
+| Resource access | 72 | 21.56s | 2.78s |
+| CLI | 169 | 21.22s | 9.24s |
+| Update checker | 35 | 13.72s | 7.50s |
+
+These are local samples, not CI speedup claims. The explicit factory covers 26
+resource setup sites, 41 direct CLI sites plus two existing shared CLI helpers,
+and 31 update-checker setups. CLI's already-created-store path remains untouched;
+the factory must never overwrite it. The migration/config persistence test and
+the CLI's unseeded first-bootstrap regression remain unchanged.
+
+AST comparison of all 307 original functions, including nested helpers, is equal
+after normalizing only the explicit preparation calls and fixture arguments.
+All 1,038 assertions, input data, original constructor calls and business calls
+are identical. Whole-file validation passed all 276 consumer cases; another
+213 fixture/workflow/shard/real-migration/settings cases passed in separate
+processes. Ruff 0.4.9, 84-package dependency consistency and whitespace checks
+passed. No global environment or production installation was changed.
+
+PR #1901's merged-source run 34006127752 passed all 17 checks, 405 files and
+every Finished/metrics record once in 9m20s. Its CLI file took 163.18s but only
+33.02s CPU, versus 61.75s/38.90s in the PR run; resource contention is still
+unproven. Both real installer suites passed, including 21 distribution cases and
+196 installer cases. The historical upgrade timeout remains an explicit residual.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,7 +49,7 @@ import shutil
 import sqlite3
 import sys
 import warnings
-from contextlib import contextmanager
+from contextlib import closing, contextmanager
 from functools import wraps
 from pathlib import Path
 
@@ -156,6 +156,35 @@ def sqlite_db_factory(tmp_path, _sqlite_state_template_factory):
         with source_path.open("rb") as source, db_path.open("xb") as target:
             shutil.copyfileobj(source, target)
         return db_path
+
+    return create
+
+
+@pytest.fixture(scope="session")
+def _sqlite_schema_template_factory(tmp_path_factory):
+    """Lazily build raw schema only, without running the JSON/data importer."""
+    template_path: Path | None = None
+
+    def get_template() -> Path:
+        nonlocal template_path
+        if template_path is None:
+            from storage.migrations import run_migrations
+
+            path = tmp_path_factory.mktemp("sqlite-schema-template") / "empty.sqlite"
+            run_migrations(path)
+            with closing(sqlite3.connect(path)) as connection:
+                connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+            template_path = path
+        return template_path
+
+    return get_template
+
+
+@pytest.fixture
+def sqlite_schema_db_factory(sqlite_db_factory, _sqlite_schema_template_factory):
+    """Opt ordinary setup into private raw schemas; constructors/imports stay real."""
+    def create(db_path: Path) -> Path:
+        return sqlite_db_factory(db_path, template=_sqlite_schema_template_factory())
 
     return create
 

--- a/tests/test_ci_test_fixtures.py
+++ b/tests/test_ci_test_fixtures.py
@@ -74,6 +74,40 @@ def test_migration_tests_still_begin_without_seeded_state():
     assert not paths.get_sqlite_state_path().exists()
 
 
+def test_raw_schema_copies_match_fresh_migrations_and_preserve_isolation(
+    tmp_path, sqlite_schema_db_factory, _sqlite_schema_template_factory,
+):
+    from storage.migrations import run_migrations
+    from tests.test_sqlite_state_migration import _schema_fingerprint
+
+    fresh_path = tmp_path / "fresh.sqlite"
+    run_migrations(fresh_path)
+    first = sqlite_schema_db_factory(tmp_path / "first.sqlite")
+    template = _sqlite_schema_template_factory()
+    original = template.read_bytes()
+    with closing(sqlite3.connect(fresh_path)) as fresh, closing(sqlite3.connect(first)) as clone:
+        assert _schema_fingerprint(fresh) == _schema_fingerprint(clone)
+        assert sorted(row for row in fresh.iterdump() if row.startswith("INSERT INTO")) == sorted(
+            row for row in clone.iterdump() if row.startswith("INSERT INTO")
+        )
+        for pragma in ("journal_mode", "user_version", "application_id"):
+            assert fresh.execute(f"PRAGMA {pragma}").fetchall() == clone.execute(f"PRAGMA {pragma}").fetchall()
+        assert clone.execute("PRAGMA integrity_check").fetchone() == ("ok",)
+    with closing(sqlite3.connect(first)) as connection, connection:
+        connection.execute("CREATE TABLE fixture_mutation (value TEXT)")
+        connection.execute("INSERT INTO fixture_mutation VALUES ('private')")
+    second = sqlite_schema_db_factory(tmp_path / "second.sqlite")
+    assert second.read_bytes() == template.read_bytes() == original
+    changed = first.read_bytes()
+    with pytest.raises(FileExistsError):
+        sqlite_schema_db_factory(first)
+    assert first.read_bytes() == changed
+    outside = tmp_path.parent / f"{tmp_path.name}-outside"
+    with pytest.raises(ValueError):
+        sqlite_schema_db_factory(outside / "vibe.sqlite")
+    assert not outside.exists()
+
+
 @pytest.mark.parametrize("fixture", [_reset_cached_sqlite_engines, _reset_oauth_runtime_state])
 def test_cache_cleanup_does_not_import_unused_runtime_modules(monkeypatch, fixture):
     names = ("storage.db", "storage.importer", "vibe.remote_access", "vibe.ui_server")

--- a/tests/test_cli_task_command.py
+++ b/tests/test_cli_task_command.py
@@ -66,8 +66,8 @@ def _capture_stderr_json(func, *args):
     return result, json.loads(stderr.getvalue())
 
 
-def test_agent_enable_disable_cli_toggles_enabled_state(tmp_path: Path, capsys) -> None:
-    db_path = tmp_path / "state" / "vibe.sqlite"
+def test_agent_enable_disable_cli_toggles_enabled_state(tmp_path: Path, capsys, sqlite_schema_db_factory) -> None:
+    db_path = sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     agent_store = cli.VibeAgentStore(db_path)
     agent_store.create(name="worker", backend="codex")
 
@@ -89,8 +89,8 @@ def test_agent_enable_disable_cli_toggles_enabled_state(tmp_path: Path, capsys) 
         assert enabled_payload["agent"]["enabled"] is True
 
 
-def test_disabled_agent_cannot_run(tmp_path: Path) -> None:
-    db_path = tmp_path / "state" / "vibe.sqlite"
+def test_disabled_agent_cannot_run(tmp_path: Path, sqlite_schema_db_factory) -> None:
+    db_path = sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     agent_store = cli.VibeAgentStore(db_path)
     agent_store.create(name="worker", backend="codex", enabled=False)
     args = _parse_agent_run(["--agent", "worker", "--async", "--no-callback", "--message", "hello"])
@@ -245,8 +245,8 @@ def test_task_update_preserves_archived_agent_reference(capsys) -> None:
         agent_store.close()
 
 
-def test_agent_remove_cli_archives_agent(tmp_path: Path, capsys) -> None:
-    agent_store = cli.VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
+def test_agent_remove_cli_archives_agent(tmp_path: Path, capsys, sqlite_schema_db_factory) -> None:
+    agent_store = cli.VibeAgentStore(sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite"))
     try:
         agent_store.create(name="archive-fallback", backend="codex")
         agent_store.create(name="worker", backend="codex")
@@ -262,8 +262,8 @@ def test_agent_remove_cli_archives_agent(tmp_path: Path, capsys) -> None:
         agent_store.close()
 
 
-def test_agent_remove_cli_localizes_archive_refusal(tmp_path: Path) -> None:
-    agent_store = cli.VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
+def test_agent_remove_cli_localizes_archive_refusal(tmp_path: Path, sqlite_schema_db_factory) -> None:
+    agent_store = cli.VibeAgentStore(sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite"))
     try:
         agent_store.create(name="only-agent", backend="codex")
         agent_store.set_default_agent_name("only-agent")
@@ -307,8 +307,8 @@ def test_agent_remove_cli_localizes_invalid_reference_metadata() -> None:
     assert payload["hint"] == "请修复或删除元数据异常的任务或监控，然后重试。"
 
 
-def test_agent_update_and_enable_localize_archived_edit_refusal(tmp_path: Path) -> None:
-    agent_store = cli.VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
+def test_agent_update_and_enable_localize_archived_edit_refusal(tmp_path: Path, sqlite_schema_db_factory) -> None:
+    agent_store = cli.VibeAgentStore(sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite"))
     try:
         agent_store.create(name="archive-fallback", backend="codex")
         agent_store.create(name="worker", backend="codex")
@@ -336,8 +336,8 @@ def test_agent_update_and_enable_localize_archived_edit_refusal(tmp_path: Path) 
         agent_store.close()
 
 
-def test_agent_list_is_bounded_and_compact_by_default(tmp_path: Path, capsys) -> None:
-    agent_store = cli.VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
+def test_agent_list_is_bounded_and_compact_by_default(tmp_path: Path, capsys, sqlite_schema_db_factory) -> None:
+    agent_store = cli.VibeAgentStore(sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite"))
     for index in range(25):
         agent_store.create(
             name=f"worker-{index:02d}",
@@ -875,8 +875,8 @@ def test_remote_editor_task_add_persists_authorization_context(
     assert len(cli.ScheduledTaskStore(store_path).list_tasks()) == 1
 
 
-def test_task_add_create_per_run_scope_id_records_session_scope_metadata(tmp_path: Path, capsys) -> None:
-    db_path = tmp_path / "state" / "vibe.sqlite"
+def test_task_add_create_per_run_scope_id_records_session_scope_metadata(tmp_path: Path, capsys, sqlite_schema_db_factory) -> None:
+    db_path = sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     agent_store = cli.VibeAgentStore(db_path)
     agent_store.create(name="project-agent", backend="codex")
     from storage.importer import ensure_sqlite_state
@@ -941,8 +941,8 @@ def test_task_add_create_per_run_scope_id_records_session_scope_metadata(tmp_pat
     assert payload["definition"]["agent_name"] == "project-agent"
 
 
-def test_task_add_create_per_run_without_scope_records_standalone_definition(tmp_path: Path, capsys) -> None:
-    db_path = tmp_path / "state" / "vibe.sqlite"
+def test_task_add_create_per_run_without_scope_records_standalone_definition(tmp_path: Path, capsys, sqlite_schema_db_factory) -> None:
+    db_path = sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     agent_store = cli.VibeAgentStore(db_path)
     agent_store.create(name="worker", backend="codex")
     store = cli.ScheduledTaskStore(tmp_path / "scheduled_tasks.json")
@@ -975,8 +975,8 @@ def test_task_add_create_per_run_without_scope_records_standalone_definition(tmp
     assert "session_workdir" not in task["metadata"]
 
 
-def test_task_add_create_session_scope_id_supports_project_scope(tmp_path: Path, capsys) -> None:
-    db_path = tmp_path / "state" / "vibe.sqlite"
+def test_task_add_create_session_scope_id_supports_project_scope(tmp_path: Path, capsys, sqlite_schema_db_factory) -> None:
+    db_path = sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     agent_store = cli.VibeAgentStore(db_path)
     agent_store.create(name="project-agent", backend="codex")
     from storage.importer import ensure_sqlite_state
@@ -1175,8 +1175,8 @@ def test_task_add_create_session_scope_id_uses_unique_definition_anchors(tmp_pat
     assert all(anchor.startswith("avibe_proj-once-unique:definition_") for anchor in anchors)
 
 
-def test_task_add_defaults_target_to_caller_session(tmp_path: Path, capsys) -> None:
-    db_path = tmp_path / "state" / "vibe.sqlite"
+def test_task_add_defaults_target_to_caller_session(tmp_path: Path, capsys, sqlite_schema_db_factory) -> None:
+    db_path = sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     agent_store = cli.VibeAgentStore(db_path)
     agent_store.create(name="codex", backend="codex")
     from storage.importer import ensure_sqlite_state
@@ -1718,7 +1718,7 @@ def test_task_update_modifies_existing_task_without_changing_id(tmp_path: Path, 
     assert payload["definition"]["prompt"] == "updated"
 
 
-def test_task_update_rejects_agent_together_with_clear_agent(tmp_path: Path) -> None:
+def test_task_update_rejects_agent_together_with_clear_agent(tmp_path: Path, sqlite_schema_db_factory) -> None:
     """HFR-255 — ``--agent X --clear-agent`` re-pinned today's default Agent.
 
     THE DEFECT. The two flags mean opposite things, and unlike ``--name`` /
@@ -1739,7 +1739,7 @@ def test_task_update_rejects_agent_together_with_clear_agent(tmp_path: Path) -> 
     The stored definition must also be untouched: a rejected command may not have
     written a pin on its way to failing.
     """
-    db_path = tmp_path / "state" / "vibe.sqlite"
+    db_path = sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     agent_store = cli.VibeAgentStore(db_path)
     try:
         # The Agent the bound Session runs as, and a DIFFERENT current default. The
@@ -1836,12 +1836,12 @@ def test_task_update_rejects_scope_without_session_creation(tmp_path: Path) -> N
 
 
 def test_task_update_repoints_an_escalating_command_tasks_cwd(
-    tmp_path: Path, capsys, monkeypatch
+    tmp_path: Path, capsys, monkeypatch, sqlite_schema_db_factory
 ) -> None:
     """SCT-050 -- the same flag the add path now accepts, on a task that already exists."""
 
     _bare_terminal_caller(monkeypatch)
-    db_path, agent_store = _caller_session_state(tmp_path)
+    db_path, agent_store = _caller_session_state(tmp_path, sqlite_schema_db_factory)
     store = _command_task_store(tmp_path)
     old = tmp_path / "old"
     old.mkdir()
@@ -1871,7 +1871,7 @@ def test_task_update_repoints_an_escalating_command_tasks_cwd(
 
 
 def test_task_update_keeps_a_command_tasks_cwd_through_an_unrelated_edit(
-    tmp_path: Path, capsys, monkeypatch
+    tmp_path: Path, capsys, monkeypatch, sqlite_schema_db_factory
 ) -> None:
     """SCT-051 -- a rename must not silently un-pin the directory the command was given.
 
@@ -1882,7 +1882,7 @@ def test_task_update_keeps_a_command_tasks_cwd_through_an_unrelated_edit(
     """
 
     _bare_terminal_caller(monkeypatch)
-    db_path, agent_store = _caller_session_state(tmp_path)
+    db_path, agent_store = _caller_session_state(tmp_path, sqlite_schema_db_factory)
     store = _command_task_store(tmp_path)
     pinned = tmp_path / "pinned"
     pinned.mkdir()
@@ -1913,7 +1913,7 @@ def test_task_update_keeps_a_command_tasks_cwd_through_an_unrelated_edit(
 
 
 def test_task_update_retarget_does_not_pull_the_command_back_to_its_sessions_directory(
-    tmp_path: Path, capsys, monkeypatch
+    tmp_path: Path, capsys, monkeypatch, sqlite_schema_db_factory
 ) -> None:
     """SCT-059 -- once the two halves differ, neither may be read as the other.
 
@@ -1926,7 +1926,7 @@ def test_task_update_retarget_does_not_pull_the_command_back_to_its_sessions_dir
     """
 
     _bare_terminal_caller(monkeypatch)
-    db_path, agent_store = _caller_session_state(tmp_path)
+    db_path, agent_store = _caller_session_state(tmp_path, sqlite_schema_db_factory)
     store = _command_task_store(tmp_path)
     session_dir = tmp_path / "session-dir"
     session_dir.mkdir()
@@ -1971,7 +1971,7 @@ def test_task_update_retarget_does_not_pull_the_command_back_to_its_sessions_dir
 
 
 def test_task_update_unrelated_edit_leaves_a_per_run_definitions_sessions_unplaced(
-    tmp_path: Path, capsys, monkeypatch
+    tmp_path: Path, capsys, monkeypatch, sqlite_schema_db_factory
 ) -> None:
     """SCT-058 -- an edit that asks nothing about directories must place no Session.
 
@@ -1985,7 +1985,7 @@ def test_task_update_unrelated_edit_leaves_a_per_run_definitions_sessions_unplac
     """
 
     _bare_terminal_caller(monkeypatch)
-    db_path, agent_store = _caller_session_state(tmp_path)
+    db_path, agent_store = _caller_session_state(tmp_path, sqlite_schema_db_factory)
     store = _command_task_store(tmp_path)
     described_in = tmp_path / "described-in"
     described_in.mkdir()
@@ -2022,7 +2022,7 @@ def test_task_update_unrelated_edit_leaves_a_per_run_definitions_sessions_unplac
 
 
 def test_task_update_retarget_does_not_promote_a_command_cwd_onto_a_new_session(
-    tmp_path: Path, capsys, monkeypatch
+    tmp_path: Path, capsys, monkeypatch, sqlite_schema_db_factory
 ) -> None:
     """SCT-053 -- the two halves of ``cwd`` survive a policy change separately.
 
@@ -2035,7 +2035,7 @@ def test_task_update_retarget_does_not_promote_a_command_cwd_onto_a_new_session(
     """
 
     _bare_terminal_caller(monkeypatch)
-    db_path, agent_store = _caller_session_state(tmp_path)
+    db_path, agent_store = _caller_session_state(tmp_path, sqlite_schema_db_factory)
     store = _command_task_store(tmp_path)
     pinned = tmp_path / "pinned"
     pinned.mkdir()
@@ -2174,7 +2174,7 @@ def test_task_update_reserves_a_replacement_session_without_the_commands_directo
 
 
 def test_task_update_repoints_a_reserved_command_task_without_replacing_its_session(
-    tmp_path: Path, capsys
+    tmp_path: Path, capsys, sqlite_schema_db_factory
 ) -> None:
     """SCT-057 -- repointing the command must not mean replacing the escalation Session.
 
@@ -2186,7 +2186,7 @@ def test_task_update_repoints_a_reserved_command_task_without_replacing_its_sess
     softened the same way: the command's half moves, the Session's half is untouched.
     """
 
-    db_path, agent_store = _caller_session_state(tmp_path, session_id="sesReserved")
+    db_path, agent_store = _caller_session_state(tmp_path, sqlite_schema_db_factory, session_id="sesReserved")
     store = _command_task_store(tmp_path)
     saved = tmp_path / "saved"
     saved.mkdir()
@@ -2480,7 +2480,7 @@ def test_hook_send_deprecation_warning_names_callback_policy(tmp_path: Path, cap
     assert "--callback-session-id <session-id>" in payload["deprecation_warning"]
 
 
-def test_hook_send_guards_an_explicit_agent_inside_enqueue(tmp_path: Path, capsys) -> None:
+def test_hook_send_guards_an_explicit_agent_inside_enqueue(tmp_path: Path, capsys, sqlite_schema_db_factory) -> None:
     args = _parse_hook_send(
         [
             "--session-key",
@@ -2491,7 +2491,7 @@ def test_hook_send_guards_an_explicit_agent_inside_enqueue(tmp_path: Path, capsy
             "hello",
         ]
     )
-    agent_store = cli.VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
+    agent_store = cli.VibeAgentStore(sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite"))
     agent = agent_store.create(name="worker", backend="codex")
     captured: dict[str, object] = {}
 
@@ -2515,7 +2515,7 @@ def test_hook_send_guards_an_explicit_agent_inside_enqueue(tmp_path: Path, capsy
     assert captured["expected_enabled_agent_id"] == agent.id
 
 
-def test_hook_send_guards_the_implicit_default_agent_inside_enqueue(tmp_path: Path, capsys) -> None:
+def test_hook_send_guards_the_implicit_default_agent_inside_enqueue(tmp_path: Path, capsys, sqlite_schema_db_factory) -> None:
     args = _parse_hook_send(
         [
             "--session-key",
@@ -2524,7 +2524,7 @@ def test_hook_send_guards_the_implicit_default_agent_inside_enqueue(tmp_path: Pa
             "hello",
         ]
     )
-    db_path = tmp_path / "state" / "vibe.sqlite"
+    db_path = sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     agent_store = cli.VibeAgentStore(db_path)
     default_agent = agent_store.ensure_default_agent(backend="codex")
     captured: dict[str, object] = {}
@@ -2914,8 +2914,8 @@ def test_runs_cancel_queued_agent_run_does_not_call_live_controller(
     assert payload["run"]["status"] == "canceled"
 
 
-def test_hook_send_allows_unresolved_legacy_scope_backend(tmp_path: Path, capsys) -> None:
-    db_path = tmp_path / "state" / "vibe.sqlite"
+def test_hook_send_allows_unresolved_legacy_scope_backend(tmp_path: Path, capsys, sqlite_schema_db_factory) -> None:
+    db_path = sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     agent_store = cli.VibeAgentStore(db_path)
     default_agent = agent_store.ensure_default_agent(backend="claude")
     agent_store.create(name="codex", backend="opencode")
@@ -2988,8 +2988,8 @@ def test_hook_send_returns_reachability_warning_for_unbound_lark_dm(tmp_path: Pa
     assert payload["warnings"][0]["code"] == "lark_user_not_bound"
 
 
-def test_agent_run_standalone_async_reserves_background_session(tmp_path: Path, capsys) -> None:
-    db_path = tmp_path / "state" / "vibe.sqlite"
+def test_agent_run_standalone_async_reserves_background_session(tmp_path: Path, capsys, sqlite_schema_db_factory) -> None:
+    db_path = sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     agent_store = cli.VibeAgentStore(db_path)
     agent = agent_store.create(name="worker", backend="codex")
     request_store = cli.TaskExecutionStore(tmp_path / "task_requests")
@@ -3127,8 +3127,8 @@ def test_agent_run_caller_scope_default_keeps_caller_cwd_and_same_scope_uses_sco
     assert rows[visible["session_id"]].workdir == str(invocation_cwd)
 
 
-def test_agent_run_create_session_uses_scope_anchor_for_channel_deliver_key(tmp_path: Path, capsys) -> None:
-    db_path = tmp_path / "state" / "vibe.sqlite"
+def test_agent_run_create_session_uses_scope_anchor_for_channel_deliver_key(tmp_path: Path, capsys, sqlite_schema_db_factory) -> None:
+    db_path = sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     agent_store = cli.VibeAgentStore(db_path)
     agent_store.create(name="worker", backend="codex")
     request_store = cli.TaskExecutionStore(tmp_path / "task_requests")
@@ -3162,8 +3162,8 @@ def test_agent_run_create_session_uses_scope_anchor_for_channel_deliver_key(tmp_
     assert target.session_anchor.startswith("slack_C123:run_")
 
 
-def test_agent_run_create_session_preserves_legacy_thread_deliver_key(tmp_path: Path, capsys) -> None:
-    db_path = tmp_path / "state" / "vibe.sqlite"
+def test_agent_run_create_session_preserves_legacy_thread_deliver_key(tmp_path: Path, capsys, sqlite_schema_db_factory) -> None:
+    db_path = sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     agent_store = cli.VibeAgentStore(db_path)
     agent_store.create(name="worker", backend="codex")
     request_store = cli.TaskExecutionStore(tmp_path / "task_requests")
@@ -3281,8 +3281,8 @@ def test_agent_run_create_session_scope_id_uses_unique_project_anchors(tmp_path:
     assert all(anchor.startswith("avibe_proj_unique:run_") for anchor in anchors)
 
 
-def test_agent_run_standalone_does_not_create_platform_pseudo_scope(tmp_path: Path, capsys) -> None:
-    db_path = tmp_path / "state" / "vibe.sqlite"
+def test_agent_run_standalone_does_not_create_platform_pseudo_scope(tmp_path: Path, capsys, sqlite_schema_db_factory) -> None:
+    db_path = sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     agent_store = cli.VibeAgentStore(db_path)
     agent_store.create(name="worker", backend="codex")
     request_store = cli.TaskExecutionStore(tmp_path / "task_requests")
@@ -3310,8 +3310,8 @@ def test_agent_run_standalone_does_not_create_platform_pseudo_scope(tmp_path: Pa
     assert row == (None, "background")
 
 
-def test_agent_run_rejects_deprecated_prompt_argument(tmp_path: Path) -> None:
-    db_path = tmp_path / "state" / "vibe.sqlite"
+def test_agent_run_rejects_deprecated_prompt_argument(tmp_path: Path, sqlite_schema_db_factory) -> None:
+    db_path = sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     agent_store = cli.VibeAgentStore(db_path)
     agent_store.create(name="worker", backend="codex")
     args = _parse_agent_run(["--agent", "worker", "--async", "--prompt", "hello"])
@@ -3332,8 +3332,8 @@ def test_agent_run_rejects_per_run_for_direct_invocation() -> None:
     assert payload["code"] == "invalid_session_policy"
 
 
-def test_agent_run_rejects_cross_backend_agent_for_existing_session(tmp_path: Path) -> None:
-    db_path = tmp_path / "state" / "vibe.sqlite"
+def test_agent_run_rejects_cross_backend_agent_for_existing_session(tmp_path: Path, sqlite_schema_db_factory) -> None:
+    db_path = sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     agent_store = cli.VibeAgentStore(db_path)
     agent_store.create(name="codex-worker", backend="codex")
     from storage.sessions_service import SQLiteSessionsService
@@ -3359,8 +3359,8 @@ def test_agent_run_rejects_cross_backend_agent_for_existing_session(tmp_path: Pa
     assert payload["code"] == "agent_session_backend_mismatch"
 
 
-def test_agent_run_existing_session_allows_matching_agent_hint(tmp_path: Path, capsys) -> None:
-    db_path = tmp_path / "state" / "vibe.sqlite"
+def test_agent_run_existing_session_allows_matching_agent_hint(tmp_path: Path, capsys, sqlite_schema_db_factory) -> None:
+    db_path = sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     agent_store = cli.VibeAgentStore(db_path)
     agent_store.create(name="codex-worker", backend="codex")
     request_store = cli.TaskExecutionStore(tmp_path / "task_requests")
@@ -3403,8 +3403,8 @@ def test_agent_run_existing_session_allows_matching_agent_hint(tmp_path: Path, c
     assert payload["agent"] == "codex-worker"
 
 
-def test_agent_run_rejects_different_same_backend_agent_for_existing_session(tmp_path: Path) -> None:
-    db_path = tmp_path / "state" / "vibe.sqlite"
+def test_agent_run_rejects_different_same_backend_agent_for_existing_session(tmp_path: Path, sqlite_schema_db_factory) -> None:
+    db_path = sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     agent_store = cli.VibeAgentStore(db_path)
     agent_store.create(name="session-worker", backend="codex")
     agent_store.create(name="other-worker", backend="codex")
@@ -3432,8 +3432,8 @@ def test_agent_run_rejects_different_same_backend_agent_for_existing_session(tmp
     assert payload["code"] == "agent_session_agent_mismatch"
 
 
-def test_agent_run_rejects_post_to_thread_for_threadless_session_before_enqueue(tmp_path: Path) -> None:
-    db_path = tmp_path / "state" / "vibe.sqlite"
+def test_agent_run_rejects_post_to_thread_for_threadless_session_before_enqueue(tmp_path: Path, sqlite_schema_db_factory) -> None:
+    db_path = sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     agent_store = cli.VibeAgentStore(db_path)
     agent_store.create(name="worker", backend="codex")
     request_store = cli.TaskExecutionStore(tmp_path / "task_requests")
@@ -3464,8 +3464,8 @@ def test_agent_run_rejects_post_to_thread_for_threadless_session_before_enqueue(
     assert request_store.list_pending() == []
 
 
-def test_agent_run_rejects_cross_platform_deliver_key_before_enqueue(tmp_path: Path) -> None:
-    db_path = tmp_path / "state" / "vibe.sqlite"
+def test_agent_run_rejects_cross_platform_deliver_key_before_enqueue(tmp_path: Path, sqlite_schema_db_factory) -> None:
+    db_path = sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     agent_store = cli.VibeAgentStore(db_path)
     agent_store.create(name="worker", backend="codex")
     request_store = cli.TaskExecutionStore(tmp_path / "task_requests")
@@ -3519,8 +3519,8 @@ def test_agent_run_rejects_delivery_options_without_session_policy() -> None:
     assert payload["code"] == "delivery_target_without_session_policy"
 
 
-def test_agent_run_existing_session_uses_session_agent_when_agent_omitted(tmp_path: Path, capsys) -> None:
-    db_path = tmp_path / "state" / "vibe.sqlite"
+def test_agent_run_existing_session_uses_session_agent_when_agent_omitted(tmp_path: Path, capsys, sqlite_schema_db_factory) -> None:
+    db_path = sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     agent_store = cli.VibeAgentStore(db_path)
     agent_store.create(name="worker", backend="codex")
     request_store = cli.TaskExecutionStore(tmp_path / "task_requests")
@@ -3563,8 +3563,8 @@ def test_agent_run_rejects_default_async_wait_timeout_combo() -> None:
     assert "--sync" in payload["hint"]
 
 
-def test_agent_create_accepts_effort_alias(tmp_path: Path, capsys) -> None:
-    db_path = tmp_path / "state" / "vibe.sqlite"
+def test_agent_create_accepts_effort_alias(tmp_path: Path, capsys, sqlite_schema_db_factory) -> None:
+    db_path = sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     agent_store = cli.VibeAgentStore(db_path)
     args = _parse_agent(["create", "worker", "--backend", "codex", "--effort", "high"])
 
@@ -3576,8 +3576,8 @@ def test_agent_create_accepts_effort_alias(tmp_path: Path, capsys) -> None:
     assert payload["agent"]["reasoning_effort"] == "high"
 
 
-def test_agent_create_localizes_reserved_name_error(tmp_path: Path) -> None:
-    agent_store = cli.VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
+def test_agent_create_localizes_reserved_name_error(tmp_path: Path, sqlite_schema_db_factory) -> None:
+    agent_store = cli.VibeAgentStore(sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite"))
     args = _parse_agent(["create", "_hidden", "--backend", "codex"])
 
     with (
@@ -3592,8 +3592,8 @@ def test_agent_create_localizes_reserved_name_error(tmp_path: Path) -> None:
     assert payload["hint"] == "请选择不以下划线 `_` 开头的 Agent 名称。"
 
 
-def test_agent_default_cli_sets_default_agent(tmp_path: Path, capsys) -> None:
-    db_path = tmp_path / "state" / "vibe.sqlite"
+def test_agent_default_cli_sets_default_agent(tmp_path: Path, capsys, sqlite_schema_db_factory) -> None:
+    db_path = sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     agent_store = cli.VibeAgentStore(db_path)
     agent_store.ensure_builtin_default_agents(["opencode", "codex"])
     args = _parse_agent(["default", "codex"])
@@ -3607,8 +3607,8 @@ def test_agent_default_cli_sets_default_agent(tmp_path: Path, capsys) -> None:
     assert agent_store.get_default_agent_name() == "codex"
 
 
-def test_agent_default_cli_bootstraps_builtin_backend_agent(tmp_path: Path, capsys) -> None:
-    db_path = tmp_path / "state" / "vibe.sqlite"
+def test_agent_default_cli_bootstraps_builtin_backend_agent(tmp_path: Path, capsys, sqlite_schema_db_factory) -> None:
+    db_path = sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     agent_store = cli.VibeAgentStore(db_path)
     args = _parse_agent(["default", "codex"])
 
@@ -3625,8 +3625,8 @@ def test_agent_default_cli_bootstraps_builtin_backend_agent(tmp_path: Path, caps
     assert agent_store.get_default_agent_name() == "codex"
 
 
-def test_agent_import_name_filters_global_candidates(tmp_path: Path, capsys) -> None:
-    db_path = tmp_path / "state" / "vibe.sqlite"
+def test_agent_import_name_filters_global_candidates(tmp_path: Path, capsys, sqlite_schema_db_factory) -> None:
+    db_path = sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     agent_store = cli.VibeAgentStore(db_path)
     keep = tmp_path / "reviewer.md"
     skip = tmp_path / "builder.md"
@@ -3646,8 +3646,8 @@ def test_agent_import_name_filters_global_candidates(tmp_path: Path, capsys) -> 
     assert agent_store.get("builder") is None
 
 
-def test_agent_import_skips_malformed_global_candidates(tmp_path: Path, capsys) -> None:
-    db_path = tmp_path / "state" / "vibe.sqlite"
+def test_agent_import_skips_malformed_global_candidates(tmp_path: Path, capsys, sqlite_schema_db_factory) -> None:
+    db_path = sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     agent_store = cli.VibeAgentStore(db_path)
     valid = tmp_path / "reviewer.md"
     broken = tmp_path / "broken.md"
@@ -3668,8 +3668,8 @@ def test_agent_import_skips_malformed_global_candidates(tmp_path: Path, capsys) 
     assert payload["skipped"][0]["reason"] == "invalid"
 
 
-def test_default_agent_pointer_is_created(tmp_path: Path) -> None:
-    agent_store = cli.VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
+def test_default_agent_pointer_is_created(tmp_path: Path, sqlite_schema_db_factory) -> None:
+    agent_store = cli.VibeAgentStore(sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite"))
     agent = agent_store.ensure_default_agent(backend="codex")
 
     assert agent.name == "default"
@@ -3705,8 +3705,8 @@ def test_resolve_agent_for_target_bootstraps_sqlite_before_scope_lookup(tmp_path
         assert conn.execute("select count(*) from scope_settings").fetchone()[0] == 0
 
 
-def test_resolve_agent_for_target_ignores_deprecated_scope_backend(tmp_path: Path) -> None:
-    db_path = tmp_path / "state" / "vibe.sqlite"
+def test_resolve_agent_for_target_ignores_deprecated_scope_backend(tmp_path: Path, sqlite_schema_db_factory) -> None:
+    db_path = sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     default_agent = cli.VibeAgentStore(db_path).ensure_default_agent(backend="claude")
     from storage.importer import ensure_sqlite_state
     from storage.models import scope_settings
@@ -3762,8 +3762,8 @@ def test_resolve_agent_for_target_ignores_deprecated_scope_backend(tmp_path: Pat
     assert "agent_name" not in json.loads(row[2])["routing"]
 
 
-def test_scope_derived_agent_target_preserves_the_stable_reference(tmp_path: Path) -> None:
-    db_path = tmp_path / "state" / "vibe.sqlite"
+def test_scope_derived_agent_target_preserves_the_stable_reference(tmp_path: Path, sqlite_schema_db_factory) -> None:
+    db_path = sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     agent_store = cli.VibeAgentStore(db_path)
     original = agent_store.create(name="pm", backend="claude")
     agent_store.create(name="archive-fallback", backend="codex")
@@ -3828,8 +3828,8 @@ def test_scope_derived_agent_target_preserves_the_stable_reference(tmp_path: Pat
     assert cli._agent_write_guard_ids(resolution) == (None, original.id)
 
 
-def test_session_derived_agent_target_prefers_the_stable_id(tmp_path: Path) -> None:
-    db_path = tmp_path / "state" / "vibe.sqlite"
+def test_session_derived_agent_target_prefers_the_stable_id(tmp_path: Path, sqlite_schema_db_factory) -> None:
+    db_path = sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     agent_store = cli.VibeAgentStore(db_path)
     original = agent_store.create(name="pm", backend="claude")
     agent_store.create(name="archive-fallback", backend="codex")
@@ -3865,9 +3865,9 @@ def test_session_derived_agent_target_prefers_the_stable_id(tmp_path: Path) -> N
 
 
 def test_resolve_agent_for_target_allows_unresolved_legacy_scope_backend_without_session_creation(
-    tmp_path: Path,
+    tmp_path: Path, sqlite_schema_db_factory,
 ) -> None:
-    db_path = tmp_path / "state" / "vibe.sqlite"
+    db_path = sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     agent_store = cli.VibeAgentStore(db_path)
     default_agent = agent_store.ensure_default_agent(backend="claude")
     agent_store.create(name="codex", backend="opencode")
@@ -3915,9 +3915,9 @@ def test_resolve_agent_for_target_allows_unresolved_legacy_scope_backend_without
 
 
 def test_resolve_agent_for_target_ignores_unresolved_legacy_scope_backend_for_session_creation(
-    tmp_path: Path,
+    tmp_path: Path, sqlite_schema_db_factory,
 ) -> None:
-    db_path = tmp_path / "state" / "vibe.sqlite"
+    db_path = sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     agent_store = cli.VibeAgentStore(db_path)
     default_agent = agent_store.ensure_default_agent(backend="claude")
     agent_store.create(name="codex", backend="opencode")
@@ -3964,8 +3964,8 @@ def test_resolve_agent_for_target_ignores_unresolved_legacy_scope_backend_for_se
     assert agent.name == default_agent.name
 
 
-def test_reserve_definition_session_ignores_deprecated_scope_backend(tmp_path: Path) -> None:
-    db_path = tmp_path / "state" / "vibe.sqlite"
+def test_reserve_definition_session_ignores_deprecated_scope_backend(tmp_path: Path, sqlite_schema_db_factory) -> None:
+    db_path = sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     default_agent = cli.VibeAgentStore(db_path).ensure_default_agent(backend="claude")
     from storage.importer import ensure_sqlite_state
     from storage.models import scope_settings
@@ -4011,8 +4011,8 @@ def test_reserve_definition_session_ignores_deprecated_scope_backend(tmp_path: P
     assert target.agent_id
 
 
-def test_reserve_definition_session_ignores_unresolved_legacy_scope_backend(tmp_path: Path) -> None:
-    db_path = tmp_path / "state" / "vibe.sqlite"
+def test_reserve_definition_session_ignores_unresolved_legacy_scope_backend(tmp_path: Path, sqlite_schema_db_factory) -> None:
+    db_path = sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     agent_store = cli.VibeAgentStore(db_path)
     default_agent = agent_store.ensure_default_agent(backend="claude")
     agent_store.create(name="codex", backend="opencode")
@@ -4060,8 +4060,8 @@ def test_reserve_definition_session_ignores_unresolved_legacy_scope_backend(tmp_
     assert target.agent_name == default_agent.name
 
 
-def test_task_add_create_per_run_ignores_unresolved_legacy_scope_backend(tmp_path: Path, capsys) -> None:
-    db_path = tmp_path / "state" / "vibe.sqlite"
+def test_task_add_create_per_run_ignores_unresolved_legacy_scope_backend(tmp_path: Path, capsys, sqlite_schema_db_factory) -> None:
+    db_path = sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     agent_store = cli.VibeAgentStore(db_path)
     default_agent = agent_store.ensure_default_agent(backend="claude")
     agent_store.create(name="codex", backend="opencode")
@@ -4368,7 +4368,7 @@ def _no_caller_context(monkeypatch) -> None:
     monkeypatch.delenv("AVIBE_SESSION_ID", raising=False)
 
 
-def _reserved_session_cli_db(tmp_path: Path):
+def _reserved_session_cli_db(tmp_path: Path, sqlite_schema_db_factory):
     """A migrated CLI state DB holding the reserved row plus one ordinary session.
 
     Both rows in ONE database because the point is DISCRIMINATION: the same command,
@@ -4381,7 +4381,7 @@ def _reserved_session_cli_db(tmp_path: Path):
     from storage.importer import ensure_sqlite_state
     from storage.sessions_service import SQLiteSessionsService
 
-    db_path = tmp_path / "state" / "vibe.sqlite"
+    db_path = sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     agent_store = cli.VibeAgentStore(db_path)
     agent_store.create(name="worker", backend="codex")
     ensure_sqlite_state(db_path=db_path, primary_platform="slack")
@@ -4454,7 +4454,7 @@ def _message_rows(db_path: Path, session_id: str) -> list[tuple]:
 
 
 def test_task_add_refuses_the_reserved_session_with_no_side_effects(
-    tmp_path: Path, capsys, monkeypatch
+    tmp_path: Path, capsys, monkeypatch, sqlite_schema_db_factory
 ) -> None:
     """``vibe task add --session-id ses-workspace-notices`` is refused at ADMISSION.
 
@@ -4474,7 +4474,7 @@ def test_task_add_refuses_the_reserved_session_with_no_side_effects(
     fail here.
     """
     _no_caller_context(monkeypatch)
-    db_path, agent_store, ordinary = _reserved_session_cli_db(tmp_path)
+    db_path, agent_store, ordinary = _reserved_session_cli_db(tmp_path, sqlite_schema_db_factory)
     store = cli.ScheduledTaskStore(tmp_path / "scheduled_tasks.json")
     request_store = cli.TaskExecutionStore(tmp_path / "task_requests")
     args = _parse_task_add(
@@ -4551,7 +4551,7 @@ def test_task_add_refuses_the_reserved_session_with_no_side_effects(
 
 
 def test_agent_run_refuses_the_reserved_session_with_no_side_effects(
-    tmp_path: Path, capsys, monkeypatch
+    tmp_path: Path, capsys, monkeypatch, sqlite_schema_db_factory
 ) -> None:
     """The direct lane named in the finding, as a test rather than a hand probe.
 
@@ -4570,7 +4570,7 @@ def test_agent_run_refuses_the_reserved_session_with_no_side_effects(
     picked up) and no ``messages`` row. Positive control: the ordinary session queues.
     """
     _no_caller_context(monkeypatch)
-    db_path, agent_store, ordinary = _reserved_session_cli_db(tmp_path)
+    db_path, agent_store, ordinary = _reserved_session_cli_db(tmp_path, sqlite_schema_db_factory)
     request_store = cli.TaskExecutionStore(tmp_path / "task_requests")
     args = _parse_agent_run(
         [
@@ -4699,10 +4699,10 @@ def _command_task_store(tmp_path: Path):
     return cli.ScheduledTaskStore(tmp_path / "scheduled_tasks.json")
 
 
-def _caller_session_state(tmp_path: Path, *, session_id: str = "sesCaller"):
+def _caller_session_state(tmp_path: Path, sqlite_schema_db_factory, *, session_id: str = "sesCaller"):
     """A migrated CLI state DB holding one active Session owned by an enabled Agent."""
 
-    db_path = tmp_path / "state" / "vibe.sqlite"
+    db_path = sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     agent_store = cli.VibeAgentStore(db_path)
     agent_store.create(name="codex", backend="codex")
     from storage.importer import ensure_sqlite_state
@@ -4885,7 +4885,7 @@ def test_task_add_rejects_session_flags_for_pure_command_task(
 
 
 def test_task_add_pure_command_task_ignores_caller_session_default(
-    tmp_path: Path, capsys, monkeypatch
+    tmp_path: Path, capsys, monkeypatch, sqlite_schema_db_factory
 ) -> None:
     """Created from chat, a pure command task must NOT inherit the calling Session.
 
@@ -4895,7 +4895,7 @@ def test_task_add_pure_command_task_ignores_caller_session_default(
     """
 
     _agent_shell_caller(monkeypatch)
-    db_path, agent_store = _caller_session_state(tmp_path)
+    db_path, agent_store = _caller_session_state(tmp_path, sqlite_schema_db_factory)
     store = _command_task_store(tmp_path)
     args = _parse_task_add(["--cron", "0 3 * * *", "--shell", "./scripts/sync.sh"])
 
@@ -4920,10 +4920,10 @@ def test_task_add_pure_command_task_ignores_caller_session_default(
 
 
 def test_task_add_escalating_command_task_binds_caller_session(
-    tmp_path: Path, capsys, monkeypatch
+    tmp_path: Path, capsys, monkeypatch, sqlite_schema_db_factory
 ) -> None:
     _agent_shell_caller(monkeypatch)
-    db_path, agent_store = _caller_session_state(tmp_path)
+    db_path, agent_store = _caller_session_state(tmp_path, sqlite_schema_db_factory)
     store = _command_task_store(tmp_path)
     args = _parse_task_add(
         [
@@ -4959,7 +4959,7 @@ def test_task_add_escalating_command_task_binds_caller_session(
 
 
 def test_task_add_escalating_command_task_accepts_an_explicit_cwd(
-    tmp_path: Path, capsys, monkeypatch
+    tmp_path: Path, capsys, monkeypatch, sqlite_schema_db_factory
 ) -> None:
     """SCT-050 -- the command's directory is not the bound Session's question.
 
@@ -4975,7 +4975,7 @@ def test_task_add_escalating_command_task_accepts_an_explicit_cwd(
     """
 
     _agent_shell_caller(monkeypatch)
-    db_path, agent_store = _caller_session_state(tmp_path)
+    db_path, agent_store = _caller_session_state(tmp_path, sqlite_schema_db_factory)
     store = _command_task_store(tmp_path)
     project = tmp_path / "project"
     project.mkdir()
@@ -5016,7 +5016,7 @@ def test_task_add_escalating_command_task_accepts_an_explicit_cwd(
 
 
 def test_task_add_escalating_command_task_rejects_a_missing_cwd(
-    tmp_path: Path, monkeypatch
+    tmp_path: Path, monkeypatch, sqlite_schema_db_factory
 ) -> None:
     """SCT-050 -- accepted does not mean unchecked, and the error must name the real problem.
 
@@ -5026,7 +5026,7 @@ def test_task_add_escalating_command_task_rejects_a_missing_cwd(
     """
 
     _agent_shell_caller(monkeypatch)
-    db_path, agent_store = _caller_session_state(tmp_path)
+    db_path, agent_store = _caller_session_state(tmp_path, sqlite_schema_db_factory)
     store = _command_task_store(tmp_path)
     args = _parse_task_add(
         [
@@ -5054,7 +5054,7 @@ def test_task_add_escalating_command_task_rejects_a_missing_cwd(
 
 
 def test_task_add_message_task_still_refuses_cwd_for_a_bound_session(
-    tmp_path: Path, monkeypatch
+    tmp_path: Path, monkeypatch, sqlite_schema_db_factory
 ) -> None:
     """SCT-050 -- the softened refusal is softened for commands only.
 
@@ -5064,7 +5064,7 @@ def test_task_add_message_task_still_refuses_cwd_for_a_bound_session(
     """
 
     _agent_shell_caller(monkeypatch)
-    db_path, agent_store = _caller_session_state(tmp_path)
+    db_path, agent_store = _caller_session_state(tmp_path, sqlite_schema_db_factory)
     store = _command_task_store(tmp_path)
     project = tmp_path / "project"
     project.mkdir()
@@ -5085,7 +5085,7 @@ def test_task_add_message_task_still_refuses_cwd_for_a_bound_session(
 
 
 def test_task_add_per_run_command_records_the_directory_it_was_described_in(
-    tmp_path: Path, capsys, monkeypatch
+    tmp_path: Path, capsys, monkeypatch, sqlite_schema_db_factory
 ) -> None:
     """SCT-047 -- a command whose Session does not exist yet still runs somewhere.
 
@@ -5103,7 +5103,7 @@ def test_task_add_per_run_command_records_the_directory_it_was_described_in(
     """
 
     _bare_terminal_caller(monkeypatch)
-    db_path = tmp_path / "state" / "vibe.sqlite"
+    db_path = sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     agent_store = cli.VibeAgentStore(db_path)
     agent_store.create(name="worker", backend="codex")
     store = _command_task_store(tmp_path)

--- a/tests/test_resource_access_service.py
+++ b/tests/test_resource_access_service.py
@@ -67,9 +67,9 @@ def _seed_policies(connection) -> None:
     )
 
 
-def test_resource_acl_is_enforced_for_editors_and_unknown_kinds_fail_closed(tmp_path) -> None:
+def test_resource_acl_is_enforced_for_editors_and_unknown_kinds_fail_closed(tmp_path, sqlite_schema_db_factory) -> None:
     db = tmp_path / "vibe.sqlite"
-    run_migrations(db)
+    sqlite_schema_db_factory(db)
     engine = create_sqlite_engine(db)
     try:
         with engine.begin() as connection:
@@ -95,9 +95,9 @@ def test_resource_acl_is_enforced_for_editors_and_unknown_kinds_fail_closed(tmp_
         engine.dispose()
 
 
-def test_personal_editor_uses_all_agents_without_organization_acl(tmp_path) -> None:
+def test_personal_editor_uses_all_agents_without_organization_acl(tmp_path, sqlite_schema_db_factory) -> None:
     db = tmp_path / "vibe.sqlite"
-    run_migrations(db)
+    sqlite_schema_db_factory(db)
     engine = create_sqlite_engine(db)
     try:
         with engine.begin() as connection:
@@ -144,7 +144,7 @@ def test_personal_editor_uses_all_agents_without_organization_acl(tmp_path) -> N
         engine.dispose()
 
 
-def test_show_page_is_no_longer_a_resource_kind(monkeypatch, tmp_path) -> None:
+def test_show_page_is_no_longer_a_resource_kind(monkeypatch, tmp_path, sqlite_schema_db_factory) -> None:
     """§3.2 retired show_page from the Resource ACL: every entry point fails
     closed with ``invalid_resource_kind`` and nothing reads or writes a
     ``resource_access_policies`` row for it.
@@ -152,7 +152,7 @@ def test_show_page_is_no_longer_a_resource_kind(monkeypatch, tmp_path) -> None:
 
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
     db = tmp_path / "vibe.sqlite"
-    run_migrations(db)
+    sqlite_schema_db_factory(db)
     engine = create_sqlite_engine(db)
     owner = _context("owner-1", instance_role="owner", access_source="owner")
     try:
@@ -215,14 +215,14 @@ def _insert_legacy_show_page_policy(connection, *, organization_id: str | None, 
     )
 
 
-def test_retired_show_page_rows_stay_inert_in_unscoped_queries(tmp_path) -> None:
+def test_retired_show_page_rows_stay_inert_in_unscoped_queries(tmp_path, sqlite_schema_db_factory) -> None:
     """§3.2 kept legacy ``show_page`` policy rows in place for load safety, but
     unscoped queries must not resurrect them: neither the sync organization
     enumeration nor an unscoped policy listing may surface a retired kind.
     """
 
     db = tmp_path / "vibe.sqlite"
-    run_migrations(db)
+    sqlite_schema_db_factory(db)
     engine = create_sqlite_engine(db)
     try:
         with engine.begin() as connection:
@@ -319,9 +319,9 @@ def test_resource_policy_narrowing_matrix(
     )
 
 
-def test_active_org_members_can_use_legacy_resources_without_forging_local_identity(tmp_path) -> None:
+def test_active_org_members_can_use_legacy_resources_without_forging_local_identity(tmp_path, sqlite_schema_db_factory) -> None:
     db = tmp_path / "vibe.sqlite"
-    run_migrations(db)
+    sqlite_schema_db_factory(db)
     engine = create_sqlite_engine(db)
     try:
         with engine.connect() as connection:
@@ -350,9 +350,9 @@ def test_active_org_members_can_use_legacy_resources_without_forging_local_ident
         engine.dispose()
 
 
-def test_non_member_role_rank_does_not_bypass_organization_resource_acl(tmp_path) -> None:
+def test_non_member_role_rank_does_not_bypass_organization_resource_acl(tmp_path, sqlite_schema_db_factory) -> None:
     db = tmp_path / "vibe.sqlite"
-    run_migrations(db)
+    sqlite_schema_db_factory(db)
     engine = create_sqlite_engine(db)
     try:
         with engine.begin() as connection:
@@ -702,7 +702,7 @@ def test_migrate_legacy_deferred_contexts_binds_definitions_and_queued_deliverie
     tmp_path,
     paired_kind: str,
     access_source: str,
-    organization_claims: bool,
+    organization_claims: bool, sqlite_schema_db_factory,
 ) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
     config = V2Config.default()
@@ -729,7 +729,7 @@ def test_migrate_legacy_deferred_contexts_binds_definitions_and_queued_deliverie
         )
     legacy_metadata = {resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY: legacy_context}
     db = tmp_path / "vibe.sqlite"
-    run_migrations(db)
+    sqlite_schema_db_factory(db)
     store = SQLiteBackgroundTaskStore(db)
     engine = create_sqlite_engine(db)
     try:
@@ -872,7 +872,7 @@ def test_migrate_legacy_deferred_contexts_binds_definitions_and_queued_deliverie
         engine.dispose()
 
 
-def test_legacy_migration_keeps_opposite_instance_semantics_unbound(monkeypatch, tmp_path) -> None:
+def test_legacy_migration_keeps_opposite_instance_semantics_unbound(monkeypatch, tmp_path, sqlite_schema_db_factory) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
     config = V2Config.default()
     config.remote_access.vibe_cloud.enabled = True
@@ -891,7 +891,7 @@ def test_legacy_migration_keeps_opposite_instance_semantics_unbound(monkeypatch,
         }
     }
     db = tmp_path / "vibe.sqlite"
-    run_migrations(db)
+    sqlite_schema_db_factory(db)
     store = SQLiteBackgroundTaskStore(db)
     engine = create_sqlite_engine(db)
     try:
@@ -929,7 +929,7 @@ def test_legacy_migration_keeps_opposite_instance_semantics_unbound(monkeypatch,
         engine.dispose()
 
 
-def test_legacy_migration_does_not_bind_after_later_pairing(monkeypatch, tmp_path) -> None:
+def test_legacy_migration_does_not_bind_after_later_pairing(monkeypatch, tmp_path, sqlite_schema_db_factory) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
     config = V2Config.default()
     config.remote_access.vibe_cloud.enabled = False
@@ -943,7 +943,7 @@ def test_legacy_migration_does_not_bind_after_later_pairing(monkeypatch, tmp_pat
         }
     }
     db = tmp_path / "vibe.sqlite"
-    run_migrations(db)
+    sqlite_schema_db_factory(db)
     store = SQLiteBackgroundTaskStore(db)
     engine = create_sqlite_engine(db)
     try:
@@ -1001,7 +1001,7 @@ def test_legacy_migration_does_not_bind_after_later_pairing(monkeypatch, tmp_pat
 
 def test_legacy_migration_retries_when_same_pairing_kind_is_backfilled(
     monkeypatch,
-    tmp_path,
+    tmp_path, sqlite_schema_db_factory,
 ) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
     config = V2Config.default()
@@ -1019,7 +1019,7 @@ def test_legacy_migration_retries_when_same_pairing_kind_is_backfilled(
         }
     }
     db = tmp_path / "vibe.sqlite"
-    run_migrations(db)
+    sqlite_schema_db_factory(db)
     store = SQLiteBackgroundTaskStore(db)
     engine = create_sqlite_engine(db)
     try:
@@ -1070,7 +1070,7 @@ def test_legacy_migration_retries_when_same_pairing_kind_is_backfilled(
 
 def test_legacy_migration_preserves_instance_id_while_pairing_is_partial(
     monkeypatch,
-    tmp_path,
+    tmp_path, sqlite_schema_db_factory,
 ) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
     config = V2Config.default()
@@ -1088,7 +1088,7 @@ def test_legacy_migration_preserves_instance_id_while_pairing_is_partial(
         }
     }
     db = tmp_path / "vibe.sqlite"
-    run_migrations(db)
+    sqlite_schema_db_factory(db)
     store = SQLiteBackgroundTaskStore(db)
     engine = create_sqlite_engine(db)
     try:
@@ -1149,7 +1149,7 @@ def test_legacy_migration_preserves_instance_id_while_pairing_is_partial(
 
 def test_typed_binding_reader_preserves_partial_identity_and_does_not_latch_read_failure(
     monkeypatch,
-    tmp_path,
+    tmp_path, sqlite_schema_db_factory,
 ) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
     config = V2Config.default()
@@ -1166,7 +1166,7 @@ def test_typed_binding_reader_preserves_partial_identity_and_does_not_latch_read
     assert partial.instance_kind == "personal"
 
     db = tmp_path / "vibe.sqlite"
-    run_migrations(db)
+    sqlite_schema_db_factory(db)
     engine = create_sqlite_engine(db)
     marker = {
         "schema_version": 2,
@@ -1301,7 +1301,7 @@ def _stored_migration_marker(connection) -> str | None:
 
 def test_partial_pairing_marker_records_configured_instance_without_claiming_a_kind(
     monkeypatch,
-    tmp_path,
+    tmp_path, sqlite_schema_db_factory,
 ) -> None:
     """A deferred opportunity keeps its identity but never a guessed kind."""
 
@@ -1309,7 +1309,7 @@ def test_partial_pairing_marker_records_configured_instance_without_claiming_a_k
     _paired_cloud_config(tmp_path, instance_secret="")
 
     db = tmp_path / "vibe.sqlite"
-    run_migrations(db)
+    sqlite_schema_db_factory(db)
     engine = create_sqlite_engine(db)
     try:
         from storage.importer import _run_sqlite_data_migrations
@@ -1331,7 +1331,7 @@ def test_partial_pairing_marker_records_configured_instance_without_claiming_a_k
 
 def test_credential_repair_on_the_same_pairing_completes_the_deferred_migration(
     monkeypatch,
-    tmp_path,
+    tmp_path, sqlite_schema_db_factory,
 ) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
     config = _paired_cloud_config(tmp_path, instance_secret="")
@@ -1342,7 +1342,7 @@ def test_credential_repair_on_the_same_pairing_completes_the_deferred_migration(
         "claims_issued_at": 1_700_000_000,
     }
     db = tmp_path / "vibe.sqlite"
-    run_migrations(db)
+    sqlite_schema_db_factory(db)
     store = SQLiteBackgroundTaskStore(db)
     engine = create_sqlite_engine(db)
     try:
@@ -1397,7 +1397,7 @@ def test_credential_repair_on_the_same_pairing_completes_the_deferred_migration(
 
 def test_transient_configuration_failure_leaves_the_migration_retryable(
     monkeypatch,
-    tmp_path,
+    tmp_path, sqlite_schema_db_factory,
 ) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
     _paired_cloud_config(tmp_path)
@@ -1408,7 +1408,7 @@ def test_transient_configuration_failure_leaves_the_migration_retryable(
         "claims_issued_at": 1_700_000_000,
     }
     db = tmp_path / "vibe.sqlite"
-    run_migrations(db)
+    sqlite_schema_db_factory(db)
     store = SQLiteBackgroundTaskStore(db)
     engine = create_sqlite_engine(db)
     try:
@@ -1458,7 +1458,7 @@ def test_transient_configuration_failure_leaves_the_migration_retryable(
 
 def test_unpaired_first_opportunity_cannot_be_adopted_by_a_later_pairing(
     monkeypatch,
-    tmp_path,
+    tmp_path, sqlite_schema_db_factory,
 ) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
     config = _paired_cloud_config(
@@ -1475,7 +1475,7 @@ def test_unpaired_first_opportunity_cannot_be_adopted_by_a_later_pairing(
         "claims_issued_at": 1_700_000_000,
     }
     db = tmp_path / "vibe.sqlite"
-    run_migrations(db)
+    sqlite_schema_db_factory(db)
     store = SQLiteBackgroundTaskStore(db)
     engine = create_sqlite_engine(db)
     try:
@@ -1510,7 +1510,7 @@ def test_unpaired_first_opportunity_cannot_be_adopted_by_a_later_pairing(
 
 def test_pending_marker_for_one_instance_cannot_be_adopted_by_another_instance(
     monkeypatch,
-    tmp_path,
+    tmp_path, sqlite_schema_db_factory,
 ) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
     config = _paired_cloud_config(tmp_path, instance_id="instance-a", instance_secret="")
@@ -1521,7 +1521,7 @@ def test_pending_marker_for_one_instance_cannot_be_adopted_by_another_instance(
         "claims_issued_at": 1_700_000_000,
     }
     db = tmp_path / "vibe.sqlite"
-    run_migrations(db)
+    sqlite_schema_db_factory(db)
     store = SQLiteBackgroundTaskStore(db)
     engine = create_sqlite_engine(db)
     try:
@@ -1567,7 +1567,7 @@ def test_shared_access_source_snapshots_migrate_for_either_pairing_kind(
     monkeypatch,
     tmp_path,
     paired_kind: str,
-    access_source: str,
+    access_source: str, sqlite_schema_db_factory,
 ) -> None:
     """``email``/``email_domain``/``public_instance`` are kind-agnostic.
 
@@ -1584,7 +1584,7 @@ def test_shared_access_source_snapshots_migrate_for_either_pairing_kind(
         "claims_issued_at": 1_700_000_000,
     }
     db = tmp_path / "vibe.sqlite"
-    run_migrations(db)
+    sqlite_schema_db_factory(db)
     store = SQLiteBackgroundTaskStore(db)
     engine = create_sqlite_engine(db)
     try:
@@ -1686,7 +1686,7 @@ def test_released_migration_marker_shapes_stay_idempotent_and_fail_closed(
     tmp_path,
     marker_json: str,
     expected_state: str | None,
-    expect_marker_preserved: bool,
+    expect_marker_preserved: bool, sqlite_schema_db_factory,
 ) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
     _paired_cloud_config(tmp_path)
@@ -1697,7 +1697,7 @@ def test_released_migration_marker_shapes_stay_idempotent_and_fail_closed(
         "claims_issued_at": 1_700_000_000,
     }
     db = tmp_path / "vibe.sqlite"
-    run_migrations(db)
+    sqlite_schema_db_factory(db)
     store = SQLiteBackgroundTaskStore(db)
     engine = create_sqlite_engine(db)
     try:
@@ -1770,9 +1770,9 @@ def test_pre_member_resource_user_context_snapshot_keeps_editor_role() -> None:
     assert not restored.can_manage_instance
 
 
-def test_organization_member_remains_subject_to_resource_acl_for_use(tmp_path) -> None:
+def test_organization_member_remains_subject_to_resource_acl_for_use(tmp_path, sqlite_schema_db_factory) -> None:
     db = tmp_path / "vibe.sqlite"
-    run_migrations(db)
+    sqlite_schema_db_factory(db)
     engine = create_sqlite_engine(db)
     try:
         with engine.begin() as connection:
@@ -1796,9 +1796,9 @@ def test_organization_member_remains_subject_to_resource_acl_for_use(tmp_path) -
         engine.dispose()
 
 
-def test_personal_resources_cannot_use_organization_access_levels(tmp_path) -> None:
+def test_personal_resources_cannot_use_organization_access_levels(tmp_path, sqlite_schema_db_factory) -> None:
     db = tmp_path / "vibe.sqlite"
-    run_migrations(db)
+    sqlite_schema_db_factory(db)
     engine = create_sqlite_engine(db)
     try:
         with engine.begin() as connection:
@@ -1817,7 +1817,7 @@ def test_personal_resources_cannot_use_organization_access_levels(tmp_path) -> N
 
 def test_migration_defers_to_a_disagreeing_durable_binding_row(
     monkeypatch,
-    tmp_path,
+    tmp_path, sqlite_schema_db_factory,
 ) -> None:
     """A binding row from a peer's reclassification outranks the config read.
 
@@ -1835,7 +1835,7 @@ def test_migration_defers_to_a_disagreeing_durable_binding_row(
         "claims_issued_at": 1_700_000_000,
     }
     db = tmp_path / "vibe.sqlite"
-    run_migrations(db)
+    sqlite_schema_db_factory(db)
     store = SQLiteBackgroundTaskStore(db)
     engine = create_sqlite_engine(db)
     try:
@@ -1878,7 +1878,7 @@ def test_migration_defers_to_a_disagreeing_durable_binding_row(
 
 def test_recovered_config_is_unavailable_and_does_not_seal_legacy_snapshots(
     monkeypatch,
-    tmp_path,
+    tmp_path, sqlite_schema_db_factory,
 ) -> None:
     """Regression PR #1606 r3: a recovered/defaulted V2Config.load() (broken
     JSON, load_warnings set) is UNAVAILABLE, never authoritative UNPAIRED.
@@ -1894,7 +1894,7 @@ def test_recovered_config_is_unavailable_and_does_not_seal_legacy_snapshots(
         "claims_issued_at": 1_700_000_000,
     }
     db = tmp_path / "vibe.sqlite"
-    run_migrations(db)
+    sqlite_schema_db_factory(db)
     store = SQLiteBackgroundTaskStore(db)
     engine = create_sqlite_engine(db)
     try:
@@ -1942,7 +1942,7 @@ def test_recovered_config_is_unavailable_and_does_not_seal_legacy_snapshots(
 
 def test_gate_under_writer_lock_does_not_open_a_second_write_connection(
     monkeypatch,
-    tmp_path,
+    tmp_path, sqlite_schema_db_factory,
 ) -> None:
     """Regression PR #1606 r3: resource_user_context_from_metadata is called
     while a queued-delivery transaction already holds reserve_write_lock.
@@ -1953,7 +1953,7 @@ def test_gate_under_writer_lock_does_not_open_a_second_write_connection(
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
     _paired_cloud_config(tmp_path)
     db = tmp_path / "vibe.sqlite"
-    run_migrations(db)
+    sqlite_schema_db_factory(db)
     engine = create_sqlite_engine(db)
     try:
         from storage.agent_session_rows import reserve_write_lock
@@ -2015,7 +2015,7 @@ def test_typed_reader_from_sqlite_migration_does_not_persist_config(
 
 def test_terminal_delivery_snapshots_are_left_byte_identical(
     monkeypatch,
-    tmp_path,
+    tmp_path, sqlite_schema_db_factory,
 ) -> None:
     """Regression PR #1606 r4: accepted/retired delivery snapshots are the
     immutable submitted Message candidate and must not be rewritten.
@@ -2024,7 +2024,7 @@ def test_terminal_delivery_snapshots_are_left_byte_identical(
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
     _paired_cloud_config(tmp_path)
     db = tmp_path / "vibe.sqlite"
-    run_migrations(db)
+    sqlite_schema_db_factory(db)
     engine = create_sqlite_engine(db)
     try:
         from storage.importer import _run_sqlite_data_migrations
@@ -2135,7 +2135,7 @@ def test_absent_binding_fails_closed_for_deferred_personal_context(
 
 def test_migration_stays_pending_without_a_validated_binding_row(
     monkeypatch,
-    tmp_path,
+    tmp_path, sqlite_schema_db_factory,
 ) -> None:
     """Regression PR #1606 r5: known-kind config + absent binding row must
     not complete the deferred-context migration or relabel snapshots.
@@ -2156,7 +2156,7 @@ def test_migration_stays_pending_without_a_validated_binding_row(
         "claims_issued_at": 1_700_000_000,
     }
     db = tmp_path / "vibe.sqlite"
-    run_migrations(db)
+    sqlite_schema_db_factory(db)
     store = SQLiteBackgroundTaskStore(db)
     engine = create_sqlite_engine(db)
     try:

--- a/tests/test_update_checker_platforms.py
+++ b/tests/test_update_checker_platforms.py
@@ -61,8 +61,9 @@ class _FakeIMClient:
         return self.message_id
 
 
-def test_get_admin_user_ids_includes_all_platforms(monkeypatch, tmp_path):
+def test_get_admin_user_ids_includes_all_platforms(monkeypatch, tmp_path, sqlite_schema_db_factory):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     SettingsStore.reset_instance()
     store = SettingsStore.get_instance()
     store.set_users_for_platform("slack", {"U1": UserSettings(display_name="Slack", is_admin=True)})
@@ -76,8 +77,9 @@ def test_get_admin_user_ids_includes_all_platforms(monkeypatch, tmp_path):
     assert set(admin_ids) == {"slack::U1", "discord::D1"}
 
 
-def test_update_notification_admin_dms_include_buttons_except_wechat(monkeypatch, tmp_path):
+def test_update_notification_admin_dms_include_buttons_except_wechat(monkeypatch, tmp_path, sqlite_schema_db_factory):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     SettingsStore.reset_instance()
     store = SettingsStore.get_instance()
     store.set_users_for_platform("slack", {"U1": UserSettings(display_name="Slack", is_admin=True)})
@@ -150,8 +152,9 @@ def test_fetch_update_notification_policy_reads_github_release_body():
     assert info == {"version": "1.0.1", "policy": "none", "error": None}
 
 
-def test_update_notification_returns_false_when_all_admin_dms_fail(monkeypatch, tmp_path):
+def test_update_notification_returns_false_when_all_admin_dms_fail(monkeypatch, tmp_path, sqlite_schema_db_factory):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     SettingsStore.reset_instance()
     store = SettingsStore.get_instance()
     store.set_users_for_platform("discord", {"123456789012345678": UserSettings(display_name="Discord", is_admin=True)})
@@ -170,8 +173,9 @@ def test_update_notification_returns_false_when_all_admin_dms_fail(monkeypatch, 
     assert delivered is False
 
 
-def test_failed_update_notification_does_not_defer_idle_auto_update(monkeypatch, tmp_path):
+def test_failed_update_notification_does_not_defer_idle_auto_update(monkeypatch, tmp_path, sqlite_schema_db_factory):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     SettingsStore.reset_instance()
     store = SettingsStore.get_instance()
     store.set_users_for_platform("discord", {"123456789012345678": UserSettings(display_name="Discord", is_admin=True)})
@@ -209,8 +213,9 @@ def test_failed_update_notification_does_not_defer_idle_auto_update(monkeypatch,
     assert performed == [("1.0.1", {})]
 
 
-def test_partial_admin_transport_readiness_defers_all_notifications_and_auto_update(monkeypatch, tmp_path):
+def test_partial_admin_transport_readiness_defers_all_notifications_and_auto_update(monkeypatch, tmp_path, sqlite_schema_db_factory):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     SettingsStore.reset_instance()
     store = SettingsStore.get_instance()
     store.set_users_for_platform(
@@ -269,8 +274,9 @@ def test_partial_admin_transport_readiness_defers_all_notifications_and_auto_upd
     assert performed == []
 
 
-def test_stale_admin_transport_does_not_block_auto_update(monkeypatch, tmp_path):
+def test_stale_admin_transport_does_not_block_auto_update(monkeypatch, tmp_path, sqlite_schema_db_factory):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     SettingsStore.reset_instance()
     store = SettingsStore.get_instance()
     store.set_users_for_platform(
@@ -316,8 +322,9 @@ def test_stale_admin_transport_does_not_block_auto_update(monkeypatch, tmp_path)
     assert performed == [("1.0.1", {})]
 
 
-def test_no_admin_discord_without_fallback_does_not_block_auto_update(monkeypatch, tmp_path):
+def test_no_admin_discord_without_fallback_does_not_block_auto_update(monkeypatch, tmp_path, sqlite_schema_db_factory):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     SettingsStore.reset_instance()
     controller = _StubController(SettingsStore.get_instance())
     controller.config.platform = "discord"
@@ -355,8 +362,9 @@ def test_no_admin_discord_without_fallback_does_not_block_auto_update(monkeypatc
     assert performed == [("1.0.1", {})]
 
 
-def test_silent_release_metadata_skips_notifications_but_keeps_auto_update(monkeypatch, tmp_path):
+def test_silent_release_metadata_skips_notifications_but_keeps_auto_update(monkeypatch, tmp_path, sqlite_schema_db_factory):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     SettingsStore.reset_instance()
     store = SettingsStore.get_instance()
     store.set_users_for_platform("slack", {"U1": UserSettings(display_name="Slack", is_admin=True)})
@@ -402,8 +410,9 @@ def test_silent_release_metadata_skips_notifications_but_keeps_auto_update(monke
     assert performed == [("1.0.1", {"suppress_post_update_notification": True})]
 
 
-def test_update_check_reconciles_askill_even_when_product_auto_update_disabled(monkeypatch, tmp_path):
+def test_update_check_reconciles_askill_even_when_product_auto_update_disabled(monkeypatch, tmp_path, sqlite_schema_db_factory):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     SettingsStore.reset_instance()
     checker = UpdateChecker(
         _StubController(SettingsStore.get_instance()),
@@ -433,8 +442,9 @@ def test_update_check_reconciles_askill_even_when_product_auto_update_disabled(m
     assert performed == []
 
 
-def test_update_check_reconciles_askill_even_when_product_checks_disabled(monkeypatch, tmp_path):
+def test_update_check_reconciles_askill_even_when_product_checks_disabled(monkeypatch, tmp_path, sqlite_schema_db_factory):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     SettingsStore.reset_instance()
     checker = UpdateChecker(_StubController(SettingsStore.get_instance()), UpdateConfig(check_interval_minutes=0))
     reconciled = []
@@ -449,8 +459,9 @@ def test_update_check_reconciles_askill_even_when_product_checks_disabled(monkey
     assert reconciled == [True]
 
 
-def test_update_check_loop_catches_python_310_asyncio_timeout(monkeypatch, tmp_path):
+def test_update_check_loop_catches_python_310_asyncio_timeout(monkeypatch, tmp_path, sqlite_schema_db_factory):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     SettingsStore.reset_instance()
     checker = UpdateChecker(
         _StubController(SettingsStore.get_instance()),
@@ -486,8 +497,9 @@ def test_update_check_loop_catches_python_310_asyncio_timeout(monkeypatch, tmp_p
     assert checks == [True, True]
 
 
-def test_suppressed_post_update_notification_writes_verification_marker(monkeypatch, tmp_path):
+def test_suppressed_post_update_notification_writes_verification_marker(monkeypatch, tmp_path, sqlite_schema_db_factory):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     SettingsStore.reset_instance()
     checker = UpdateChecker(_StubController(SettingsStore.get_instance()), UpdateConfig())
 
@@ -505,8 +517,9 @@ def test_suppressed_post_update_notification_writes_verification_marker(monkeypa
     assert data["suppress_success_notification"] is True
 
 
-def test_update_marker_records_platform_for_non_slack_callbacks(monkeypatch, tmp_path):
+def test_update_marker_records_platform_for_non_slack_callbacks(monkeypatch, tmp_path, sqlite_schema_db_factory):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     SettingsStore.reset_instance()
     checker = UpdateChecker(_StubController(SettingsStore.get_instance()), UpdateConfig())
 
@@ -519,8 +532,9 @@ def test_update_marker_records_platform_for_non_slack_callbacks(monkeypatch, tmp
     assert data["message_id"] == "42"
 
 
-def test_post_update_notification_uses_unicode_emoji_for_non_slack(monkeypatch, tmp_path):
+def test_post_update_notification_uses_unicode_emoji_for_non_slack(monkeypatch, tmp_path, sqlite_schema_db_factory):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     SettingsStore.reset_instance()
     store = SettingsStore.get_instance()
     controller = _StubController(store)
@@ -538,8 +552,9 @@ def test_post_update_notification_uses_unicode_emoji_for_non_slack(monkeypatch, 
     assert ":white_check_mark:" not in text
 
 
-def test_post_update_marker_waits_for_its_transport(monkeypatch, tmp_path):
+def test_post_update_marker_waits_for_its_transport(monkeypatch, tmp_path, sqlite_schema_db_factory):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     SettingsStore.reset_instance()
     controller = _StubController(SettingsStore.get_instance())
     telegram_client = _FakeIMClient()
@@ -562,8 +577,9 @@ def test_post_update_marker_waits_for_its_transport(monkeypatch, tmp_path):
     assert not marker.exists()
 
 
-def test_post_update_marker_is_retained_when_delivery_returns_none(monkeypatch, tmp_path):
+def test_post_update_marker_is_retained_when_delivery_returns_none(monkeypatch, tmp_path, sqlite_schema_db_factory):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     SettingsStore.reset_instance()
     controller = _StubController(SettingsStore.get_instance())
     telegram_client = _FakeIMClient(edit_result=None)
@@ -580,8 +596,9 @@ def test_post_update_marker_is_retained_when_delivery_returns_none(monkeypatch, 
     assert marker.exists()
 
 
-def test_no_channel_post_update_marker_tracks_completed_admin_platforms(monkeypatch, tmp_path):
+def test_no_channel_post_update_marker_tracks_completed_admin_platforms(monkeypatch, tmp_path, sqlite_schema_db_factory):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     SettingsStore.reset_instance()
     store = SettingsStore.get_instance()
     store.set_users_for_platform(
@@ -626,8 +643,9 @@ def test_no_channel_post_update_marker_tracks_completed_admin_platforms(monkeypa
     assert not marker.exists()
 
 
-def test_no_channel_post_update_marker_skips_disabled_admin_platforms(monkeypatch, tmp_path):
+def test_no_channel_post_update_marker_skips_disabled_admin_platforms(monkeypatch, tmp_path, sqlite_schema_db_factory):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     SettingsStore.reset_instance()
     store = SettingsStore.get_instance()
     store.set_users_for_platform(
@@ -651,8 +669,9 @@ def test_no_channel_post_update_marker_skips_disabled_admin_platforms(monkeypatc
     assert not marker.exists()
 
 
-def test_no_admin_discord_post_update_marker_uses_default_channel(monkeypatch, tmp_path):
+def test_no_admin_discord_post_update_marker_uses_default_channel(monkeypatch, tmp_path, sqlite_schema_db_factory):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     SettingsStore.reset_instance()
     store = SettingsStore.get_instance()
     store.update_channel("123456789012345678", ChannelSettings(enabled=True), platform="discord")
@@ -681,8 +700,9 @@ def test_no_admin_discord_post_update_marker_uses_default_channel(monkeypatch, t
     assert not marker.exists()
 
 
-def test_no_admin_discord_post_update_marker_clears_without_default_channel(monkeypatch, tmp_path):
+def test_no_admin_discord_post_update_marker_clears_without_default_channel(monkeypatch, tmp_path, sqlite_schema_db_factory):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     SettingsStore.reset_instance()
     controller = _StubController(SettingsStore.get_instance())
     controller.config.platform = "discord"
@@ -700,8 +720,9 @@ def test_no_admin_discord_post_update_marker_clears_without_default_channel(monk
     assert not marker.exists()
 
 
-def test_no_admin_discord_version_mismatch_uses_default_channel(monkeypatch, tmp_path):
+def test_no_admin_discord_version_mismatch_uses_default_channel(monkeypatch, tmp_path, sqlite_schema_db_factory):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     SettingsStore.reset_instance()
     store = SettingsStore.get_instance()
     store.update_channel("123456789012345678", ChannelSettings(enabled=True), platform="discord")
@@ -724,8 +745,9 @@ def test_no_admin_discord_version_mismatch_uses_default_channel(monkeypatch, tmp
     assert not marker.exists()
 
 
-def test_suppressed_post_update_marker_verifies_without_success_message(monkeypatch, tmp_path):
+def test_suppressed_post_update_marker_verifies_without_success_message(monkeypatch, tmp_path, sqlite_schema_db_factory):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     SettingsStore.reset_instance()
     controller = _StubController(SettingsStore.get_instance())
     telegram_client = _FakeIMClient()
@@ -747,8 +769,9 @@ def test_suppressed_post_update_marker_verifies_without_success_message(monkeypa
     assert not marker.exists()
 
 
-def test_auto_update_skips_unattended_source_checkout_install(monkeypatch, tmp_path):
+def test_auto_update_skips_unattended_source_checkout_install(monkeypatch, tmp_path, sqlite_schema_db_factory):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     SettingsStore.reset_instance()
     checker = UpdateChecker(
         _StubController(SettingsStore.get_instance()),
@@ -782,8 +805,9 @@ def test_auto_update_skips_unattended_source_checkout_install(monkeypatch, tmp_p
     assert checker.state.blocked_auto_update_version is None
 
 
-def test_restartless_auto_update_blocks_same_version_retry_and_notifies(monkeypatch, tmp_path):
+def test_restartless_auto_update_blocks_same_version_retry_and_notifies(monkeypatch, tmp_path, sqlite_schema_db_factory):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     SettingsStore.reset_instance()
     store = SettingsStore.get_instance()
     store.set_users_for_platform("telegram", {"123456": UserSettings(display_name="Telegram", is_admin=True)})
@@ -830,8 +854,9 @@ def test_restartless_auto_update_blocks_same_version_retry_and_notifies(monkeypa
     assert checker.state.blocked_auto_update_reason == "restart_not_scheduled"
 
 
-def test_install_failure_auto_update_remains_retryable(monkeypatch, tmp_path):
+def test_install_failure_auto_update_remains_retryable(monkeypatch, tmp_path, sqlite_schema_db_factory):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     SettingsStore.reset_instance()
     checker = UpdateChecker(
         _StubController(SettingsStore.get_instance()),
@@ -867,8 +892,9 @@ def test_install_failure_auto_update_remains_retryable(monkeypatch, tmp_path):
     assert checker.state.blocked_auto_update_reason is None
 
 
-def test_update_check_error_preserves_blocked_auto_update(monkeypatch, tmp_path):
+def test_update_check_error_preserves_blocked_auto_update(monkeypatch, tmp_path, sqlite_schema_db_factory):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     SettingsStore.reset_instance()
     checker = UpdateChecker(
         _StubController(SettingsStore.get_instance()),
@@ -888,8 +914,9 @@ def test_update_check_error_preserves_blocked_auto_update(monkeypatch, tmp_path)
     assert checker.state.blocked_auto_update_current_version == "3.0.3"
 
 
-def test_post_update_notification_accepts_newer_running_version(monkeypatch, tmp_path):
+def test_post_update_notification_accepts_newer_running_version(monkeypatch, tmp_path, sqlite_schema_db_factory):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     SettingsStore.reset_instance()
     controller = _StubController(SettingsStore.get_instance())
     telegram_client = _FakeIMClient()
@@ -908,8 +935,9 @@ def test_post_update_notification_accepts_newer_running_version(monkeypatch, tmp
     assert not marker.exists()
 
 
-def test_post_update_notification_skips_success_when_running_version_mismatches(monkeypatch, tmp_path):
+def test_post_update_notification_skips_success_when_running_version_mismatches(monkeypatch, tmp_path, sqlite_schema_db_factory):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     SettingsStore.reset_instance()
     controller = _StubController(SettingsStore.get_instance())
     telegram_client = _FakeIMClient()
@@ -932,7 +960,7 @@ def test_post_update_notification_skips_success_when_running_version_mismatches(
     assert not marker.exists()
 
 
-def test_a_version_that_did_not_take_effect_is_blocked_even_with_no_one_to_tell(monkeypatch, tmp_path):
+def test_a_version_that_did_not_take_effect_is_blocked_even_with_no_one_to_tell(monkeypatch, tmp_path, sqlite_schema_db_factory):
     """Blocking is decided by the version, not by whether anyone can be told.
 
     An instance whose upgrade failed and was rolled back is running the old
@@ -946,6 +974,7 @@ def test_a_version_that_did_not_take_effect_is_blocked_even_with_no_one_to_tell(
     """
 
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     SettingsStore.reset_instance()
     controller = _StubController(SettingsStore.get_instance())
     controller.im_clients = {}
@@ -961,8 +990,9 @@ def test_a_version_that_did_not_take_effect_is_blocked_even_with_no_one_to_tell(
     assert not (tmp_path / "state" / "pending_update_notification.json").exists()
 
 
-def test_stop_returns_cancellable_task(monkeypatch, tmp_path):
+def test_stop_returns_cancellable_task(monkeypatch, tmp_path, sqlite_schema_db_factory):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     SettingsStore.reset_instance()
 
     async def run_test():
@@ -977,8 +1007,9 @@ def test_stop_returns_cancellable_task(monkeypatch, tmp_path):
     asyncio.run(run_test())
 
 
-def test_start_keeps_running_for_managed_dependencies_when_product_checks_disabled(monkeypatch, tmp_path):
+def test_start_keeps_running_for_managed_dependencies_when_product_checks_disabled(monkeypatch, tmp_path, sqlite_schema_db_factory):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
     SettingsStore.reset_instance()
 
     async def run_test():


### PR DESCRIPTION
## Summary

Reduce measured repeated schema preparation in resource-access, CLI and update
checker tests. This is stage two of the owner's stability -> repeated preparation
-> multi-run measured shard review order. PR #1901 is already merged and its
master CI is green; this PR is not stacked on unmerged work.

Scope: `tests/conftest.py`, `tests/test_ci_test_fixtures.py`,
`tests/test_resource_access_service.py`, `tests/test_cli_task_command.py`,
`tests/test_update_checker_platforms.py`, and `docs/plans/ci-store-preparation.md`.

## Contracts and Scenarios

- Lazily build one closed/checkpointed raw Alembic-head template, then reuse the
  existing exclusive private-copy factory. Do not seed importer/default-Agent
  state and do not alter global automatic template opt-in detection.
- Preserve the real Resource ACL/legacy-context conversion paths, CLI HFR/SCT
  command admission and session behavior, and cross-platform update notifications.
  Original stores, importers, query data, mutations and assertions stay real.
- First SQLite bootstrap, migration/config lock-boundary and an already-created
  store path remain untouched. No overwrite or shared mutable database.
- New contract checks the entire schema fingerprint, every initial row, persisted
  pragmas, integrity, mutation isolation, no overwrite and path bounds against a
  genuinely migrated reference database.

## Evidence

- Local unprofiled full modules: ACL 72 cases, 21.56s -> 2.78s; CLI 169 cases,
  21.22s -> 9.24s; update checker 35 cases, 13.72s -> 7.50s.
- 213 additional fixture/workflow/shard/real migration/settings tests passed,
  including all 129 historical migration cases. One interpreter per module.
- AST comparison retains all 1,038 assertions across 307 original functions;
  only explicit preparation calls and fixture plumbing differ.
- Ruff 0.4.9, 84-package consistency and whitespace checks passed.
- Actual CI timings and complete file/metrics/exit inventory remain required;
  local samples are not CI performance claims.

## Known by Design and Delivery

- No production, dependency, workflow, timeout, test-selection or runner change.
  All 17 checks and existing fail-closed aggregates remain required.
- Real migration/import/locking and package/Memory/Windows scenarios remain real.
  CLI parser construction is lower-cost and intentionally unchanged.
- Prior master CI took 9m20s despite a 6m53s green PR run. Host contention is not
  proven; do not rebalance from that variation or cherry-pick a faster rerun.
- PR #1901's old released-wheel upgrade timeout remains unexplained. Its new
  retained diagnostics are not a claim that a passing rerun fixed the root cause.
- No dependencies on unmerged PRs. No release, install or service operations.
- Initial review inventory: zero findings-bearing heads. Require current-head
  bot PASS, every matching lint run and all expected checks successful, zero
  whole-PR unresolved threads and CLEAN independent scope/integration before merge.
  Verify merged-source CI, then perform the multi-run shard review separately.

## Integrated Results and Stage-Three Decision

Merged as `20327369ada634b9187b1ad3bc3478df833e399e`; its source tree equals
the reviewed head. [PR CI](https://github.com/avibe-bot/avibe/actions/runs/34006937107)
passed in 6m40s; [master CI](https://github.com/avibe-bot/avibe/actions/runs/34007354215)
passed in 6m01s. Both were first attempts, with all 17 expected checks and all
405 selected unit files, metrics and Finished exits exactly once. Both also
passed all 21 distribution and 196 installer cases, including the actual released
3.0.13 core upgrade. The historical timeout remains unexplained.

Compared with preceding PR run 34005497283, ACL/CLI/update file wall times were
27.03/61.75/41.42s before, 6.44/25.94/21.55s in this PR, and 7.19/21.86/20.22s
on master. These are measured samples, not a guarantee of stable CI latency.

**Orchestrator decision: retain the existing six shards and timing snapshot in
this iteration.** Review used complete first-attempt green runs 34002971875,
34005497283, 34006127752 and both runs above, each with the same 405-file
inventory. For each optimized run held out of training, replay the unchanged
LPT planner using the other optimized run; the alternative also uses historical
median samples only where that test file's source blob is unchanged. The three
optimized consumers and fixture contracts never inherit pre-optimization weights.

| Held-out run | Actual maximum file work | Other optimized run weights | Eligible historical median weights |
| --- | ---: | ---: | ---: |
| PR 34006937107 | 362.28s | 335.16s | 332.91s |
| Master 34007354215 | 319.29s | 322.84s | 317.45s |

The replay columns are estimates, not executed CI or predicted workflow latency.
Master's six actual jobs span only 327-348s; even perfect file-work balancing
has a 309.57s lower bound, leaving at most 9.72s versus its current file-work
maximum before job overhead and other gates. Its installer aggregate already
finishes only eight seconds before the final unit aggregate. The median replay
improves this sample by just 1.85s, while single-run weights regress by 3.55s.
This does not support another rebalance as a material whole-workflow improvement.
No runner increase, algorithm rewrite, test removal, or cherry-picked rerun.
Host CPU/disk contention remains unproven; larger future persistent imbalance
needs new complete measured samples before revisiting the allocation.
