### PR TITLE
fix(delivery): render message metadata at native dispatch

### DIFF
--- a/core/agent_input.py
+++ b/core/agent_input.py
@@ -36,12 +36,14 @@ def without_legacy_metadata(text: str, *, original: str, user_id: str) -> str:
         return text
     time_line = r"\[Current Time: \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC[+-]\d{2}:\d{2}\]\n"
     identity_line = rf"\[[^\[\]<>\n]{{1,80}}<{re.escape(sanitize_identity(user_id))}>\]\n"
-    match = re.match(rf"(?:{time_line})?(?:{identity_line})?", text)
-    if match is None or match.end() == 0:
-        return text
-    body = text[match.end() :]
-    if _matches_original_body(body, original):
-        return body
+    # A user-authored first line may look like metadata. The immutable body,
+    # not a greedy match, decides which released prefix was actually added.
+    for prefix in (time_line + identity_line, time_line, identity_line):
+        match = re.match(prefix, text)
+        if match is not None:
+            body = text[match.end() :]
+            if _matches_original_body(body, original):
+                return body
     return text
 
 

--- a/core/agent_input.py
+++ b/core/agent_input.py
@@ -1,0 +1,55 @@
+"""Render execution-only metadata without changing canonical message content."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import re
+from typing import Any
+
+
+def sanitize_identity(value: str) -> str:
+    token = (value or "").replace("\n", " ").replace("\r", " ").strip()
+    token = token.replace("[", "(").replace("]", ")").replace("<", "(").replace(">", ")")
+    return token[:80] or "unknown"
+
+
+def without_legacy_metadata(text: str, *, original: str, user_id: str) -> str:
+    """Remove a released IM prefix only when the immutable body proves its extent."""
+    if text == original or text.startswith(original + "\n\n[Attachment Download Errors]"):
+        return text
+    time_line = r"\[Current Time: \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC[+-]\d{2}:\d{2}\]\n"
+    identity_line = rf"\[[^\[\]<>\n]{{1,80}}<{re.escape(sanitize_identity(user_id))}>\]\n"
+    match = re.match(rf"(?:{time_line})?(?:{identity_line})?", text)
+    if match is None or match.end() == 0:
+        return text
+    body = text[match.end() :]
+    if body == original or body.startswith(original + "\n\n[Attachment Download Errors]"):
+        return body
+    return text
+
+
+@dataclass(frozen=True)
+class AgentInputMetadata:
+    """Stable sender facts; the clock and display switches are evaluated on send."""
+
+    user_id: str | None = None
+    user_name: str | None = None
+    source_session_id: str | None = None
+
+    def render(self, text: str, config: Any, *, now: datetime | None = None) -> str:
+        lines: list[str] = []
+        if getattr(config, "include_time_info", True):
+            current = now or datetime.now().astimezone()
+            if current.tzinfo is None:
+                current = current.astimezone()
+            offset = current.strftime("%z")
+            if len(offset) == 5:
+                offset = f"{offset[:3]}:{offset[3:]}"
+            lines.append(f"[Now: {current.strftime('%Y-%m-%d %H:%M:%S')} UTC{offset}]")
+        if self.source_session_id:
+            lines.append(f"From: #{sanitize_identity(self.source_session_id)}")
+        if self.user_id and getattr(config, "include_user_info", True):
+            name = sanitize_identity(self.user_name or self.user_id)
+            lines.append(f"[{name}<{sanitize_identity(self.user_id)}>]")
+        return "\n".join([*lines, text]) if lines else text

--- a/core/agent_input.py
+++ b/core/agent_input.py
@@ -8,6 +8,22 @@ import re
 from typing import Any
 
 
+# Released wire titles must remain recognizable even if translations change.
+_LEGACY_ATTACHMENT_ERROR_TITLES = (
+    "Attachment Download Errors",
+    "\u9644\u4ef6\u4e0b\u8f7d\u9519\u8bef",
+)
+
+
+def _matches_original_body(text: str, original: str) -> bool:
+    if text == original:
+        return True
+    blocks = tuple(f"[{title}]\n" for title in _LEGACY_ATTACHMENT_ERROR_TITLES)
+    if text.startswith(original + "\n\n"):
+        return text[len(original) + 2 :].startswith(blocks)
+    return not original.strip() and text.startswith(blocks)
+
+
 def sanitize_identity(value: str) -> str:
     token = (value or "").replace("\n", " ").replace("\r", " ").strip()
     token = token.replace("[", "(").replace("]", ")").replace("<", "(").replace(">", ")")
@@ -16,7 +32,7 @@ def sanitize_identity(value: str) -> str:
 
 def without_legacy_metadata(text: str, *, original: str, user_id: str) -> str:
     """Remove a released IM prefix only when the immutable body proves its extent."""
-    if text == original or text.startswith(original + "\n\n[Attachment Download Errors]"):
+    if _matches_original_body(text, original):
         return text
     time_line = r"\[Current Time: \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC[+-]\d{2}:\d{2}\]\n"
     identity_line = rf"\[[^\[\]<>\n]{{1,80}}<{re.escape(sanitize_identity(user_id))}>\]\n"
@@ -24,7 +40,7 @@ def without_legacy_metadata(text: str, *, original: str, user_id: str) -> str:
     if match is None or match.end() == 0:
         return text
     body = text[match.end() :]
-    if body == original or body.startswith(original + "\n\n[Attachment Download Errors]"):
+    if _matches_original_body(body, original):
         return body
     return text
 

--- a/core/handlers/message_handler.py
+++ b/core/handlers/message_handler.py
@@ -3,7 +3,6 @@
 import asyncio
 import logging
 import inspect
-from datetime import datetime
 from typing import Any, List, Optional, Tuple
 
 from core.audio_asr import (
@@ -13,11 +12,11 @@ from core.audio_asr import (
     detect_audio_mime_from_sample,
     format_audio_transcript_echo,
 )
+from core.agent_input import AgentInputMetadata
 from core.backend_failure import emit_backend_failure
 from core.message_output import HARNESS_PROMPT_ECHO_SPEC_KEY
 from core.memory_adapter import TurnAccepted, snapshot_memory_files
 from core.message_context import (
-    SCHEDULED_DISPATCH_METADATA_APPLIED_KEY,
     resolve_context_thread_id,
 )
 from core.native_dispatch_phase import (
@@ -705,14 +704,6 @@ class MessageHandler(BaseHandler):
                 spec["backend_composite_session_id"] = composite_key
                 context.platform_specific = spec
 
-            durable_dispatch_text = None
-            if durable_ingress_enabled and not durable_delivery_owned:
-                durable_dispatch_text = await self._prepend_message_metadata(
-                    context,
-                    message,
-                    include_user_info=True,
-                )
-
             # Resolve remote attachments before admission so a queued Delivery
             # owns stable local media references and can survive a restart.
             processed_files = None
@@ -772,12 +763,11 @@ class MessageHandler(BaseHandler):
                 capture_lifecycle_snapshot = None
 
             if durable_ingress_enabled and not durable_delivery_owned:
-                assert durable_dispatch_text is not None
                 admitted = await self._admit_human_delivery(
                     manager=delivery_manager,
                     context=context,
                     dispatch_text=self._append_attachment_errors(
-                        durable_dispatch_text,
+                        message,
                         attachment_errors,
                     ),
                     display_text=control_message,
@@ -865,20 +855,8 @@ class MessageHandler(BaseHandler):
                 user_message = append_audio_transcripts_to_message(user_message, audio_transcripts)
                 await self._echo_audio_transcripts_if_enabled(context, audio_transcripts)
 
-            scheduled_metadata_applied = bool(
-                source == self.TURN_SOURCE_SCHEDULED
-                and (context.platform_specific or {}).get(
-                    SCHEDULED_DISPATCH_METADATA_APPLIED_KEY
-                )
-            )
-            if not (is_human and durable_delivery_owned) and not scheduled_metadata_applied:
-                message = await self._prepend_message_metadata(
-                    context,
-                    message,
-                    include_user_info=is_human,
-                )
-
             message = self._append_attachment_errors(message, attachment_errors)
+            input_metadata = await self.prepare_input_metadata(context, human=is_human)
 
             if vibe_agent:
                 spec = dict(context.platform_specific or {})
@@ -893,6 +871,7 @@ class MessageHandler(BaseHandler):
                 context=context,
                 message=message,
                 user_message=user_message,
+                input_metadata=input_metadata,
                 working_path=working_path,
                 base_session_id=base_session_id,
                 composite_session_id=composite_key,
@@ -1046,6 +1025,7 @@ class MessageHandler(BaseHandler):
         from storage.db import get_cached_sqlite_engine
 
         priority = priority_for_delivery_intent(delivery_intent)
+        author_name = await self._input_user_name(context)
         scope_id = None
         request = None
         duplicate_delivery_id = None
@@ -1127,6 +1107,7 @@ class MessageHandler(BaseHandler):
                         author="user",
                         message_type="user",
                         author_id=str(context.user_id or "").strip() or None,
+                        author_name=author_name,
                         display_text=display_text,
                         content_json=content,
                         admission_context=admission_context,
@@ -1412,38 +1393,15 @@ class MessageHandler(BaseHandler):
         spec[HARNESS_PROMPT_ECHO_SPEC_KEY] = message
         context.platform_specific = spec
 
-    @staticmethod
-    def _sanitize_identity(value: str) -> str:
-        """Strip control chars and delimiters that could break the [name<id>] format."""
-        token = (value or "").replace("\n", " ").replace("\r", " ").strip()
-        token = token.replace("[", "(").replace("]", ")").replace("<", "(").replace(">", ")")
-        return token[:80] or "unknown"
-
-    async def _prepend_user_info(self, context: MessageContext, message: str) -> str:
-        """Prepend user identity as [username<user_id>] to the message."""
-        user_info_line = await self._build_user_info_line(context)
-        return f"{user_info_line}\n{message}"
-
-    async def _prepend_message_metadata(
-        self,
-        context: MessageContext,
-        message: str,
-        *,
-        include_user_info: bool,
-    ) -> str:
-        """Prepend configured per-turn metadata lines to the agent message."""
-        metadata_lines: list[str] = []
-        if getattr(self.config, "include_time_info", True):
-            metadata_lines.append(self._build_current_time_line())
-        source_session_id = self._source_session_id(context)
-        if source_session_id:
-            metadata_lines.append(f"From: #{self._sanitize_identity(source_session_id)}")
-        if include_user_info and getattr(self.config, "include_user_info", True):
-            metadata_lines.append(await self._build_user_info_line(context))
-
-        if not metadata_lines:
-            return message
-        return "\n".join([*metadata_lines, message])
+    async def prepare_input_metadata(
+        self, context: MessageContext, *, human: bool
+    ) -> AgentInputMetadata:
+        """Resolve stable sender facts without rendering execution context."""
+        return AgentInputMetadata(
+            user_id=context.user_id if human else None,
+            user_name=await self._input_user_name(context) if human else None,
+            source_session_id=self._source_session_id(context) or None,
+        )
 
     @staticmethod
     def _source_session_id(context: MessageContext) -> str:
@@ -1456,31 +1414,32 @@ class MessageHandler(BaseHandler):
             return str(payload.get("source_actor") or "").strip()
         return ""
 
-    @staticmethod
-    def _build_current_time_line(now: datetime | None = None) -> str:
-        """Return the current local time with seconds and UTC offset."""
-        current = now or datetime.now().astimezone()
-        if current.tzinfo is None:
-            current = current.astimezone()
-        offset = current.strftime("%z")
-        if len(offset) == 5:
-            offset = f"{offset[:3]}:{offset[3:]}"
-        return f"[Current Time: {current.strftime('%Y-%m-%d %H:%M:%S')} UTC{offset}]"
-
-    async def _build_user_info_line(self, context: MessageContext) -> str:
-        """Return user identity as [username<user_id>]."""
+    async def _input_user_name(self, context: MessageContext) -> str:
+        payload = context.platform_specific or {}
+        if payload.get("author_name") and payload.get("author_id") == context.user_id:
+            return str(payload["author_name"])
         try:
             user_info = await self._get_im_client(context).get_user_info(context.user_id)
-            raw_name = self._resolve_user_display_name(user_info, context.user_id)
+            return self._resolve_user_display_name(user_info, context.user_id)
         except Exception as e:
             logger.debug(f"Failed to fetch user info for {context.user_id}: {e}")
-            raw_name = context.user_id
-        name = self._sanitize_identity(raw_name)
-        uid = self._sanitize_identity(context.user_id)
-        return f"[{name}<{uid}>]"
+            return context.user_id
+
+    @staticmethod
+    def _delivery_user_text(context: MessageContext) -> str | None:
+        payload = context.platform_specific or {}
+        content = payload.get("message_content")
+        if payload.get("delivery_ids") and isinstance(content, dict):
+            text = content.get("text")
+            if isinstance(text, str):
+                return text
+        return None
 
     @staticmethod
     def _get_control_message(context: MessageContext, message: str) -> str:
+        original = MessageHandler._delivery_user_text(context)
+        if original is not None:
+            return original
         payload = context.platform_specific or {}
         control_text = payload.get("control_text")
         if isinstance(control_text, str):
@@ -1489,6 +1448,9 @@ class MessageHandler(BaseHandler):
 
     @staticmethod
     def _get_user_message(context: MessageContext, message: str) -> str:
+        original = MessageHandler._delivery_user_text(context)
+        if original is not None:
+            return original
         payload = context.platform_specific or {}
         normalized_user_text = payload.get("normalized_user_text")
         if isinstance(normalized_user_text, str):

--- a/core/message_context.py
+++ b/core/message_context.py
@@ -11,7 +11,6 @@ from modules.im import MessageContext
 # Internal-only marker persisted with scheduled Delivery provenance. It keeps
 # durable turns from applying the backend-only metadata a second time when the
 # stored dispatch text is finally handed to MessageHandler.
-SCHEDULED_DISPATCH_METADATA_APPLIED_KEY = "scheduled_dispatch_metadata_applied"
 
 
 def resolve_context_platform(

--- a/core/services/agent_steering.py
+++ b/core/services/agent_steering.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Mapping
 
+from core.agent_input import AgentInputMetadata
+
 if TYPE_CHECKING:
     from modules.agents.base import AgentRequest
 
@@ -32,6 +34,7 @@ class SteerRequest:
     expected_native_turn_id: str
     text: str
     attempt_id: str = ""
+    input_metadata: AgentInputMetadata | None = None
 
 
 @dataclass(frozen=True)

--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -31,8 +31,8 @@ from sqlalchemy.exc import IntegrityError
 
 from core.web_push_notifications import WEB_PUSH_USER_KEY_METADATA, WEB_PUSH_USER_KEYS_METADATA
 from core.delivery_target import normalize_message_kind
+from core.agent_input import AgentInputMetadata
 from core.message_context import (
-    SCHEDULED_DISPATCH_METADATA_APPLIED_KEY,
     resolve_turn_sink_key,
 )
 from core.native_dispatch_phase import (
@@ -432,10 +432,33 @@ def _collect_delivery_segment(rows: list[dict[str, Any]]) -> list[dict[str, Any]
     return segment
 
 
+def _delivery_dispatch_text(delivery: dict[str, Any]) -> str:
+    text = str(delivery.get("dispatch_text") or "")
+    admission = delivery_store.delivery_admission_context(delivery)
+    route = admission.get("message_handler_route")
+    if not isinstance(route, dict):
+        return text
+    payload = delivery_store.delivery_payload(delivery)
+    if payload.get("source") != "user" or payload.get("platform") == "avibe":
+        return text
+    from core.agent_input import without_legacy_metadata
+    from modules.agents.subagent_router import parse_subagent_prefix
+
+    original = str(payload.get("text") or "")
+    if route.get("subagent_key"):
+        parsed = parse_subagent_prefix(original)
+        if parsed is not None:
+            original = parsed.message
+    return without_legacy_metadata(text, original=original, user_id=str(payload.get("author_id") or ""))
+
+
 def _segment_dispatch_text(segment: list[dict[str, Any]]) -> str:
-    texts = [str(row.get("dispatch_text") or "") for row in segment]
+    texts = [_delivery_dispatch_text(row) for row in segment]
     texts = [text for text in texts if text.strip()]
-    scheduled = bool(segment and _scheduled_merge_key(segment[0]) is not None)
+    leader = segment[0] if segment else {}
+    if "snapshot_json" in leader:
+        leader = delivery_store.delivery_payload(leader)
+    scheduled = _scheduled_merge_key(leader) is not None
     return ("\n\n---\n\n" if scheduled else "\n").join(texts)
 
 
@@ -1219,27 +1242,18 @@ class SessionTurnManager:
             raise RuntimeError("Session delivery context builder is not bound")
         return self._build_context(session_id)
 
-    async def prepare_scheduled_dispatch(
-        self,
-        context: "MessageContext",
-        text: str,
-        *,
-        delivery: Optional[dict[str, Any]] = None,
-        decorate: bool = True,
-    ) -> str:
-        """Restore scheduled provenance and optionally decorate backend text."""
-        if delivery is not None:
-            self._restore_scheduled_dispatch_context(context, delivery)
-        if not decorate:
-            return text
-        spec = dict(getattr(context, "platform_specific", None) or {})
-        if spec.get(SCHEDULED_DISPATCH_METADATA_APPLIED_KEY):
-            return text
+    async def _steer_input_metadata(self, deliveries: list[dict[str, Any]]) -> AgentInputMetadata | None:
+        """Attribute the inserted input to its sender, independently of the active Turn."""
         handler = getattr(self.controller, "message_handler", None)
-        decorator = getattr(handler, "_prepend_message_metadata", None)
-        if not callable(decorator) or not inspect.iscoroutinefunction(decorator):
-            return text
-        return await decorator(context, text, include_user_info=False)
+        prepare = getattr(handler, "prepare_input_metadata", None)
+        if not callable(prepare) or not inspect.iscoroutinefunction(prepare):
+            return None
+        context = self._delivery_context(str(deliveries[0]["session_id"]))
+        payload = self._hydrate_delivery_batch_context(context, deliveries)
+        scheduled = payload.get("source") == "harness"
+        if scheduled:
+            self._restore_scheduled_dispatch_context(context, deliveries[0])
+        return await prepare(context, human=not scheduled)
 
     @staticmethod
     def _restore_scheduled_dispatch_context(
@@ -2993,15 +3007,8 @@ class SessionTurnManager:
                 attempted_turn_id=turn_id,
             )
         elif delivery["state"] == "steering" and turn_id and attempt_id and native_id:
-            raw_steer_text = str(delivery.get("dispatch_text") or "")
-            if request.source == "harness" or _scheduled_provenance(delivery) is not None:
-                steer_text = await self.prepare_scheduled_dispatch(
-                    context,
-                    raw_steer_text,
-                    delivery=delivery,
-                )
-            else:
-                steer_text = raw_steer_text
+            steer_text = _delivery_dispatch_text(delivery)
+            input_metadata = await self._steer_input_metadata([delivery])
             receipt = await self._attempt_steer(
                 steer_backend,
                 SteerRequest(
@@ -3010,6 +3017,7 @@ class SessionTurnManager:
                     expected_native_turn_id=native_id,
                     text=steer_text,
                     attempt_id=attempt_id,
+                    input_metadata=input_metadata,
                 ),
             )
             return await self._finish_steer(str(delivery["id"]), receipt, context=context)
@@ -3174,19 +3182,16 @@ class SessionTurnManager:
                 attempted_turn_id=turn_id,
             )
         elif leader["state"] == "steering" and turn_id and attempt_id and native_id:
-            steer_text = await self.prepare_scheduled_dispatch(
-                context,
-                dispatch_text,
-                delivery=leader,
-            ) if _scheduled_provenance(leader) is not None else dispatch_text
+            input_metadata = await self._steer_input_metadata(claimed_rows)
             receipt = await self._attempt_steer(
                 steer_backend,
                 SteerRequest(
                     target_session_id=session_id,
                     expected_logical_turn_id=turn_id,
                     expected_native_turn_id=native_id,
-                    text=steer_text,
+                    text=_segment_dispatch_text(claimed_rows),
                     attempt_id=attempt_id,
+                    input_metadata=input_metadata,
                 ),
             )
             return await self._finish_steer(delivery_id, receipt, context=context)
@@ -4293,17 +4298,15 @@ class SessionTurnManager:
                     else str(delivery["id"])
                 )
             text = str(turn.get("dispatch_text") or "")
+            if source == SOURCE_HUMAN:
+                stored = "\n".join(str(row.get("dispatch_text") or "") for row in deliveries if row.get("dispatch_text"))
+                if stored and text.endswith(stored):
+                    text = text[: -len(stored)] + _segment_dispatch_text(deliveries)
             if source == SOURCE_SCHEDULED:
                 # Keep the raw prompt until MessageHandler parses an explicit
-                # ``subagent: prompt`` prefix. The handler adds metadata to the
-                # final backend request after routing; decorating here would make
-                # the metadata line hide that prefix from the parser.
-                await self.prepare_scheduled_dispatch(
-                    resolved,
-                    text,
-                    delivery=delivery,
-                    decorate=False,
-                )
+                # ``subagent: prompt`` prefix. The handler prepares structured
+                # metadata; only the native write renders it as text.
+                self._restore_scheduled_dispatch_context(resolved, delivery)
         except Exception:
             logger.exception(
                 "durable native start failed during pre-dispatch preparation for Turn=%s",
@@ -5307,18 +5310,10 @@ class SessionTurnManager:
                 )
                 if not claimed_batch:
                     continue
-                steer_text = "\n".join(
-                    str(row.get("dispatch_text") or "")
-                    for row in claimed_batch
-                    if str(row.get("dispatch_text") or "")
-                )
+                steer_text = _segment_dispatch_text(claimed_batch)
                 backend = str(turn["backend"])
                 delivery_id = str(claimed_batch[0]["id"])
-            steer_text = await self.prepare_scheduled_dispatch(
-                context,
-                steer_text,
-                delivery=claimed_batch[0],
-            ) if _scheduled_provenance(claimed_batch[0]) is not None else steer_text
+            input_metadata = await self._steer_input_metadata(claimed_batch)
             receipt = await self._attempt_steer(
                 backend,
                 SteerRequest(
@@ -5327,6 +5322,7 @@ class SessionTurnManager:
                     expected_native_turn_id=native_turn_id,
                     text=steer_text,
                     attempt_id=attempt_id,
+                    input_metadata=input_metadata,
                 ),
             )
             result = await self._finish_steer(delivery_id, receipt, context=context)

--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -2645,6 +2645,45 @@ class SessionTurnManager:
                 error_type=type(exc).__name__,
             )
 
+    async def _dispatch_steer_batch(
+        self,
+        backend: str,
+        deliveries: list[dict[str, Any]],
+        *,
+        logical_turn_id: str,
+        native_turn_id: str,
+        attempt_id: str,
+        context: "MessageContext",
+    ) -> DeliveryResult:
+        delivery_id = str(deliveries[0]["id"])
+        try:
+            metadata = await self._steer_input_metadata(deliveries)
+            request = SteerRequest(
+                target_session_id=str(deliveries[0]["session_id"]),
+                expected_logical_turn_id=logical_turn_id,
+                expected_native_turn_id=native_turn_id,
+                text=_segment_dispatch_text(deliveries),
+                attempt_id=attempt_id,
+                input_metadata=metadata,
+            )
+        except asyncio.CancelledError:
+            await self._finish_steer(
+                delivery_id,
+                steer_result(SteerOutcome.REFUSED, reason="preparation_cancelled"),
+                context=context,
+            )
+            raise
+        except Exception as exc:
+            logger.exception("steering preparation failed before native write for delivery=%s", delivery_id)
+            receipt = steer_result(
+                SteerOutcome.REFUSED,
+                reason="preparation_failed",
+                error_type=type(exc).__name__,
+            )
+        else:
+            receipt = await self._attempt_steer(backend, request)
+        return await self._finish_steer(delivery_id, receipt, context=context)
+
     async def _reconcile_steer_attempt(
         self,
         backend: str,
@@ -3007,20 +3046,14 @@ class SessionTurnManager:
                 attempted_turn_id=turn_id,
             )
         elif delivery["state"] == "steering" and turn_id and attempt_id and native_id:
-            steer_text = _delivery_dispatch_text(delivery)
-            input_metadata = await self._steer_input_metadata([delivery])
-            receipt = await self._attempt_steer(
+            return await self._dispatch_steer_batch(
                 steer_backend,
-                SteerRequest(
-                    target_session_id=request.session_id,
-                    expected_logical_turn_id=turn_id,
-                    expected_native_turn_id=native_id,
-                    text=steer_text,
-                    attempt_id=attempt_id,
-                    input_metadata=input_metadata,
-                ),
+                [delivery],
+                logical_turn_id=turn_id,
+                native_turn_id=native_id,
+                attempt_id=attempt_id,
+                context=context,
             )
-            return await self._finish_steer(str(delivery["id"]), receipt, context=context)
         return DeliveryResult(str(delivery["id"]), None, str(delivery["state"]), turn_id)
 
     async def _promote_fifo_head(
@@ -3182,19 +3215,14 @@ class SessionTurnManager:
                 attempted_turn_id=turn_id,
             )
         elif leader["state"] == "steering" and turn_id and attempt_id and native_id:
-            input_metadata = await self._steer_input_metadata(claimed_rows)
-            receipt = await self._attempt_steer(
+            return await self._dispatch_steer_batch(
                 steer_backend,
-                SteerRequest(
-                    target_session_id=session_id,
-                    expected_logical_turn_id=turn_id,
-                    expected_native_turn_id=native_id,
-                    text=_segment_dispatch_text(claimed_rows),
-                    attempt_id=attempt_id,
-                    input_metadata=input_metadata,
-                ),
+                claimed_rows,
+                logical_turn_id=turn_id,
+                native_turn_id=native_id,
+                attempt_id=attempt_id,
+                context=context,
             )
-            return await self._finish_steer(delivery_id, receipt, context=context)
         return DeliveryResult(delivery_id, None, str(leader["state"]), turn_id)
 
     async def _finish_steer(
@@ -5310,22 +5338,15 @@ class SessionTurnManager:
                 )
                 if not claimed_batch:
                     continue
-                steer_text = _segment_dispatch_text(claimed_batch)
                 backend = str(turn["backend"])
-                delivery_id = str(claimed_batch[0]["id"])
-            input_metadata = await self._steer_input_metadata(claimed_batch)
-            receipt = await self._attempt_steer(
+            result = await self._dispatch_steer_batch(
                 backend,
-                SteerRequest(
-                    target_session_id=session_id,
-                    expected_logical_turn_id=logical_turn_id,
-                    expected_native_turn_id=native_turn_id,
-                    text=steer_text,
-                    attempt_id=attempt_id,
-                    input_metadata=input_metadata,
-                ),
+                claimed_batch,
+                logical_turn_id=logical_turn_id,
+                native_turn_id=native_turn_id,
+                attempt_id=attempt_id,
+                context=context,
             )
-            result = await self._finish_steer(delivery_id, receipt, context=context)
             # Every row of the attempt settles together, so the leader's outcome
             # is the batch's outcome: accepted upgrades 👌 to ✍️, a definitive
             # refusal after the Session went inactive retires it to 🤷, and an

--- a/docs/plans/dispatch-time-message-metadata.md
+++ b/docs/plans/dispatch-time-message-metadata.md
@@ -42,3 +42,16 @@ mtime-guarded config at the shared render boundary, recognize released wire titl
 and empty-body formats without rewriting content, and settle pre-write failures
 as definitive refusals through the existing batch fallback. Only errors after
 entering the backend adapter retain the conservative unknown-outcome policy.
+
+The second findings-bearing head, `d7635351c`, repeated the legacy-parser class:
+one finding showed that a greedy optional identity match could consume the start
+of the immutable user body when only a timestamp had actually been added. The
+two-head circuit breaker was evaluated before another patch. Full inventory:
+`20a7d050b` had three findings (config reload, legacy body formats, pre-write
+steering settlement); `d7635351c` had one (legacy prefix-boundary selection).
+The first and third classes remain resolved. The orchestrator decision is to retain the
+data model and close the parser's finite protocol: test every released time/user
+switch combination against bodies beginning with those same prefix shapes, and
+accept a prefix candidate only when its remainder matches the immutable body.
+This replaces greedy boundary selection; it does not weaken body validation or
+expand historical rewriting. Native dispatch and persistence owners stay unchanged.

--- a/docs/plans/dispatch-time-message-metadata.md
+++ b/docs/plans/dispatch-time-message-metadata.md
@@ -31,3 +31,14 @@ not freeze the clock, every real input path receives configured metadata, and
 canonical content stays unchanged. Test sender/source restoration, merged input,
 configuration switches, native reconciliation, and released pending deliveries.
 No developer runtime restart is required for these tests.
+
+## Review Decisions
+
+At head `20a7d050b`, the first findings-bearing review identified three independent
+boundary gaps: cached display switches, incomplete released attachment-error
+formats, and steering preparation failures after durable attempt admission.
+Keep the existing model and close each gap at its owner: refresh the controller's
+mtime-guarded config at the shared render boundary, recognize released wire titles
+and empty-body formats without rewriting content, and settle pre-write failures
+as definitive refusals through the existing batch fallback. Only errors after
+entering the backend adapter retain the conservative unknown-outcome policy.

--- a/docs/plans/dispatch-time-message-metadata.md
+++ b/docs/plans/dispatch-time-message-metadata.md
@@ -1,0 +1,33 @@
+# Dispatch-Time Message Metadata
+
+## Contract
+
+User content, sender identity, and execution context have separate owners. Message
+snapshots remain the source of truth for display, Memory, analysis, and training.
+Delivery retains undecorated dispatch content for durable admission and recovery.
+Backend adapters render one shared metadata format immediately before writing a
+native input, after waiting for runtime readiness.
+
+`[Now: ...]` is the local wall-clock time at that native dispatch, including the
+UTC offset. It is not the sender's timestamp or the admission timestamp. The
+global time and identity switches apply when rendering. Harness source-session
+provenance remains independent of those switches. No formatted prefix is written
+back into canonical content. Native transcripts and reconciliation receipts may
+contain the actual rendered input.
+
+## Scope
+
+- Keep metadata structured through normal starts, queued batches, and steering.
+- Share rendering across Codex, Claude, and OpenCode, preserving exact native
+  reconciliation evidence and original user text.
+- Preserve released queued inputs without duplicating their legacy metadata.
+- Assert raw Message and Memory content independently of rendered backend input.
+- Preserve the existing schema, delivery ownership, and ambiguity policy.
+
+## Validation
+
+Focused handler, durable-delivery, and backend tests must prove that waiting does
+not freeze the clock, every real input path receives configured metadata, and
+canonical content stays unchanged. Test sender/source restoration, merged input,
+configuration switches, native reconciliation, and released pending deliveries.
+No developer runtime restart is required for these tests.

--- a/modules/agents/base.py
+++ b/modules/agents/base.py
@@ -11,6 +11,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 from modules.im import MessageContext
 from modules.im.base import FileAttachment
+from core.agent_input import AgentInputMetadata
 from core.agent_session_context import resolve_context_agent_session_target
 from core.message_output import MessageOutput, terminal_turn_output
 from core.reply_enhancer import strip_silent_blocks
@@ -79,6 +80,7 @@ class AgentRequest:
     # Result; the latest supplies ``output`` provenance and the whole batch is
     # settled after delivery. The shared dispatcher sees only ``output``.
     output_activities: List[Any] = field(default_factory=list)
+    input_metadata: AgentInputMetadata | None = None
 
 
 @dataclass
@@ -118,6 +120,10 @@ class BaseAgent(ABC):
         if callable(getter):
             return getter(context)
         return self.im_client
+
+    def render_input(self, text: str, metadata: AgentInputMetadata | None) -> str:
+        """Build a native request copy at the last write boundary."""
+        return metadata.render(text, self.config) if metadata is not None else text
 
     def _get_formatter(self, context: MessageContext):
         return getattr(self._get_im_client(context), "formatter", self.im_client.formatter)

--- a/modules/agents/base.py
+++ b/modules/agents/base.py
@@ -123,7 +123,12 @@ class BaseAgent(ABC):
 
     def render_input(self, text: str, metadata: AgentInputMetadata | None) -> str:
         """Build a native request copy at the last write boundary."""
-        return metadata.render(text, self.config) if metadata is not None else text
+        if metadata is None:
+            return text
+        refresh = getattr(self.controller, "_refresh_config_from_disk", None)
+        if callable(refresh):
+            refresh()
+        return metadata.render(text, self.config)
 
     def _get_formatter(self, context: MessageContext):
         return getattr(self._get_im_client(context), "formatter", self.im_client.formatter)

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -200,6 +200,7 @@ class ClaudeAgent(BaseAgent):
 
             # Prepare message with file attachment info if present
             message = self._prepare_message_with_files(request)
+            message = self.render_input(message, getattr(request, "input_metadata", None))
             input_receipt = self._register_native_input(
                 runtime_session_key,
                 message,
@@ -1112,14 +1113,15 @@ class ClaudeAgent(BaseAgent):
                 )
             writers = self._steering_writer_keys()
             writers.add(composite_key)
+            message = self.render_input(request.text, request.input_metadata)
             input_receipt = self._register_native_input(
                 composite_key,
-                request.text,
+                message,
                 kind="steer",
             )
             try:
                 try:
-                    await client.query(request.text, session_id=composite_key)
+                    await client.query(message, session_id=composite_key)
                 except (asyncio.TimeoutError, TimeoutError) as exc:
                     input_receipt.state = "unknown"
                     self._advance_steering_generation(composite_key)

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -599,7 +599,7 @@ class CodexAgent(BaseAgent):
                 {
                     "threadId": thread_id,
                     "expectedTurnId": request.expected_native_turn_id,
-                    "input": [{"type": "text", "text": request.text}],
+                    "input": [{"type": "text", "text": self.render_input(request.text, request.input_metadata)}],
                 },
             )
         except RuntimeError as exc:
@@ -3204,7 +3204,6 @@ class CodexAgent(BaseAgent):
     ) -> str:
         """Build input, configure overrides, and send turn/start to Codex."""
         agent_session_id = self._prompt_state_agent_session_id(request)
-        input_items = self._build_input(request)
         _, effective_model, effective_effort, _ = self._resolve_codex_agent_settings(request)
         model_explicit = bool(getattr(request, "vibe_agent_model_explicit", False))
         effort_explicit = bool(
@@ -3219,7 +3218,6 @@ class CodexAgent(BaseAgent):
 
         turn_params: Dict[str, Any] = {
             "threadId": thread_id,
-            "input": input_items,
             "approvalPolicy": "never",
             "sandboxPolicy": {"type": "dangerFullAccess"},
         }
@@ -3343,6 +3341,7 @@ class CodexAgent(BaseAgent):
         )
         if callable(snapshot_generated_images):
             snapshot_generated_images(thread_id, request.base_session_id)
+        turn_params["input"] = self._build_input(request)
         mark_backend_dispatch_attempted(request.context)
         try:
             resp = await transport.send_request("turn/start", turn_params)
@@ -3489,6 +3488,7 @@ class CodexAgent(BaseAgent):
             if len(file_lines) > 2:
                 message = f"{message}\n" + "\n".join(file_lines)
 
+        message = self.render_input(message, getattr(request, "input_metadata", None))
         if message:
             items.insert(0, {"type": "text", "text": message})
 

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -1646,6 +1646,7 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                 session_key=request.session_key,
             )
             active_poll_persisted = True
+            prompt_text = self.render_input(prompt_text, getattr(request, "input_metadata", None))
             mark_backend_dispatch_attempted(request.context)
             native_start_phase = "may_have_written"
             await server.prompt_async(
@@ -2063,11 +2064,12 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                         backend=self.name,
                     )
                 before_insert = _SteeringAwareOpenCodeServer._message_ids(messages)
+                prompt_text = self.render_input(request.text, request.input_metadata)
                 try:
                     prompt_kwargs = {
                         "session_id": native_session_id,
                         "directory": directory,
-                        "text": request.text,
+                        "text": prompt_text,
                         "agent": state.agent,
                         "model": state.model,
                         "reasoning_effort": state.reasoning_effort,
@@ -2083,13 +2085,13 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                     raise
                 except (asyncio.TimeoutError, TimeoutError, aiohttp.ClientConnectionError):
                     state.awaiting_after_message_ids = before_insert
-                    state.awaiting_user_text = request.text
+                    state.awaiting_user_text = prompt_text
                     state.awaiting_prompt_accepted = False
                     state.awaiting_prompt_activity_deadline = None
                     state.awaiting_active_status_observed = False
                     raise
                 state.awaiting_after_message_ids = before_insert
-                state.awaiting_user_text = request.text
+                state.awaiting_user_text = prompt_text
                 state.awaiting_prompt_accepted = True
                 state.awaiting_prompt_activity_deadline = (
                     time.monotonic()

--- a/storage/models.py
+++ b/storage/models.py
@@ -807,8 +807,8 @@ message_deliveries = Table(
     Column("state", String, nullable=False),
     Column("snapshot_json", Text, nullable=True),
     Column("snapshot_sha256", String, nullable=False),
-    # The exact backend-facing prompt is independent of Message display content
-    # and remains immutable after materialization for audit/recovery.
+    # Durable dispatch content is independent of Message display content.
+    # Execution metadata is rendered on a request copy at the native write.
     Column("dispatch_text", Text, nullable=True),
     Column("dispatch_sha256", String, nullable=False),
     Column("dedupe_key", Text, nullable=True),

--- a/tests/scenarios/message_delivery/catalog.yaml
+++ b/tests/scenarios/message_delivery/catalog.yaml
@@ -284,5 +284,17 @@ scenarios:
     kind: regression
     layer: scenario
     test: tests/test_session_delivery_fsm.py::test_wechat_outbound_send_uses_hydrated_author_id
+  - id: MESSAGE-DELIVERY-317
+    name: Delivery metadata stays separate from canonical Message and Memory content
+    status: covered
+    kind: regression
+    layer: contract
+    test: tests/test_message_handler_typing.py::MessageHandlerTypingTests::test_durable_input_keeps_canonical_text_for_memory_and_user_message
+  - id: MESSAGE-DELIVERY-318
+    name: Native dispatch samples Now after runtime preparation without rewriting user content
+    status: covered
+    kind: lifecycle
+    layer: contract
+    test: tests/test_agent_steering.py::test_codex_start_renders_now_after_runtime_prompt_preparation
 next_priority:
-  - MESSAGE-DELIVERY-317
+  - MESSAGE-DELIVERY-319

--- a/tests/scenarios/message_delivery/catalog.yaml
+++ b/tests/scenarios/message_delivery/catalog.yaml
@@ -296,5 +296,11 @@ scenarios:
     kind: lifecycle
     layer: contract
     test: tests/test_agent_steering.py::test_codex_start_renders_now_after_runtime_prompt_preparation
+  - id: MESSAGE-DELIVERY-319
+    name: Steering preparation failure preserves a definitively unwritten retryable batch
+    status: covered
+    kind: recovery
+    layer: contract
+    test: tests/test_session_delivery_fsm.py::test_steering_preparation_failure_preserves_a_definitively_unwritten_batch
 next_priority:
-  - MESSAGE-DELIVERY-319
+  - MESSAGE-DELIVERY-320

--- a/tests/test_agent_input.py
+++ b/tests/test_agent_input.py
@@ -8,6 +8,15 @@ from core.agent_input import AgentInputMetadata, without_legacy_metadata
 from vibe.i18n import get_supported_languages, get_translator
 
 
+_TIME_PREFIX = "[Current Time: 2026-08-02 11:00:00 UTC+08:00]\n"
+_IDENTITY_PREFIX = "[Alex<U1>]\n"
+_RELEASED_PREFIXES = tuple(
+    time_prefix + identity_prefix
+    for time_prefix in ("", _TIME_PREFIX)
+    for identity_prefix in ("", _IDENTITY_PREFIX)
+)
+
+
 def test_clock_and_switches_are_evaluated_for_each_native_input():
     metadata = AgentInputMetadata(user_id="U1", user_name="Alex")
     config = SimpleNamespace(include_time_info=True, include_user_info=True)
@@ -36,12 +45,12 @@ def test_switches_do_not_hide_harness_source(include_time, include_user):
     assert "<" not in rendered
 
 
-@pytest.mark.parametrize("time_prefix", ["", "[Current Time: 2026-08-02 11:00:00 UTC+08:00]\n"])
-@pytest.mark.parametrize("identity_prefix", ["", "[Alex<U1>]\n"])
+@pytest.mark.parametrize("prefix", _RELEASED_PREFIXES)
+@pytest.mark.parametrize("user_prefix", _RELEASED_PREFIXES)
 @pytest.mark.parametrize("suffix", ["", "\n\n[Attachment Download Errors]\nreport.pdf unavailable"])
-def test_legacy_prefix_removal_requires_the_original_body(time_prefix, identity_prefix, suffix):
-    original = "hello\n[Current Time: this is the user's own example]"
-    decorated = time_prefix + identity_prefix + original + suffix
+def test_legacy_prefix_removal_requires_the_original_body(prefix, user_prefix, suffix):
+    original = user_prefix + "hello\n[Current Time: this is the user's own example]"
+    decorated = prefix + original + suffix
     assert without_legacy_metadata(decorated, original=original, user_id="U1") == original + suffix
     assert without_legacy_metadata(decorated, original=decorated, user_id="U1") == decorated
 
@@ -53,12 +62,11 @@ def test_legacy_metadata_never_strips_a_different_body_or_sender():
 
 
 @pytest.mark.parametrize("language", get_supported_languages())
-@pytest.mark.parametrize("original", ["", " \t\n", "hello", "[Attachment Download Errors]\n- user example"])
-@pytest.mark.parametrize("prefix", [
-    "[Current Time: 2026-08-02 11:00:00 UTC+08:00]\n",
-    "[Alex<U1>]\n",
-    "[Current Time: 2026-08-02 11:00:00 UTC+08:00]\n[Alex<U1>]\n",
+@pytest.mark.parametrize("original", [
+    "", " \t\n", "[Attachment Download Errors]\n- user example",
+    *(prefix + "hello" for prefix in _RELEASED_PREFIXES),
 ])
+@pytest.mark.parametrize("prefix", _RELEASED_PREFIXES[1:])
 @pytest.mark.parametrize("append_first", [False, True])
 def test_legacy_attachment_blocks_match_the_released_producer(language, original, prefix, append_first):
     from core.handlers.message_handler import MessageHandler

--- a/tests/test_agent_input.py
+++ b/tests/test_agent_input.py
@@ -1,0 +1,51 @@
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from core.agent_input import AgentInputMetadata, without_legacy_metadata
+
+
+def test_clock_and_switches_are_evaluated_for_each_native_input():
+    metadata = AgentInputMetadata(user_id="U1", user_name="Alex")
+    config = SimpleNamespace(include_time_info=True, include_user_info=True)
+    original = "hello\n```text\n[Now: literal user content]\n```"
+    first = datetime(2026, 9, 6, 11, tzinfo=timezone(timedelta(hours=8)))
+    second = first + timedelta(minutes=10)
+    with patch("core.agent_input.datetime") as clock:
+        clock.now.return_value.astimezone.return_value = first
+        assert metadata.render(original, config) == f"[Now: 2026-09-06 11:00:00 UTC+08:00]\n[Alex<U1>]\n{original}"
+        clock.now.return_value.astimezone.return_value = second
+        assert metadata.render(original, config) == f"[Now: 2026-09-06 11:10:00 UTC+08:00]\n[Alex<U1>]\n{original}"
+        config.include_time_info = False
+        config.include_user_info = False
+        assert metadata.render(original, config) == original
+    assert metadata == AgentInputMetadata(user_id="U1", user_name="Alex")
+
+
+@pytest.mark.parametrize("include_time", [False, True])
+@pytest.mark.parametrize("include_user", [False, True])
+def test_switches_do_not_hide_harness_source(include_time, include_user):
+    config = SimpleNamespace(include_time_info=include_time, include_user_info=include_user)
+    metadata = AgentInputMetadata(source_session_id="ses-source")
+    rendered = metadata.render("work", config, now=datetime(2026, 9, 6, tzinfo=timezone.utc))
+    assert rendered.endswith("From: #ses-source\nwork")
+    assert ("[Now:" in rendered) is include_time
+    assert "<" not in rendered
+
+
+@pytest.mark.parametrize("time_prefix", ["", "[Current Time: 2026-08-02 11:00:00 UTC+08:00]\n"])
+@pytest.mark.parametrize("identity_prefix", ["", "[Alex<U1>]\n"])
+@pytest.mark.parametrize("suffix", ["", "\n\n[Attachment Download Errors]\nreport.pdf unavailable"])
+def test_legacy_prefix_removal_requires_the_original_body(time_prefix, identity_prefix, suffix):
+    original = "hello\n[Current Time: this is the user's own example]"
+    decorated = time_prefix + identity_prefix + original + suffix
+    assert without_legacy_metadata(decorated, original=original, user_id="U1") == original + suffix
+    assert without_legacy_metadata(decorated, original=decorated, user_id="U1") == decorated
+
+
+def test_legacy_metadata_never_strips_a_different_body_or_sender():
+    decorated = "[Current Time: 2026-08-02 11:00:00 UTC+08:00]\n[Alex<U1>]\nhello"
+    assert without_legacy_metadata(decorated, original="other", user_id="U1") == decorated
+    assert without_legacy_metadata(decorated, original="hello", user_id="U2") == decorated

--- a/tests/test_agent_input.py
+++ b/tests/test_agent_input.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from core.agent_input import AgentInputMetadata, without_legacy_metadata
+from vibe.i18n import get_supported_languages, get_translator
 
 
 def test_clock_and_switches_are_evaluated_for_each_native_input():
@@ -49,3 +50,32 @@ def test_legacy_metadata_never_strips_a_different_body_or_sender():
     decorated = "[Current Time: 2026-08-02 11:00:00 UTC+08:00]\n[Alex<U1>]\nhello"
     assert without_legacy_metadata(decorated, original="other", user_id="U1") == decorated
     assert without_legacy_metadata(decorated, original="hello", user_id="U2") == decorated
+
+
+@pytest.mark.parametrize("language", get_supported_languages())
+@pytest.mark.parametrize("original", ["", " \t\n", "hello", "[Attachment Download Errors]\n- user example"])
+@pytest.mark.parametrize("prefix", [
+    "[Current Time: 2026-08-02 11:00:00 UTC+08:00]\n",
+    "[Alex<U1>]\n",
+    "[Current Time: 2026-08-02 11:00:00 UTC+08:00]\n[Alex<U1>]\n",
+])
+@pytest.mark.parametrize("append_first", [False, True])
+def test_legacy_attachment_blocks_match_the_released_producer(language, original, prefix, append_first):
+    from core.handlers.message_handler import MessageHandler
+
+    handler = object.__new__(MessageHandler)
+    handler._t = get_translator(language)
+    errors = ["report.pdf unavailable", "image.png unavailable"]
+    if append_first:
+        body = handler._append_attachment_errors(original, errors)
+        decorated = prefix + body
+    else:
+        decorated = handler._append_attachment_errors(prefix + original, errors)
+        body = decorated[len(prefix):]
+    assert without_legacy_metadata(decorated, original=original, user_id="U1") == body
+    assert without_legacy_metadata(decorated, original=decorated, user_id="U1") == decorated
+
+
+def test_legacy_attachment_matching_does_not_accept_arbitrary_bracketed_suffixes():
+    decorated = "[Alex<U1>]\nhello\n\n[Another block]\n- not a released error"
+    assert without_legacy_metadata(decorated, original="hello", user_id="U1") == decorated

--- a/tests/test_agent_steering.py
+++ b/tests/test_agent_steering.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import asyncio
 import time
+from datetime import datetime, timezone
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import aiohttp
 import pytest
 from aiohttp.client_reqrep import ConnectionKey
+from core.agent_input import AgentInputMetadata
 
 from core.services.agent_steering import (
     ActiveSteerTarget,
@@ -33,6 +35,19 @@ from modules.im import MessageContext
 
 STEER_TEXT = "补充：**不要改写**\n```python\nprint('λ')\n```"
 ATTEMPT_ID = "atm_1234567890abcdef1234567890abcdef"
+
+
+@pytest.fixture(params=["plain", "human", "harness"])
+def native_input(request, monkeypatch):
+    now = datetime(2026, 9, 6, 11, 10, tzinfo=timezone.utc)
+    monkeypatch.setattr("core.agent_input.datetime", SimpleNamespace(
+        now=lambda: SimpleNamespace(astimezone=lambda: now)
+    ))
+    if request.param == "plain":
+        return None, ""
+    if request.param == "human":
+        return AgentInputMetadata(user_id="incoming", user_name="Sender"), "[Now: 2026-09-06 11:10:00 UTC+00:00]\n[Sender<incoming>]\n"
+    return AgentInputMetadata(source_session_id="source-session"), "[Now: 2026-09-06 11:10:00 UTC+00:00]\nFrom: #source-session\n"
 
 
 def test_steer_outcomes_are_exhaustive() -> None:
@@ -237,12 +252,13 @@ def _controller_with_active_gate(agent, primary: AgentRequest, gate_task: asynci
     return controller
 
 
-def _steer_request(native_turn_id: str, *, logical_turn_id: str = "logical-turn") -> SteerRequest:
+def _steer_request(native_turn_id: str, *, logical_turn_id: str = "logical-turn", input_metadata=None) -> SteerRequest:
     return SteerRequest(
         target_session_id="avibe-session",
         expected_logical_turn_id=logical_turn_id,
         expected_native_turn_id=native_turn_id,
         text=STEER_TEXT,
+        input_metadata=input_metadata,
     )
 
 
@@ -258,11 +274,13 @@ async def _cancel_tasks(*tasks: asyncio.Task) -> None:
 
 
 @pytest.mark.anyio
-async def test_codex_steers_expected_active_turn_without_starting_another_turn() -> None:
+async def test_codex_steers_expected_active_turn_without_starting_another_turn(native_input) -> None:
+    metadata, prefix = native_input
     primary = _primary_request(backend="codex")
     gate_task = await _held_task()
     transport = _CodexTransport()
     agent = object.__new__(CodexAgent)
+    agent.config = SimpleNamespace(include_time_info=True, include_user_info=True)
     agent._turn_registry = _CodexTurnRegistry(primary.base_session_id, "codex-turn")
     agent._session_mgr = _CodexSessionManager(primary.base_session_id, "codex-thread", primary.working_path)
     agent._transports = {primary.working_path: transport}
@@ -271,7 +289,10 @@ async def test_codex_steers_expected_active_turn_without_starting_another_turn()
         identity = active_steer_identity(controller, "codex", "avibe-session")
         assert identity == ("logical-turn", "codex-turn")
 
-        receipt = await steer_active_turn(controller, "codex", _steer_request(identity[1]))
+        request = _steer_request(identity[1], input_metadata=metadata)
+        receipt = await steer_active_turn(controller, "codex", request)
+        assert request.text == STEER_TEXT
+        assert primary.message == "primary"
 
         assert receipt.outcome is SteerOutcome.ACCEPTED
         assert transport.calls == [
@@ -280,7 +301,7 @@ async def test_codex_steers_expected_active_turn_without_starting_another_turn()
                 {
                     "threadId": "codex-thread",
                     "expectedTurnId": "codex-turn",
-                    "input": [{"type": "text", "text": STEER_TEXT}],
+                    "input": [{"type": "text", "text": prefix + STEER_TEXT}],
                 },
             )
         ]
@@ -289,6 +310,41 @@ async def test_codex_steers_expected_active_turn_without_starting_another_turn()
         assert not gate_task.done()
     finally:
         await _cancel_tasks(gate_task)
+
+
+@pytest.mark.anyio
+async def test_codex_start_renders_now_after_runtime_prompt_preparation(monkeypatch):
+    """Scenario: MESSAGE-DELIVERY-318."""
+    current = datetime(2026, 9, 6, 11, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr("core.agent_input.datetime", SimpleNamespace(
+        now=lambda: SimpleNamespace(astimezone=lambda: current)
+    ))
+    request = _primary_request(backend="codex")
+    request.input_metadata = AgentInputMetadata(user_id="sender", user_name="Sender")
+    agent = object.__new__(CodexAgent)
+    agent.config = SimpleNamespace(include_time_info=True, include_user_info=True)
+    agent.controller = SimpleNamespace()
+    agent._prompt_state_agent_session_id = lambda _request: None
+    agent._resolve_codex_agent_settings = lambda _request: (None, None, None, None)
+    agent._read_persisted_prompt_strategy_marker = Mock(return_value=None)
+    agent._write_caller_env_script = Mock()
+    agent._turn_registry = SimpleNamespace(
+        begin_turn_start=Mock(),
+        finalize_turn_start_response=Mock(return_value=SimpleNamespace()),
+    )
+
+    async def prepare_runtime(*_args, **_kwargs):
+        nonlocal current
+        await asyncio.sleep(0)
+        current = datetime(2026, 9, 6, 11, 10, tzinfo=timezone.utc)
+
+    agent._inject_thread_developer_instructions = AsyncMock(side_effect=prepare_runtime)
+    transport = SimpleNamespace(send_request=AsyncMock(return_value={"turn": {"id": "native-turn"}}))
+    await agent._start_turn(transport, request, "native-thread", developer_instructions="runtime instructions")
+    agent._inject_thread_developer_instructions.assert_awaited_once()
+    params = transport.send_request.await_args.args[1]
+    assert params["input"] == [{"type": "text", "text": "[Now: 2026-09-06 11:10:00 UTC+00:00]\n[Sender<sender>]\nprimary"}]
+    assert request.message == request.user_message == "primary"
 
 
 @pytest.mark.anyio
@@ -367,12 +423,14 @@ async def test_codex_rejects_stale_native_turn_and_unavailable_runtime() -> None
 
 
 @pytest.mark.anyio
-async def test_claude_uses_one_client_receiver_and_primary_result_owner() -> None:
+async def test_claude_uses_one_client_receiver_and_primary_result_owner(native_input) -> None:
+    metadata, prefix = native_input
     primary = _primary_request(backend="claude")
     gate_task = await _held_task()
     receiver_task = await _held_task()
     client = _ClaudeClient()
     agent = object.__new__(ClaudeAgent)
+    agent.config = SimpleNamespace(include_time_info=True, include_user_info=True)
     agent.claude_sessions = {"runtime-key": client}
     agent.receiver_tasks = {"runtime-key": receiver_task}
     agent.session_handler = _ClaudeSessionHandler("runtime-key")
@@ -384,10 +442,12 @@ async def test_claude_uses_one_client_receiver_and_primary_result_owner() -> Non
         assert identity is not None
         receiver_generation = identity[1]
 
-        receipt = await steer_active_turn(controller, "claude", _steer_request(receiver_generation))
+        request = _steer_request(receiver_generation, input_metadata=metadata)
+        receipt = await steer_active_turn(controller, "claude", request)
+        assert request.text == STEER_TEXT
 
         assert receipt.outcome is SteerOutcome.ACCEPTED
-        assert client.queries == [("primary", "runtime-key"), (STEER_TEXT, "runtime-key")]
+        assert client.queries == [("primary", "runtime-key"), (prefix + STEER_TEXT, "runtime-key")]
         assert agent.receiver_tasks == {"runtime-key": receiver_task}
         assert agent._pending_requests["runtime-key"] is primary_requests
         assert agent._pending_requests["runtime-key"] == [primary]
@@ -632,21 +692,25 @@ def _opencode_agent(primary: AgentRequest, task: asyncio.Task, server: _OpenCode
 
 
 @pytest.mark.anyio
-async def test_opencode_steers_existing_runner_without_abort_or_new_turn() -> None:
+async def test_opencode_steers_existing_runner_without_abort_or_new_turn(native_input) -> None:
+    metadata, prefix = native_input
     primary = _primary_request(backend="opencode")
     gate_task = await _held_task()
     server = _OpenCodeServer()
     agent = _opencode_agent(primary, gate_task, server)
+    agent.config = SimpleNamespace(include_time_info=True, include_user_info=True)
     controller = _controller_with_active_gate(agent, primary, gate_task)
     try:
         identity = active_steer_identity(controller, "opencode", "avibe-session")
         assert identity is not None
 
-        receipt = await steer_active_turn(controller, "opencode", _steer_request(identity[1]))
+        request = _steer_request(identity[1], input_metadata=metadata)
+        receipt = await steer_active_turn(controller, "opencode", request)
+        assert request.text == STEER_TEXT
 
         assert receipt.outcome is SteerOutcome.ACCEPTED
         state = agent._steering_states[primary.base_session_id]
-        assert state.awaiting_user_text == STEER_TEXT
+        assert state.awaiting_user_text == prefix + STEER_TEXT
         assert state.awaiting_prompt_accepted is True
         assert state.awaiting_prompt_activity_deadline is not None
         assert state.awaiting_prompt_activity_deadline > time.monotonic()
@@ -655,7 +719,7 @@ async def test_opencode_steers_existing_runner_without_abort_or_new_turn() -> No
             {
                 "session_id": "opencode-session",
                 "directory": primary.working_path,
-                "text": STEER_TEXT,
+                "text": prefix + STEER_TEXT,
                 "agent": "build",
                 "model": {"providerID": "openai", "modelID": "gpt-5"},
                 "reasoning_effort": "high",
@@ -894,9 +958,11 @@ async def test_opencode_replacement_waits_for_in_flight_steering_write() -> None
 
 @pytest.mark.anyio
 async def test_opencode_coordinator_error_aborts_through_steering_owner(
-    monkeypatch,
+    monkeypatch, native_input,
 ) -> None:
+    metadata, prefix = native_input
     primary = _primary_request(backend="opencode")
+    primary.input_metadata = metadata
     poll_started = asyncio.Event()
     fail_poll = asyncio.Event()
     steer_started = asyncio.Event()
@@ -921,6 +987,7 @@ async def test_opencode_coordinator_error_aborts_through_steering_owner(
         async def prompt_async(self, **kwargs):
             self.prompt_count += 1
             if self.prompt_count == 1:
+                assert kwargs["text"] == prefix + primary.message
                 events.append("primary")
                 return
             steer_started.set()
@@ -1046,7 +1113,7 @@ async def test_opencode_coordinator_error_aborts_through_steering_owner(
     agent._active_requests[primary.base_session_id] = process_task
     await poll_started.wait()
     state = agent._steering_states[primary.base_session_id]
-    assert state.awaiting_user_text == primary.message
+    assert state.awaiting_user_text == prefix + primary.message
     assert state.awaiting_prompt_accepted is True
     assert state.awaiting_prompt_activity_deadline is not None
     assert state.awaiting_prompt_activity_deadline > time.monotonic()

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -1,6 +1,7 @@
 import asyncio
 import sys
 import unittest
+from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import ANY, AsyncMock, MagicMock, Mock, patch
@@ -8,6 +9,7 @@ from unittest.mock import ANY, AsyncMock, MagicMock, Mock, patch
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from modules.agents.base import BaseAgent
+from core.agent_input import AgentInputMetadata
 from core.native_dispatch_phase import (
     DISPATCH_PHASE_PREWRITE,
     backend_dispatch_attempted,
@@ -1895,6 +1897,7 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         request = SimpleNamespace(
             context=request_context,
             message="hello",
+            input_metadata=AgentInputMetadata(user_id="U1", user_name="Sender"),
             working_path="/tmp/work",
             base_session_id="wechat_o9",
             composite_session_id="wechat_o9:/tmp/work",
@@ -1908,12 +1911,23 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
             files=None,
         )
 
-        await agent.handle_message(request)
+        with patch("core.agent_input.datetime") as clock:
+            clock.now.return_value.astimezone.return_value = datetime(2026, 9, 6, 11, tzinfo=timezone.utc)
+
+            async def prepare_session(*_args, **_kwargs):
+                clock.now.return_value.astimezone.return_value = datetime(2026, 9, 6, 11, 10, tzinfo=timezone.utc)
+                return client
+
+            controller.session_handler.get_or_create_claude_session.side_effect = prepare_session
+            await agent.handle_message(request)
         await asyncio.sleep(0)
 
         controller.session_handler.get_or_create_claude_session.assert_awaited_once()
         self.assertEqual(mark_active_calls, [runtime_key])
-        client.query.assert_awaited_once_with("hello", session_id=runtime_key)
+        client.query.assert_awaited_once_with(
+            "[Now: 2026-09-06 11:10:00 UTC+00:00]\n[Sender<U1>]\nhello", session_id=runtime_key,
+        )
+        self.assertEqual(request.message, "hello")
         self.assertIn(runtime_key, agent._pending_requests)
         self.assertIn(runtime_key, agent._pending_reactions)
         self.assertNotIn(request.composite_session_id, agent._pending_requests)

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -16,6 +16,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from core.processing_indicator import STOPPED_REACTION_EMOJI
 from core.runtime_activation import RuntimeActivationRegistry
+from modules.agents.base import BaseAgent as RealBaseAgent
 from modules.agents.codex.transport import CodexRPCError
 
 _AGENT_PATH = Path(__file__).resolve().parents[1] / "modules/agents/codex/agent.py"
@@ -29,6 +30,8 @@ setattr(_base_module, "AgentRequest", object)
 
 
 class _BaseAgent:
+    render_input = RealBaseAgent.render_input
+
     def __init__(self, controller):
         self.controller = controller
 

--- a/tests/test_controller_config_reload.py
+++ b/tests/test_controller_config_reload.py
@@ -1,7 +1,11 @@
 from types import SimpleNamespace
 
+import pytest
+
 from config.v2_config import DiscordConfig, TelegramConfig, V2Config
+from core.agent_input import AgentInputMetadata
 from core.controller import Controller
+from modules.agents.base import BaseAgent
 
 
 def _config_payload(discord_payload: dict | None = None, telegram_payload: dict | None = None) -> dict:
@@ -164,3 +168,36 @@ def test_progress_style_getter_self_refreshes_from_disk(tmp_path, monkeypatch) -
     # No prior _refresh_config_from_disk call; the getter itself must pick it up.
     assert controller.get_progress_style_for_context(None) == "concise"
     assert controller.get_heartbeat_interval_ms_for_context(None) == 8000
+
+
+@pytest.mark.parametrize("include_time", [False, True])
+@pytest.mark.parametrize("include_user", [False, True])
+def test_native_metadata_boundary_self_refreshes_switches_from_disk(
+    tmp_path, monkeypatch, include_time, include_user,
+) -> None:
+    """Scenario: MESSAGE-DELIVERY-318."""
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    controller = Controller.__new__(Controller)
+    controller.config = V2Config.from_payload({
+        **_config_payload(),
+        "include_time_info": not include_time,
+        "include_user_info": not include_user,
+    })
+    controller.im_clients = {}
+    controller._config_mtime = None
+    agent = SimpleNamespace(controller=controller, config=controller.config)
+    metadata = AgentInputMetadata(user_id="U1", user_name="Sender")
+    original = "queued original text"
+    latest_config = V2Config.from_payload({
+        **_config_payload(),
+        "include_time_info": include_time,
+        "include_user_info": include_user,
+    })
+    latest_config.save()
+
+    rendered = BaseAgent.render_input(agent, original, metadata)
+
+    assert ("[Now:" in rendered) is include_time
+    assert ("[Sender<U1>]" in rendered) is include_user
+    assert rendered.endswith(original)
+    assert controller._config_mtime is not None

--- a/tests/test_message_handler_harness_echo.py
+++ b/tests/test_message_handler_harness_echo.py
@@ -17,7 +17,6 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 from core.message_output import HARNESS_PROMPT_ECHO_SPEC_KEY
-from core.message_context import SCHEDULED_DISPATCH_METADATA_APPLIED_KEY
 from modules.im import MessageContext
 
 # Reuses the isolated module loader (and controller/session stubs) from the
@@ -37,7 +36,6 @@ def _build_handler():
     handler.set_session_handler(_StubSessionHandler())
     handler._admit_human_delivery = AsyncMock(return_value=False)
     handler._is_duplicate_human_delivery = Mock(return_value=False)
-    handler._prepend_message_metadata = AsyncMock(side_effect=lambda context, message, **_kw: message)
     return controller, handler
 
 
@@ -69,24 +67,22 @@ class MessageHandlerHarnessEchoTests(unittest.IsolatedAsyncioTestCase):
 
         await handler.handle_scheduled_message(_scheduled_context(), "summarize open PRs")
 
-        # The staged text is the RAW prompt: staging runs before
-        # ``_prepend_message_metadata`` decorates the text sent to the backend.
+        # The staged text is the raw prompt, independent of execution metadata.
         self.assertEqual(_staged_prompt(controller), "summarize open PRs")
         # And nothing is posted from here: the send waits for the runtime gate in
         # ``AgentService._begin_turn_status``, so a queued turn stays quiet.
         controller.message_dispatcher.emit_harness_prompt.assert_not_awaited()
 
-    async def test_durable_scheduled_text_with_metadata_marker_is_not_decorated_twice(self):
+    async def test_scheduled_input_carries_provenance_separately_from_text(self):
         controller, handler = _build_handler()
-        context = _scheduled_context(
-            **{SCHEDULED_DISPATCH_METADATA_APPLIED_KEY: True}
-        )
+        context = _scheduled_context(source_session_id="source")
 
-        await handler.handle_scheduled_message(context, "[Current Time: ...]\nFrom: #source\nwork")
+        await handler.handle_scheduled_message(context, "work")
 
-        handler._prepend_message_metadata.assert_not_awaited()
         _agent_name, request = controller.agent_service.requests[0]
-        self.assertEqual(request.message, "[Current Time: ...]\nFrom: #source\nwork")
+        self.assertEqual(request.message, "work")
+        self.assertEqual(request.input_metadata.source_session_id, "source")
+        self.assertIsNone(request.input_metadata.user_id)
 
     async def test_subagent_prefixed_prompt_is_staged_unstripped(self):
         """Scenario: MESSAGE-DELIVERY-018
