### PR TITLE
test(ci): separate completion assertions from deadline expiry

### DIFF
--- a/docs/plans/ci-model-hub-completion-boundary.md
+++ b/docs/plans/ci-model-hub-completion-boundary.md
@@ -1,0 +1,68 @@
+# CI Model Hub Completion Boundaries
+
+## Scope and Diagnosis
+
+The owner's order is stability, build/install preparation, then repeated work
+inside test calls. This PR addresses only the first phase. Source baseline is
+`85fe96897248c04bcf3d707b9f5872907597f377`; do not stack the following phases.
+
+Master run 34007676888 at `d802675cf4` failed the exact-request terminal-result
+case in `test_out_of_window_request_releases_finalization_ownership`: history
+was `failed_terminal`, not `served`. The gateway logged transport-deadline
+abandonment. Subsequent master run 34008143484 passed without changing this test
+or the gateway, which does not resolve the failure.
+
+The test selected a 20ms transport cleanup budget while asserting successful
+completion. A disposable probe delegated to the original close method after
+300ms of asynchronous delay and reproduced the exact assertion. An independent
+100ms delay before the original request JSON method reproduced premature drain
+cancellation in the adjacent body-attribution test, which selected 50ms. The
+same close probe reproduced lost metering in an L3 cancellation test selecting
+200ms. All three failures are expected consequences of their artificially short
+test budgets, not evidence that production should ignore its deadline.
+
+The unmodified retention module passed all 30 cases normally. Under the probe,
+the six selected cases produced three failures and three passes. The original
+CI's precise scheduling delay is not reconstructible; the controlled failures
+establish the test-contract problem without attributing it to runner resources.
+
+## Smallest Complete Change
+
+Remove transport-timeout overrides from the three non-deadline tests, retaining
+the real production default. The existing outer one/five-second waits still
+bound these tests. Keep every original assertion, input, real gateway method,
+ownership event, cancellation and final cleanup. No production code, workflow,
+CI timeout, dependency, runner count, test selection, sleeps or retries change.
+
+Whole-class inventory of short gateway budgets found four other cases that
+deliberately block parsing, teardown or fallback settlement to test deadline
+expiry. Their 20ms budgets and bounded-abandonment assertions remain unchanged.
+
+## Verification and Delivery
+
+Run the original full retention and L3 modules, the six delayed probe cases,
+transport/settlement consumers and lint. Compare the original functions after
+normalizing only these three constructor keyword removals: business bodies and
+assertions must be identical. Actual deadline regressions must still pass.
+
+Require head-bound Codex review, all 17 expected checks and every exact-head
+lint run successful, zero unresolved whole-PR threads, and independently clean
+scope/integration before guarded squash. Verify the exact merged-source CI
+before proceeding to build/install optimization. Initial findings-bearing
+review-head inventory is zero. No real model, production installation or service
+operation is involved.
+
+## Local Evidence
+
+- The six controlled-delay cases now pass (the same probe originally failed
+  three). The probe delegates to original methods and is not committed.
+- Separate-process complete suites: retention 30 passed; L3 312 passed and its
+  existing AC-50 expected failure remains unchanged.
+- Transport lease, usage and workflow consumers: 143 passed.
+- AST comparison of both complete modules preserves all 1,047 original
+  assertions and all business bodies after normalizing only the three keyword
+  removals. Four explicit deadline tests remain unchanged.
+- Ruff 0.4.9, all 83 installed package requirements and whitespace checks pass.
+
+Only private local test tooling was installed. Build/install preparation and
+test-call cost analysis remain subsequent stages, not claimed outcomes here.

--- a/tests/test_model_hub_l3.py
+++ b/tests/test_model_hub_l3.py
@@ -9588,7 +9588,7 @@ def test_buffered_adapter_facts_survive_cancellation_before_body_consumption(
             ],
         )
         requested_model = _canonicalize_fixed_test_routes(service)["codex"]