@@ -126,7 +122,6 @@ class MessageHandlerHarnessEchoTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_scheduled_subagent_prefix_routes_before_hidden_provenance(self):
         controller, handler = _build_handler()
-        del handler._prepend_message_metadata
         context = _scheduled_context(
             source_kind="agent",
             source_actor="source-session",
@@ -159,8 +154,9 @@ class MessageHandlerHarnessEchoTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(request.subagent_name, "echo-probe")
         self.assertEqual(
             request.message,
-            "From: #source-session\naudit the queue",
+            "audit the queue",
         )
+        self.assertEqual(request.input_metadata.source_session_id, "source-session")
 
     async def test_human_turn_never_stages_a_prompt(self):
         controller, handler = _build_handler()

--- a/tests/test_message_handler_typing.py
+++ b/tests/test_message_handler_typing.py
@@ -57,6 +57,7 @@ def _load_message_handler_class():
             vibe_agent_reasoning_effort_explicit: bool = False
             vibe_agent_system_prompt: str | None = None
             files: list | None = None
+            input_metadata: object | None = None
 
         setattr(agents_module, "AgentRequest", _AgentRequest)
         sys.modules["modules.agents"] = agents_module
@@ -327,6 +328,33 @@ class _StubSessionHandler:
 
 
 class MessageHandlerTypingTests(unittest.IsolatedAsyncioTestCase):
+    async def test_durable_input_keeps_canonical_text_for_memory_and_user_message(self):
+        """Scenario: MESSAGE-DELIVERY-317."""
+        for platform in ("avibe", "slack"):
+            with self.subTest(platform=platform):
+                controller = _StubController(platform=platform, ack_mode="reaction", typing_result=True)
+                controller.config.include_time_info = True
+                controller.config.include_user_info = True
+                handler = MessageHandler(controller)
+                handler.set_session_handler(_StubSessionHandler())
+                original = "original user text\n[Now: literal example]"
+                context = MessageContext(
+                    user_id="sender", channel_id="session", platform=platform,
+                    message_id="message", is_original_human_text=True,
+                    platform_specific={
+                        "delivery_ids": ["delivery"],
+                        "message_content": {"text": original},
+                        "author_id": "sender", "author_name": "Sender",
+                    },
+                )
+                await handler.handle_user_message(context, "[Recovery context]\n" + original)
+                _, request = controller.agent_service.requests[0]
+                self.assertEqual(request.user_message, original)
+                self.assertEqual(request.message, "[Recovery context]\n" + original)
+                self.assertEqual(request.input_metadata.user_name, "Sender")
+                self.assertEqual([event.text for event in controller.memory_adapter.events], [original])
+                self.assertEqual(context.platform_specific["message_content"]["text"], original)
+
     async def test_im_human_input_enters_delivery_owner_before_backend(self):
         controller = _StubController(
             platform="slack",
@@ -339,9 +367,8 @@ class MessageHandlerTypingTests(unittest.IsolatedAsyncioTestCase):
         handler.set_session_handler(_StubSessionHandler())
         handler._admit_human_delivery = AsyncMock(return_value=True)
         handler._is_duplicate_human_delivery = Mock(return_value=False)
-        handler._prepend_message_metadata = AsyncMock(
-            return_value="[metadata]\nhello"
-        )
+        controller.config.include_time_info = True
+        controller.config.include_user_info = True
         context = MessageContext(
             user_id="U1",
             channel_id="C1",
@@ -354,7 +381,7 @@ class MessageHandlerTypingTests(unittest.IsolatedAsyncioTestCase):
         handler._admit_human_delivery.assert_awaited_once()
         assert (
             handler._admit_human_delivery.await_args.kwargs["dispatch_text"]
-            == "[metadata]\nhello"
+            == "hello"
         )
         controller.settings_manager.sessions.try_record_processed_message.assert_not_called()
         self.assertEqual(controller.agent_service.requests, [])
@@ -390,7 +417,6 @@ class MessageHandlerTypingTests(unittest.IsolatedAsyncioTestCase):
         handler.set_session_handler(_StubSessionHandler())
         handler._admit_human_delivery = AsyncMock(return_value=True)
         handler._is_duplicate_human_delivery = Mock(return_value=False)
-        handler._prepend_message_metadata = AsyncMock(return_value="check this")
         context = MessageContext(
             user_id="U1",
             channel_id="C1",
@@ -457,7 +483,6 @@ class MessageHandlerTypingTests(unittest.IsolatedAsyncioTestCase):
         handler = MessageHandler(controller)
         handler.set_session_handler(_StubSessionHandler())
         handler._is_duplicate_human_delivery = Mock(return_value=False)
-        handler._prepend_message_metadata = AsyncMock(return_value="review this")
         lease = Mock()
         attachment = FileAttachment(
             name="report.pdf",
@@ -507,7 +532,6 @@ class MessageHandlerTypingTests(unittest.IsolatedAsyncioTestCase):
         handler = MessageHandler(controller)
         handler.set_session_handler(_StubSessionHandler())
         handler._is_duplicate_human_delivery = Mock(return_value=False)
-        handler._prepend_message_metadata = AsyncMock(return_value="review this")
         handler._emit_agent_dispatch_failure = AsyncMock()
         lease = Mock()
         attachment = FileAttachment(
@@ -1427,6 +1451,7 @@ class MessageHandlerTypingTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_platform_specific_client_is_used_for_user_info(self):
         controller = _StubController(platform="slack", ack_mode="reaction", typing_result=True)
+        controller.config.include_user_info = True
         handler = MessageHandler(controller)
         context = MessageContext(user_id="wx-user", channel_id="wx-chat", platform="wechat")
 
@@ -1437,7 +1462,8 @@ class MessageHandlerTypingTests(unittest.IsolatedAsyncioTestCase):
         wechat_client = _WechatClient(typing_result=True)
         controller.get_im_client_for_context = lambda _context: wechat_client  # type: ignore[method-assign]
 
-        result = await handler._prepend_user_info(context, "hello")
+        metadata = await handler.prepare_input_metadata(context, human=True)
+        result = metadata.render("hello", controller.config)
 
         self.assertEqual(result, "[WeChat User<wx-user>]\nhello")
 
@@ -1586,7 +1612,6 @@ class MessageHandlerTypingTests(unittest.IsolatedAsyncioTestCase):
         controller.config.include_user_info = True
         handler = MessageHandler(controller)
         handler.set_session_handler(_StubSessionHandler())
-        handler._build_current_time_line = lambda: "[Current Time: 2026-07-26 16:00:00 UTC+08:00]"
         attachment_lease = Mock()
         handler._materialize_file_attachments = AsyncMock(
             return_value=types.SimpleNamespace(
@@ -1621,12 +1646,12 @@ class MessageHandlerTypingTests(unittest.IsolatedAsyncioTestCase):
         await handler.handle_user_message(context, "<@U_BOT> Investigate session title fallback")
 
         _, request = controller.agent_service.requests[0]
-        prepended_lines = request.message.splitlines()[:2]
         self.assertIn("<@U_BOT>", request.message)
         self.assertNotIn("<@U_BOT>", request.user_message)
         self.assertIn("[Audio Transcripts]", request.user_message)
         self.assertIn("Keep the user's words", request.user_message)
-        self.assertFalse(set(prepended_lines) & set(request.user_message.splitlines()))
+        self.assertNotIn("[Now:", request.message)
+        self.assertEqual(request.input_metadata.user_id, "U1")
         self.assertNotIn("[Attachment Download Errors]", request.user_message)
         self.assertIn("[Attachment Download Errors]", request.message)
 

--- a/tests/test_message_handler_user_info.py
+++ b/tests/test_message_handler_user_info.py
@@ -10,6 +10,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 from modules.im import MessageContext
+from core.agent_input import AgentInputMetadata
 
 
 def _load_message_handler_class():
@@ -73,17 +74,19 @@ class _StubController:
 
 class MessageHandlerUserInfoTests(unittest.IsolatedAsyncioTestCase):
     def test_build_current_time_line_uses_readable_utc_offset(self):
-        line = MessageHandler._build_current_time_line(
-            datetime(2026, 5, 13, 11, 42, 8, tzinfo=timezone(timedelta(hours=8)))
+        line = AgentInputMetadata().render(
+            "hello", types.SimpleNamespace(include_time_info=True),
+            now=datetime(2026, 5, 13, 11, 42, 8, tzinfo=timezone(timedelta(hours=8))),
         )
 
-        self.assertEqual(line, "[Current Time: 2026-05-13 11:42:08 UTC+08:00]")
+        self.assertEqual(line, "[Now: 2026-05-13 11:42:08 UTC+08:00]\nhello")
 
     async def test_prepend_user_info_prefers_real_name_over_name(self):
         handler = MessageHandler(_StubController({"display_name": "", "real_name": "Alex", "name": "cyh"}))
         context = MessageContext(user_id="U0E0FM3QT", channel_id="C1")
 
-        result = await handler._prepend_user_info(context, "hello")
+        metadata = await handler.prepare_input_metadata(context, human=True)
+        result = metadata.render("hello", types.SimpleNamespace(include_time_info=False))
 
         self.assertEqual(result, "[Alex<U0E0FM3QT>]\nhello")
 
@@ -91,7 +94,8 @@ class MessageHandlerUserInfoTests(unittest.IsolatedAsyncioTestCase):
         handler = MessageHandler(_StubController({"display_name": "Alex Chen", "real_name": "Alex", "name": "cyh"}))
         context = MessageContext(user_id="U0E0FM3QT", channel_id="C1")
 
-        result = await handler._prepend_user_info(context, "hello")
+        metadata = await handler.prepare_input_metadata(context, human=True)
+        result = metadata.render("hello", types.SimpleNamespace(include_time_info=False))
 
         self.assertEqual(result, "[Alex Chen<U0E0FM3QT>]\nhello")
 
@@ -99,28 +103,27 @@ class MessageHandlerUserInfoTests(unittest.IsolatedAsyncioTestCase):
         handler = MessageHandler(_StubController({"display_name": "", "real_name": "Alex", "name": "cyh"}))
         handler.config.include_time_info = True
         handler.config.include_user_info = True
-        handler._build_current_time_line = lambda: "[Current Time: 2026-05-13 11:42:08 UTC+08:00]"  # type: ignore[method-assign]
         context = MessageContext(user_id="U0E0FM3QT", channel_id="C1")
 
-        result = await handler._prepend_message_metadata(context, "hello", include_user_info=True)
+        metadata = await handler.prepare_input_metadata(context, human=True)
+        result = metadata.render("hello", handler.config, now=datetime(2026, 5, 13, 11, 42, 8, tzinfo=timezone(timedelta(hours=8))))
 
-        self.assertEqual(result, "[Current Time: 2026-05-13 11:42:08 UTC+08:00]\n[Alex<U0E0FM3QT>]\nhello")
+        self.assertEqual(result, "[Now: 2026-05-13 11:42:08 UTC+08:00]\n[Alex<U0E0FM3QT>]\nhello")
 
     async def test_prepend_message_metadata_can_include_time_without_user_info(self):
         handler = MessageHandler(_StubController({"display_name": "", "real_name": "Alex", "name": "cyh"}))
         handler.config.include_time_info = True
         handler.config.include_user_info = True
-        handler._build_current_time_line = lambda: "[Current Time: 2026-05-13 11:42:08 UTC+08:00]"  # type: ignore[method-assign]
         context = MessageContext(user_id="U0E0FM3QT", channel_id="C1")
 
-        result = await handler._prepend_message_metadata(context, "scheduled work", include_user_info=False)
+        metadata = await handler.prepare_input_metadata(context, human=False)
+        result = metadata.render("scheduled work", handler.config, now=datetime(2026, 5, 13, 11, 42, 8, tzinfo=timezone(timedelta(hours=8))))
 
-        self.assertEqual(result, "[Current Time: 2026-05-13 11:42:08 UTC+08:00]\nscheduled work")
+        self.assertEqual(result, "[Now: 2026-05-13 11:42:08 UTC+08:00]\nscheduled work")
 
     async def test_prepend_message_metadata_places_source_session_after_time(self):
         handler = MessageHandler(_StubController({"display_name": "", "real_name": "Alex", "name": "cyh"}))
         handler.config.include_time_info = True
-        handler._build_current_time_line = lambda: "[Current Time: 2026-05-13 11:42:08 UTC+08:00]"  # type: ignore[method-assign]
         context = MessageContext(
             user_id="caller",
             channel_id="C1",
@@ -130,11 +133,12 @@ class MessageHandlerUserInfoTests(unittest.IsolatedAsyncioTestCase):
             },
         )
 
-        result = await handler._prepend_message_metadata(context, "callback result", include_user_info=False)
+        metadata = await handler.prepare_input_metadata(context, human=False)
+        result = metadata.render("callback result", handler.config, now=datetime(2026, 5, 13, 11, 42, 8, tzinfo=timezone(timedelta(hours=8))))
 
         self.assertEqual(
             result,
-            "[Current Time: 2026-05-13 11:42:08 UTC+08:00]\n"
+            "[Now: 2026-05-13 11:42:08 UTC+08:00]\n"
             "From: #ses_sender123\ncallback result",
         )
 
@@ -150,7 +154,8 @@ class MessageHandlerUserInfoTests(unittest.IsolatedAsyncioTestCase):
             },
         )
 
-        result = await handler._prepend_message_metadata(context, "delegated work", include_user_info=False)
+        metadata = await handler.prepare_input_metadata(context, human=False)
+        result = metadata.render("delegated work", handler.config)
 
         self.assertEqual(result, "From: #ses_sender456\ndelegated work")
 

--- a/tests/test_session_delivery_fsm.py
+++ b/tests/test_session_delivery_fsm.py
@@ -1180,13 +1180,15 @@ async def test_steering_restores_incoming_sender_and_preserves_message_content(m
 
 @pytest.mark.parametrize("subagent", [False, True])
 @pytest.mark.parametrize("mode", ["start", "promote", "pending"])
-def test_legacy_queued_metadata_is_removed_only_from_dispatch_copy(managers, subagent, mode):
+@pytest.mark.parametrize("legacy_identity", [False, True])
+def test_legacy_queued_metadata_is_removed_only_from_dispatch_copy(managers, subagent, mode, legacy_identity):
     manager, _other, engine, _engine_b, starts = managers
     active_turn_id, _ = asyncio.run(_activate(manager, text="active"))
     manager._steer = AsyncMock(return_value=steer_result(SteerOutcome.ACCEPTED))
-    original = "hello\n[Now: literal user example]"
+    original = "[Alex<U1>]\nhello\n[Now: literal user example]"
     display_text = "reviewer: " + original if subagent else original
-    old_text = "[Current Time: 2026-08-02 11:00:00 UTC+08:00]\n[Alex<U1>]\n" + original
+    identity = "[Alex<U1>]\n" if legacy_identity else ""
+    old_text = "[Current Time: 2026-08-02 11:00:00 UTC+08:00]\n" + identity + original
     result = asyncio.run(manager.deliver(DeliveryRequest(
         session_id="ses_fsm", priority="p3",
         platform="slack", content=old_text,

--- a/tests/test_session_delivery_fsm.py
+++ b/tests/test_session_delivery_fsm.py
@@ -46,8 +46,9 @@ from core.session_turns import (
     Turn,
     _collect_delivery_segment,
     _scheduled_merge_key,
+    _segment_dispatch_text,
 )
-from core.message_context import SCHEDULED_DISPATCH_METADATA_APPLIED_KEY
+from core.agent_input import AgentInputMetadata
 from core.handlers.message_handler import MessageHandler
 from modules.im import MessageContext
 from modules.im.base import FileAttachment
@@ -1031,6 +1032,26 @@ def test_scheduled_segment_key_keeps_source_sessions_separate() -> None:
     assert _scheduled_merge_key(agent_row) != _scheduled_merge_key(other_agent_row)
 
 
+@pytest.mark.parametrize("scheduled", [False, True])
+def test_segment_dispatch_format_is_independent_of_delivery_projection(managers, scheduled):
+    manager, _other, engine, _engine_b, _starts = managers
+    asyncio.run(_activate(manager))
+    deliveries = []
+    for text in ("first", "second"):
+        request = DeliveryRequest(
+            session_id="ses_fsm", priority="p3", content=text,
+            source="harness" if scheduled else "user",
+            metadata={SCHEDULED_PROVENANCE_KEY: {"platform_specific": {
+                "task_trigger_kind": "agent_run", "source_session_id": "source-session",
+            }}} if scheduled else {},
+        )
+        result = asyncio.run(manager.deliver(request, context=_context()))
+        deliveries.append(_row(engine, result.delivery_id))
+    expected = "first\n\n---\n\nsecond" if scheduled else "first\nsecond"
+    assert _segment_dispatch_text(deliveries) == expected
+    assert _segment_dispatch_text([delivery_store.delivery_payload(row) for row in deliveries]) == expected
+
+
 def test_fifo_scheduled_segment_does_not_merge_different_source_sessions(managers) -> None:
     manager, _other, engine, _engine_b, starts = managers
     active_turn_id, _ = asyncio.run(_activate(manager, text="active"))
@@ -1068,11 +1089,12 @@ def test_fifo_scheduled_segment_does_not_merge_different_source_sessions(manager
 
 
 @pytest.mark.anyio
-async def test_scheduled_submit_decorates_before_native_steering(managers) -> None:
+async def test_scheduled_submit_passes_metadata_separately_to_native_steering(managers) -> None:
     manager, _other, engine, _engine_b, _starts = managers
-    decorator = AsyncMock(side_effect=lambda _context, text, **_kwargs: f"decorated: {text}")
+    metadata = AgentInputMetadata(source_session_id="source-session")
+    prepare = AsyncMock(return_value=metadata)
     manager.controller.message_handler = SimpleNamespace(
-        _prepend_message_metadata=decorator,
+        prepare_input_metadata=prepare,
     )
     await _activate(manager, text="active")
     manager._steer = AsyncMock(return_value=steer_result(SteerOutcome.ACCEPTED))
@@ -1105,9 +1127,95 @@ async def test_scheduled_submit_decorates_before_native_steering(managers) -> No
     )
 
     assert result.state == "accepted"
-    decorator.assert_awaited_once_with(context, "callback result", include_user_info=False)
+    prepare.assert_awaited_once()
+    assert prepare.await_args.kwargs == {"human": False}
+    assert prepare.await_args.args[0].platform_specific["source_session_id"] == "source-session"
     manager._steer.assert_awaited_once()
-    assert manager._steer.await_args.args[1].text == "decorated: callback result"
+    assert manager._steer.await_args.args[1].text == "callback result"
+    assert manager._steer.await_args.args[1].input_metadata == metadata
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("platform", ["avibe", "slack"])
+@pytest.mark.parametrize("mode", ["immediate", "promote", "pending"])
+async def test_steering_restores_incoming_sender_and_preserves_message_content(managers, platform, mode):
+    """Scenario: MESSAGE-DELIVERY-317."""
+    manager, _other, engine, _engine_b, _starts = managers
+    turn_id, _ = await _activate(manager, text="active")
+    prepare = AsyncMock(side_effect=lambda context, **kwargs: AgentInputMetadata(
+        user_id=context.user_id,
+        user_name=context.platform_specific["author_name"],
+    ))
+    manager.controller.message_handler = SimpleNamespace(prepare_input_metadata=prepare)
+    manager._steer = AsyncMock(return_value=steer_result(SteerOutcome.ACCEPTED))
+    original = "incoming user text\n[Now: literal example]"
+    result = await manager.deliver(
+        DeliveryRequest(
+            session_id="ses_fsm", priority="p1" if mode == "immediate" else "p3",
+            content=original, display_text=original, platform=platform,
+            author_id="incoming", author_name="Incoming Sender", message_kind="original",
+        ), context=_context(),
+    )
+    if mode == "promote":
+        assert _row(engine, result.delivery_id)["dispatch_text"] == original
+        await manager.send_now("ses_fsm")
+    elif mode == "pending":
+        with engine.begin() as conn:
+            pending = delivery_store.open_pending_steer_batch(
+                conn, deliveries=[delivery_store.get_delivery(conn, result.delivery_id)],
+                turn_id=turn_id, attempt_id=delivery_store.new_attempt_id(),
+            )
+            assert pending[0]["state"] == "pending_steer"
+        await manager._run_pending_steers("ses_fsm", turn_id, _context())
+    manager._steer.assert_awaited_once()
+    request = manager._steer.await_args.args[1]
+    assert request.text == original
+    assert request.input_metadata == AgentInputMetadata(user_id="incoming", user_name="Incoming Sender")
+    assert prepare.await_args.kwargs == {"human": True}
+    with engine.connect() as conn:
+        delivery = delivery_store.get_delivery(conn, result.delivery_id)
+        message = delivery_store.message_for_delivery(conn, delivery)
+    assert message["content_text"] == original
+
+
+@pytest.mark.parametrize("subagent", [False, True])
+@pytest.mark.parametrize("mode", ["start", "promote", "pending"])
+def test_legacy_queued_metadata_is_removed_only_from_dispatch_copy(managers, subagent, mode):
+    manager, _other, engine, _engine_b, starts = managers
+    active_turn_id, _ = asyncio.run(_activate(manager, text="active"))
+    manager._steer = AsyncMock(return_value=steer_result(SteerOutcome.ACCEPTED))
+    original = "hello\n[Now: literal user example]"
+    display_text = "reviewer: " + original if subagent else original
+    old_text = "[Current Time: 2026-08-02 11:00:00 UTC+08:00]\n[Alex<U1>]\n" + original
+    result = asyncio.run(manager.deliver(DeliveryRequest(
+        session_id="ses_fsm", priority="p3",
+        platform="slack", content=old_text,
+        display_text=display_text, author_id="U1",
+        admission_context={"message_handler_route": {"subagent_key": "reviewer" if subagent else None}},
+    ), context=_context()))
+    stored = _row(engine, result.delivery_id)
+    assert stored["dispatch_text"] == old_text
+    assert delivery_store.delivery_payload(stored)["text"] == display_text
+    if mode == "start":
+        asyncio.run(manager.terminalize_turn(active_turn_id))
+        assert starts[-1][1] == original
+        assert delivery_store.delivery_payload(_row(engine, result.delivery_id))["text"] == display_text
+    else:
+        if mode == "promote":
+            asyncio.run(manager.send_now("ses_fsm"))
+        else:
+            with engine.begin() as conn:
+                pending = delivery_store.open_pending_steer_batch(
+                    conn, deliveries=[delivery_store.get_delivery(conn, result.delivery_id)],
+                    turn_id=active_turn_id, attempt_id=delivery_store.new_attempt_id(),
+                )
+                assert pending[0]["state"] == "pending_steer"
+            asyncio.run(manager._run_pending_steers("ses_fsm", active_turn_id, _context()))
+        manager._steer.assert_awaited_once()
+        assert manager._steer.await_args.args[1].text == original
+        with engine.connect() as conn:
+            message = delivery_store.message_for_delivery(conn, _row(engine, result.delivery_id))
+        assert message["content_text"] == display_text
 
 
 def test_persisted_start_attempt_reaches_dispatch_context(managers) -> None:
@@ -1175,9 +1283,6 @@ async def test_persisted_scheduled_start_preserves_raw_text_for_handler_routing(
     assert admitted.state == "claimed"
     assert captured["text"] == "callback result"
     assert captured["context"].platform_specific["source_actor"] == "source-session"
-    assert not captured["context"].platform_specific.get(
-        SCHEDULED_DISPATCH_METADATA_APPLIED_KEY
-    )
 
 
 def test_first_delivery_binds_agentless_session_before_runtime_start(managers) -> None:
@@ -1690,16 +1795,18 @@ def test_late_steer_acceptance_upgrades_the_queued_admission_receipt(managers) -
 @pytest.mark.anyio
 async def test_pending_scheduled_batches_each_get_dispatch_metadata(managers) -> None:
     manager, _other, _engine, _engine_b, _starts = managers
-    decorator = AsyncMock(side_effect=lambda _context, text, **_kwargs: f"decorated: {text}")
+    prepare = AsyncMock(side_effect=lambda context, **_kwargs: AgentInputMetadata(
+        source_session_id=context.platform_specific["source_session_id"]
+    ))
     manager.controller.message_handler = SimpleNamespace(
-        _prepend_message_metadata=decorator,
+        prepare_input_metadata=prepare,
     )
-    context = _context()
     deliveries = []
     for index, text in enumerate(("first callback", "second callback")):
         deliveries.append(
             {
                 "id": f"delivery-{index}",
+                "session_id": "ses_fsm",
                 "dispatch_text": text,
                 "snapshot_json": json.dumps(
                     delivery_store.message_snapshot(
@@ -1723,17 +1830,11 @@ async def test_pending_scheduled_batches_each_get_dispatch_metadata(managers) ->
             }
         )
 
-    assert await manager.prepare_scheduled_dispatch(
-        context, "first callback", delivery=deliveries[0]
-    ) == "decorated: first callback"
-    assert await manager.prepare_scheduled_dispatch(
-        context, "second callback", delivery=deliveries[1]
-    ) == "decorated: second callback"
-    assert decorator.await_count == 2
-    assert [call.args[1] for call in decorator.await_args_list] == [
-        "first callback",
-        "second callback",
-    ]
+    first = await manager._steer_input_metadata([deliveries[0]])
+    second = await manager._steer_input_metadata([deliveries[1]])
+    assert first.source_session_id == "source-0"
+    assert second.source_session_id == "source-1"
+    assert prepare.await_count == 2
 
 
 def test_workbench_delivery_reports_no_reaction_receipt(managers) -> None:

--- a/tests/test_session_delivery_fsm.py
+++ b/tests/test_session_delivery_fsm.py
@@ -1218,6 +1218,67 @@ def test_legacy_queued_metadata_is_removed_only_from_dispatch_copy(managers, sub
         assert message["content_text"] == display_text
 
 
+@pytest.mark.anyio
+@pytest.mark.parametrize("mode", ["immediate", "promote", "pending"])
+@pytest.mark.parametrize("cancelled", [False, True])
+async def test_steering_preparation_failure_preserves_a_definitively_unwritten_batch(managers, mode, cancelled):
+    """Scenario: MESSAGE-DELIVERY-319."""
+    manager, _other, engine, _engine_b, _starts = managers
+    turn_id, _ = await _activate(manager, text="active")
+    manager._steer = AsyncMock(return_value=steer_result(SteerOutcome.ACCEPTED))
+    deliveries = []
+    if mode != "immediate":
+        for text in ("first incoming", "second incoming"):
+            result = await manager.deliver(DeliveryRequest(
+                session_id="ses_fsm", priority="p3", content=text,
+            ), context=_context())
+            deliveries.append(_row(engine, result.delivery_id))
+        if mode == "pending":
+            with engine.begin() as conn:
+                pending = delivery_store.open_pending_steer_batch(
+                    conn, deliveries=deliveries, turn_id=turn_id,
+                    attempt_id=delivery_store.new_attempt_id(),
+                )
+                assert all(row["state"] == "pending_steer" for row in pending)
+    error = asyncio.CancelledError() if cancelled else RuntimeError("context preparation unavailable")
+    manager._steer_input_metadata = AsyncMock(side_effect=error)
+
+    async def dispatch():
+        if mode == "immediate":
+            return await manager.deliver(DeliveryRequest(
+                session_id="ses_fsm", priority="p1", content="first incoming",
+            ), context=_context())
+        if mode == "promote":
+            return await manager.send_now("ses_fsm")
+        return await manager._run_pending_steers("ses_fsm", turn_id, _context())
+
+    if cancelled:
+        with pytest.raises(asyncio.CancelledError):
+            await dispatch()
+    else:
+        await dispatch()
+    manager._steer.assert_not_awaited()
+    queued = [row for row in _rows(engine) if row["state"] == "queued"]
+    assert len(queued) == (1 if mode == "immediate" else 2)
+    for row in queued:
+        assert row["priority"] == "p3"
+        assert row["current_attempt_id"] is None
+        assert row["message_id"] is None
+        events = json.loads(row["delivery_history_json"])["events"]
+        receipts = [event for event in events if event["kind"] == "steer"]
+        assert receipts[-1]["outcome"] == "refused"
+        assert receipts[-1]["receipt"]["reason"] == (
+            "preparation_cancelled" if cancelled else "preparation_failed"
+        )
+
+    manager._steer_input_metadata = AsyncMock(return_value=AgentInputMetadata(user_id="sender"))
+    retry = await manager.send_now("ses_fsm")
+    assert retry["status"] == "accepted"
+    manager._steer.assert_awaited_once()
+    assert manager._steer.await_args.args[1].text == "\n".join(row["dispatch_text"] for row in queued)
+    assert all(_row(engine, row["id"])["state"] == "accepted" for row in queued)
+
+
 def test_persisted_start_attempt_reaches_dispatch_context(managers) -> None:
     manager, _other, engine, _engine_b, _starts = managers
     captured: dict[str, object] = {}


### PR DESCRIPTION
## Summary

Render execution metadata at the native dispatch boundary, not at human-message admission. This restores configured timestamps and identity for Workbench inputs while keeping canonical Message content and Memory input undecorated.

- Carry stable sender and source-session facts in `AgentInputMetadata` on normal and steering requests.
- Generate `[Now: ...]` from the current local clock immediately before Codex, Claude, or OpenCode writes the input, after runtime readiness and preparation. Refresh the controller's mtime-guarded configuration at this shared boundary.
- Keep durable dispatch content undecorated and preserve native rendered-input receipts for reconciliation.
- Restore the incoming sender for immediate, promoted, and pending steering independently of the active Turn's sender. Settle preparation failures and cancellations as definitive unwritten refusals through the existing batch fallback.
- Remove released IM prefixes from a dispatch copy only when the immutable original body proves their extent, including released English/Chinese attachment errors and empty bodies. Try each released prefix shape against that evidence so user-authored first lines cannot change the boundary. Do not rewrite historical records or strip user-authored examples.

## Scenarios And Evidence

- MESSAGE-DELIVERY-317: canonical Message and Memory text remain separate from execution metadata.
- MESSAGE-DELIVERY-318: native dispatch samples Now after runtime preparation and refreshes switches from the actual configuration file.
- MESSAGE-DELIVERY-319: steering preparation failure preserves a definitively unwritten retryable batch.
- Unit/contract: 1,212 focused tests and 30 subtests passed across metadata, configuration reload, handlers, all three adapters, durable delivery, scheduled tasks, title extraction, and queue writer policy.
- Legacy protocol coverage cross-products every released prefix-switch combination with user bodies beginning with those same shapes. Six failing cases reproduced the greedy-boundary defect before the fix; the expanded matrix and real queue recovery paths pass after it.
- Scenario: the existing message-delivery scenario suite passed in the focused run.
- Changed Python files pass Ruff; `git diff --check` passes.
- Residual manual check: real-backend Workbench and IM smoke in local Incus after integration. The developer's running Avibe was not restarted or modified; no claim of live deployment.

## Dependencies

None. No new dependency or database migration.

## Known By Design

- The timestamp means dispatch-time current time, not message creation/admission time. Config switches are evaluated when rendering.
- Native backend transcripts and exact-input reconciliation receipts intentionally retain rendered prefixes; canonical content does not.
- Identity uses existing structured sender facts, with the existing platform lookup/fallback. This does not add Workbench account-profile enrichment.
- Legacy cleanup is conservative: without a matching immutable body and known IM admission route, text remains untouched. Released wire titles are stable compatibility constants independent of future translation edits. Prefix-shaped user content is preserved, not treated as execution metadata.
- Preparation failure before calling the backend is definitively unwritten. Once execution enters the adapter, existing unknown-outcome and reconciliation policy remains unchanged. Existing delivery materialization and audit lifecycle are unchanged.