-        gateway = ModelHubTurnGateway(service, transport_timeout=0.2)
+        gateway = ModelHubTurnGateway(service)
         request = _prepared_gateway_request(
             gateway,
             turn_id="turn_meter_projection_cancel",

--- a/tests/test_model_hub_retention.py
+++ b/tests/test_model_hub_retention.py
@@ -230,7 +230,8 @@ def test_out_of_window_request_releases_finalization_ownership(tmp_path, exact_r
         agent = service.store.load().agents["codex"]
         new_model = next(model for model in agent.routes if model != old_model)
         agent.routes[new_model] = agent.routes[old_model]
-        gateway = ModelHubTurnGateway(service, transport_timeout=0.02)
+        # This checks ownership, not deadline expiry; normal cleanup must finish.
+        gateway = ModelHubTurnGateway(service)
         runtime = ModelHubRuntimeRouter(service=service, turn_gateway=gateway, overlay_path=tmp_path / "overlay.json")
         old_request = _prepared_gateway_request(
             gateway, turn_id="old-route", requested_model=old_model, source_id=source.id, stream=True
@@ -294,7 +295,7 @@ def test_body_claim_releases_request_already_snapshotted_by_finalization(tmp_pat
         old_model = _canonicalize_fixed_test_routes(service)["codex"]
         agent = service.store.load().agents["codex"]
         new_model = next(model for model in agent.routes if model != old_model)
-        gateway = ModelHubTurnGateway(service, transport_timeout=0.05)
+        gateway = ModelHubTurnGateway(service)
         runtime = ModelHubRuntimeRouter(service=service, turn_gateway=gateway, overlay_path=tmp_path / "overlay.json")
         request = _prepared_gateway_request(
             gateway, turn_id="old-route", requested_model=old_model, source_id=source.id, stream=True


### PR DESCRIPTION
## Summary

Keep Model Hub ownership and metering tests on the production transport budget
instead of making normal cleanup race a 20/50/200ms test-only deadline.
This is the stability stage of the owner's ordered CI optimization request;
build/install preparation and repeated test-call work follow after integration.

Scope: `tests/test_model_hub_retention.py`, `tests/test_model_hub_l3.py`, and
`docs/plans/ci-model-hub-completion-boundary.md`. No unmerged dependencies.

## Diagnosis and Contracts

- Master run 34007676888 failed exact-request terminal-result retention with
  `failed_terminal` instead of `served`, accompanied by transport abandonment.
- A controlled 300ms delay before the original close method reproduces that
  failure and lost metering in an adjacent cancellation scenario. A 100ms delay
  before the original JSON method reproduces a second premature ownership drain.
  The unmodified six-case probe gives three failures and three passes.
- Remove only three non-deadline constructor overrides. Keep original outer
  one/five-second waits, all business calls, cancellation, joins and assertions.
- Four intentional deadline/blocked-resource tests retain their short budgets
  and deadline recovery assertions. No production timeout or behavior changes.

## Evidence

- Same controlled probe after the change: all six cases pass.
- Complete separate-process retention: 30 passed. L3: 312 passed and one existing
  AC-50 expected failure unchanged. Transport/usage/workflow consumers: 143 passed.
- Whole-module AST comparison retains every original business body and 1,047
  assertions after normalizing only the three constructor keyword removals.
- Ruff 0.4.9, 83-package consistency and whitespace checks pass.
- Real CI, the installer/distribution cases and merged-source verification are
  required before delivery. No model inference or production service operations.

## Known by Design and Review Inventory

- A later unchanged master run passing does not establish that a flaky test is
  repaired. The old runner's exact scheduling delay cannot be reconstructed.
- No workflow, runner, dependency, selection, CI timeout, assertion, committed
  sleep or retry changes. No broader production cancellation rewrite.
- Initial findings-bearing review-head inventory: zero. Require head-bound bot
  PASS, every exact-head lint run and all 17 expected checks green, zero whole-PR
  unresolved threads, and CLEAN independent scope/integration before guarded merge.
- Keep one durable combined PR watch/cursor through final delivery; post-merge
  master verification is an independent once Actions concern.
