### PR TITLE
fix(model-hub): avoid model scheduling during provider detection

### DIFF
--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -2829,6 +2829,7 @@ class ModelHubSourceConfig:
     credential_ref: Optional[str] = None
     account_label: Optional[str] = None
     masked_credential: Optional[str] = None
+    verification_pending: bool = False
 
     @classmethod
     def from_payload(cls, payload: dict, *, repairing: bool = False) -> "ModelHubSourceConfig":
@@ -2852,6 +2853,7 @@ class ModelHubSourceConfig:
             "credential_ref",
             "account_label",
             "masked_credential",
+            "verification_pending",
         }
         if set(payload) - allowed_fields:
             raise ValueError("Config 'model_hub.sources' contains unknown fields")
@@ -2899,6 +2901,9 @@ class ModelHubSourceConfig:
         credential_ref = payload.get("credential_ref")
         account_label = payload.get("account_label")
         masked_credential = payload.get("masked_credential")
+        verification_pending = payload.get("verification_pending", False)
+        if not isinstance(verification_pending, bool):
+            raise ValueError("Config 'model_hub.sources.verification_pending' must be boolean")
         created_at = payload.get("created_at")
         client_nonce = (
             validate_model_hub_source_client_nonce(payload.get("client_nonce"))
@@ -2952,6 +2957,7 @@ class ModelHubSourceConfig:
             credential_ref=credential_ref,
             account_label=account_label,
             masked_credential=masked_credential,
+            verification_pending=verification_pending,
         )
 
     def to_payload(self) -> dict:
@@ -2974,6 +2980,8 @@ class ModelHubSourceConfig:
         }
         if self.client_nonce is not None:
             payload["client_nonce"] = self.client_nonce
+        if self.verification_pending:
+            payload["verification_pending"] = True
         if self.usage is not None:
             payload["usage"] = self.usage.to_payload()
         return payload

--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -2829,7 +2829,7 @@ class ModelHubSourceConfig:
     credential_ref: Optional[str] = None
     account_label: Optional[str] = None
     masked_credential: Optional[str] = None
-    verification_pending: bool = False
+    verification_pending: Optional[str] = None
 
     @classmethod
     def from_payload(cls, payload: dict, *, repairing: bool = False) -> "ModelHubSourceConfig":
@@ -2901,9 +2901,12 @@ class ModelHubSourceConfig:
         credential_ref = payload.get("credential_ref")
         account_label = payload.get("account_label")
         masked_credential = payload.get("masked_credential")
-        verification_pending = payload.get("verification_pending", False)
-        if not isinstance(verification_pending, bool):
-            raise ValueError("Config 'model_hub.sources.verification_pending' must be boolean")
+        verification_pending = payload.get("verification_pending")
+        if verification_pending is not None and (
+            not isinstance(verification_pending, str)
+            or re.fullmatch(r"vp_[0-9a-f]{32}", verification_pending) is None
+        ):
+            raise ValueError("Config 'model_hub.sources.verification_pending' must be a verification marker")
         created_at = payload.get("created_at")
         client_nonce = (
             validate_model_hub_source_client_nonce(payload.get("client_nonce"))
@@ -2981,7 +2984,7 @@ class ModelHubSourceConfig:
         if self.client_nonce is not None:
             payload["client_nonce"] = self.client_nonce
         if self.verification_pending:
-            payload["verification_pending"] = True
+            payload["verification_pending"] = self.verification_pending
         if self.usage is not None:
             payload["usage"] = self.usage.to_payload()
         return payload

--- a/core/handlers/model_hub/adapter.py
+++ b/core/handlers/model_hub/adapter.py
@@ -510,10 +510,11 @@ class EngineAdapter(Protocol):
         ``protocol_order`` either enumerates Auto-detect probes or names one
         owner-constrained protocol. A returned protocol may be established by
         a protocol-shaped upstream response, by a shipped API-key vendor pin,
-        or by a concrete `custom` declaration. The latter two require a
-        response from that exact path plus the September 4, 2026 auth ladder:
-        401/403 reject, while 2xx and request-error 400/404/422 accept even
-        if the response shape itself stays generic. `custom` Auto detect still
+        or by a concrete `custom` declaration. Authentication requires a
+        credential-sensitive response, not schema validation alone: a control
+        credential must be rejected on the protocol path, or on a protected
+        model-list path that accepts the candidate. Public inventory and the
+        inventory waiver cannot establish authentication. `custom` Auto still
         requires response-backed proof; order alone never proves a protocol.
         OpenAI/Codex Hub OAuth can combine its bound, fixed Responses endpoint
         with an authenticated structured request error; neither OAuth success

--- a/core/handlers/model_hub/adapter.py
+++ b/core/handlers/model_hub/adapter.py
@@ -515,6 +515,9 @@ class EngineAdapter(Protocol):
         401/403 reject, while 2xx and request-error 400/404/422 accept even
         if the response shape itself stays generic. `custom` Auto detect still
         requires response-backed proof; order alone never proves a protocol.
+        OpenAI/Codex Hub OAuth can combine its bound, fixed Responses endpoint
+        with an authenticated structured request error; neither OAuth success
+        alone nor an unknown/rejected authentication response establishes it.
         """
         ...
 

--- a/core/handlers/model_hub/adapter.py
+++ b/core/handlers/model_hub/adapter.py
@@ -510,15 +510,14 @@ class EngineAdapter(Protocol):
         ``protocol_order`` either enumerates Auto-detect probes or names one
         owner-constrained protocol. A returned protocol may be established by
         a protocol-shaped upstream response, by a shipped API-key vendor pin,
-        or by a concrete `custom` declaration. Authentication requires a
-        credential-sensitive response, not schema validation alone: a control
-        credential must be rejected on the protocol path, or on a protected
-        model-list path that accepts the candidate. Public inventory and the
-        inventory waiver cannot establish authentication. `custom` Auto still
+        or by a concrete `custom` declaration. Schema-validation errors,
+        altered-credential controls and public inventory cannot establish
+        authentication. A shaped success can; a bare status cannot. Auto still
         requires response-backed proof; order alone never proves a protocol.
-        OpenAI/Codex Hub OAuth can combine its bound, fixed Responses endpoint
-        with an authenticated structured request error; neither OAuth success
-        alone nor an unknown/rejected authentication response establishes it.
+        Explicit unverified API-key saving and completed Hub OAuth admission
+        belong to Source creation, not this non-persisting evidence result.
+        They retain a fixed protocol owner with verification pending and do
+        not turn an unknown/rejected observation into authentication proof.
         """
         ...
 

--- a/core/handlers/model_hub/migration.py
+++ b/core/handlers/model_hub/migration.py
@@ -67,6 +67,9 @@ class MigrationHost(Protocol):
     @staticmethod
     def _clone_config(config: ModelHubConfig) -> ModelHubConfig: ...
 
+    @staticmethod
+    def _mark_source_unverified(source: ModelHubSourceConfig) -> None: ...
+
     async def _engine_call(self, awaitable: Awaitable[Any]) -> Any: ...
 
     async def _commit_synced(
@@ -824,6 +827,8 @@ async def apply_native_migration(
                         )
                     except (TypeError, ValueError):
                         raise MigrationConflictError from None
+                if source.supply_channel == "hub":
+                    host._mark_source_unverified(source)
                 updated.sources.append(source)
                 host._apply_source_placement(updated, source)
 

--- a/core/handlers/model_hub/service.py
+++ b/core/handlers/model_hub/service.py
@@ -269,6 +269,8 @@ class ModelHubConfigStore(Protocol):
 
     def save(self, config: ModelHubConfig) -> None: ...
 
+    def mutate(self, mutator: Callable[[ModelHubConfig], bool]) -> None: ...
+
 
 class V2ModelHubConfigStore:
     def load(self) -> ModelHubConfig:
@@ -291,6 +293,14 @@ class V2ModelHubConfigStore:
         from config.v2_config import update_config_fields
 
         update_config_fields(lambda cfg: setattr(cfg, "model_hub", model_hub))
+
+    def mutate(self, mutator: Callable[[ModelHubConfig], bool]) -> None:
+        from config.v2_config import config_file_lock
+
+        with config_file_lock():
+            config = V2Config.load()
+            if mutator(config.model_hub):
+                config.save()
 
 class UnavailableEngineAdapter:
     """Explicit fail-closed adapter for isolated callers and tests."""
@@ -396,6 +406,7 @@ class ResolvedInvocation:
     supply_channel: Literal["native_cli", "hub"] = "hub"
     credential_ref: Optional[str] = None
     settlement_generation: Optional[int] = None
+    verification_pending: Optional[str] = None
 
 
 @dataclass(frozen=True)
@@ -859,7 +870,6 @@ class ModelHubService:
         self._source_create_nonces: set[str] = set()
         self._next_settlement_generation = PRE_ATTEMPT_SETTLEMENT_GENERATION
         self._latest_source_attempt_generation: dict[str, int] = {}
-        self._verification_barrier_generations: dict[str, int] = {}
         self._engine_synced = False
         self._engine_preparation_failed = False
         self._runtime_install_reconcile_lock = asyncio.Lock()
@@ -2039,7 +2049,6 @@ class ModelHubService:
                         )
                 account_label: str | None = None
                 state = ModelHubSourceStateConfig(status="standby")
-                verification_pending = False
                 discovered: list[DiscoveredModel] | None
                 if channel == "hub":
                     rollback_credential_ref = cast(str, flow.credential_ref)
@@ -2051,10 +2060,11 @@ class ModelHubService:
                     )
                     # Completed consent supplies credential custody, not proof
                     # that a model call works. Its vendor fixes the interface.
-                    protocol = observation.protocol or pinned_api_key_protocol(vendor)
+                    protocol = observation.protocol or _FIXED_BACKEND_PROTOCOLS.get(
+                        _NATIVE_VENDOR_BACKENDS.get(vendor, vendor),
+                    )
                     if protocol is None:
                         raise ModelHubError("discovery_failed")
-                    verification_pending = observation.outcome is not ObservationOutcome.OBSERVED
                     if observation.discovery is ObservationDiscovery.SUCCEEDED:
                         discovered = list(observation.models)
                     elif observation.discovery is ObservationDiscovery.FAILED:
@@ -2113,7 +2123,6 @@ class ModelHubService:
                     "supply_channel": channel,
                     "billing": billing,
                     "state": state.to_payload(),
-                    "verification_pending": verification_pending,
                     "usage": ModelHubSourceUsageConfig().to_payload(),
                     "models": [model.to_payload() for model in manual_models],
                 }
@@ -2125,7 +2134,13 @@ class ModelHubService:
                     source = ModelHubSourceConfig.from_payload(source_payload)
                 except (TypeError, ValueError):
                     raise ModelHubError("discovery_failed") from None
-                if verification_pending and observation.authenticated is not False:
+                if channel == "hub":
+                    self._mark_source_unverified(source)
+                if (
+                    channel == "hub"
+                    and observation.outcome is not ObservationOutcome.OBSERVED
+                    and observation.authenticated is not False
+                ):
                     try:
                         discovered = await self._discover(source)
                     except ModelHubError as exc:
@@ -2906,7 +2921,7 @@ class ModelHubService:
                     detail="modelHub.errors.inventory_unavailable",
                     data={"observation": self._observation_payload(observation)},
                 )
-            source.verification_pending = save_unverified
+            self._mark_source_unverified(source)
             if observation is not None:
                 source.protocol = cast(
                     Literal["anthropic", "openai_responses", "openai_chat"],
@@ -5270,6 +5285,7 @@ class ModelHubService:
                 },
             )
         source = self._source(config, candidate_payload["source_id"])
+        verification_pending = source.verification_pending
         resolved_model = candidate_payload["model_id"]
         if source.supply_channel == "native_cli":
             ready = self.native_source_ready(
@@ -5335,7 +5351,7 @@ class ModelHubService:
         reachable = decision.action == "return"
         if reachable:
             await self._verify_successful_source(
-                source.id, source.credential_ref, settlement_generation, outcome,
+                source.id, source.credential_ref, verification_pending, outcome,
             )
         error_key: Optional[str] = None
         latency_ms: Optional[int] = elapsed_ms
@@ -6266,38 +6282,39 @@ class ModelHubService:
             resolution=resolution,
         )
 
-    def _mark_source_unverified(self, source: ModelHubSourceConfig) -> None:
-        source.verification_pending = True
-        # A reauth may replace token material under the same opaque handle.
-        # Snapshot the attempt frontier without minting a synthetic attempt.
-        self._verification_barrier_generations[source.id] = self._next_settlement_generation
+    @staticmethod
+    def _mark_source_unverified(source: ModelHubSourceConfig) -> None:
+        # Persist identity with the credential, including same-handle reauth.
+        source.verification_pending = f"vp_{uuid.uuid4().hex}"
 
     async def _verify_successful_source(
         self,
         source_id: str,
         credential_ref: str | None,
-        generation: int | None,
+        verification_pending: str | None,
         outcome: RawCallOutcome,
     ) -> None:
         """Retire pending verification only for the current credential's call."""
-        if outcome.kind is not RawOutcomeKind.SUCCESS or generation is None:
+        if outcome.kind is not RawOutcomeKind.SUCCESS or verification_pending is None:
             return
+        def clear_current(config: ModelHubConfig) -> bool:
+            current = next((item for item in config.sources if item.id == source_id), None)
+            if (
+                current is None
+                or current.credential_ref != credential_ref
+                or current.verification_pending != verification_pending
+            ):
+                return False
+            current.verification_pending = None
+            return True
+
         try:
             async with self._mutation_lock:
-                previous = self.store.load()
-                current = next((item for item in previous.sources if item.id == source_id), None)
-                if (
-                    current is None
-                    or not current.verification_pending
-                    or current.credential_ref != credential_ref
-                    or generation <= self._verification_barrier_generations.get(source_id, 0)
-                    or generation < self._latest_source_attempt_generation.get(source_id, generation)
-                ):
-                    return
-                config = self._clone_config(previous)
-                current = next(item for item in config.sources if item.id == source_id)
-                current.verification_pending = False
-                self._save_runtime_config(previous, config)
+                self.store.mutate(clear_current)
+        except ValueError as exc:
+            if "recovery warnings" not in str(exc):
+                raise
+            logger.warning("Could not persist Model Hub verification state during config recovery")
         except OSError:
             # Advisory bookkeeping must not turn a completed model call into a
             # failed response. Retain pending verification for the next success.
@@ -6336,7 +6353,7 @@ class ModelHubService:
         record_attempt(outcome, decision)
         if decision.action == "return":
             await self._verify_successful_source(
-                resolved.source_id, resolved.credential_ref, resolved.settlement_generation, outcome,
+                resolved.source_id, resolved.credential_ref, resolved.verification_pending, outcome,
             )
             return HandleSettlement(
                 outcome=outcome,
@@ -6862,6 +6879,7 @@ class ModelHubService:
             target_model = inspection.model_id
             if source is None or target_model is None:
                 raise AssertionError("runnable hop must have an exact identity")
+            verification_pending = source.verification_pending
             exact_reasoning_request = self._request_for_exact_reasoning_effort(
                 request,
                 source,
@@ -6939,6 +6957,7 @@ class ModelHubService:
                     outcome=None,
                     credential_ref=source.credential_ref,
                     settlement_generation=settlement_generation,
+                    verification_pending=verification_pending,
                 )
             decision = await self._classify_source_outcome(source, outcome)
             if cancelled is not None:
@@ -6993,6 +7012,7 @@ class ModelHubService:
                         outcome=None,
                         credential_ref=source.credential_ref,
                         settlement_generation=settlement_generation,
+                        verification_pending=verification_pending,
                     )
                 decision = classify_outcome(outcome, refresh_attempted=True)
                 if cancelled is not None:
@@ -7020,7 +7040,7 @@ class ModelHubService:
                 )
             if decision.action == "return":
                 await self._verify_successful_source(
-                    source.id, source.credential_ref, settlement_generation, outcome,
+                    source.id, source.credential_ref, verification_pending, outcome,
                 )
                 self._emit_switch(
                     agent=event_agent,
@@ -7039,6 +7059,7 @@ class ModelHubService:
                     outcome=outcome,
                     credential_ref=source.credential_ref,
                     settlement_generation=settlement_generation,
+                    verification_pending=verification_pending,
                 )
             if decision.action == "surface":
                 source_transition_persisted: bool | None = None

--- a/core/handlers/model_hub/service.py
+++ b/core/handlers/model_hub/service.py
@@ -859,6 +859,7 @@ class ModelHubService:
         self._source_create_nonces: set[str] = set()
         self._next_settlement_generation = PRE_ATTEMPT_SETTLEMENT_GENERATION
         self._latest_source_attempt_generation: dict[str, int] = {}
+        self._verification_barrier_generations: dict[str, int] = {}
         self._engine_synced = False
         self._engine_preparation_failed = False
         self._runtime_install_reconcile_lock = asyncio.Lock()
@@ -2038,19 +2039,22 @@ class ModelHubService:
                         )
                 account_label: str | None = None
                 state = ModelHubSourceStateConfig(status="standby")
+                verification_pending = False
                 discovered: list[DiscoveredModel] | None
                 if channel == "hub":
                     rollback_credential_ref = cast(str, flow.credential_ref)
-                    observation = await self._require_proven_observation(
+                    observation = await self._observe_provisioned_credential(
                         vendor,
                         None,
                         rollback_credential_ref,
                         SOURCE_PROTOCOLS,
                     )
-                    protocol = cast(
-                        Literal["anthropic", "openai_responses", "openai_chat"],
-                        observation.protocol,
-                    )
+                    # Completed consent supplies credential custody, not proof
+                    # that a model call works. Its vendor fixes the interface.
+                    protocol = observation.protocol or pinned_api_key_protocol(vendor)
+                    if protocol is None:
+                        raise ModelHubError("discovery_failed")
+                    verification_pending = observation.outcome is not ObservationOutcome.OBSERVED
                     if observation.discovery is ObservationDiscovery.SUCCEEDED:
                         discovered = list(observation.models)
                     elif observation.discovery is ObservationDiscovery.FAILED:
@@ -2060,7 +2064,12 @@ class ModelHubService:
                             detail_key="models.source.error.unclassified",
                         )
                     else:
-                        raise ModelHubError("discovery_failed", status=502)
+                        discovered = None
+                        if observation.authenticated is False:
+                            state = ModelHubSourceStateConfig(
+                                status="needs_action",
+                                detail_key="models.source.needs_action.oauth_expired",
+                            )
                 else:
                     backend = _NATIVE_VENDOR_BACKENDS.get(vendor)
                     protocol = (
@@ -2104,6 +2113,7 @@ class ModelHubService:
                     "supply_channel": channel,
                     "billing": billing,
                     "state": state.to_payload(),
+                    "verification_pending": verification_pending,
                     "usage": ModelHubSourceUsageConfig().to_payload(),
                     "models": [model.to_payload() for model in manual_models],
                 }
@@ -2115,6 +2125,14 @@ class ModelHubService:
                     source = ModelHubSourceConfig.from_payload(source_payload)
                 except (TypeError, ValueError):
                     raise ModelHubError("discovery_failed") from None
+                if verification_pending and observation.authenticated is not False:
+                    try:
+                        discovered = await self._discover(source)
+                    except ModelHubError as exc:
+                        if exc.code != "discovery_failed":
+                            raise
+                        # Inventory is optional and never verifies the login.
+                        discovered = None
                 if discovered is not None:
                     self._apply_discovered_models(
                         source,
@@ -2413,6 +2431,7 @@ class ModelHubService:
                     if model.provenance == "manual"
                 ]
                 source.credential_ref = replacement_ref
+                self._mark_source_unverified(source)
                 discovered = await self._discover(source)
                 overrides = self._apply_discovered_models(source, manual, discovered)
                 source.state = ModelHubSourceStateConfig(status="standby")
@@ -2705,6 +2724,7 @@ class ModelHubService:
             "protocol",
             "client_nonce",
             "accept_unavailable_inventory",
+            "save_unverified",
         }:
             raise ModelHubError("discovery_failed")
         forbidden = {
@@ -2791,13 +2811,16 @@ class ModelHubService:
         if kind != "api_key" and client_nonce is not None:
             raise ModelHubError("discovery_failed")
         accept_unavailable_inventory = payload.get("accept_unavailable_inventory", False)
+        save_unverified = payload.get("save_unverified", False)
         if (
             not isinstance(accept_unavailable_inventory, bool)
+            or not isinstance(save_unverified, bool)
             or (
                 kind != "api_key"
                 and (
                     "protocol" in payload
                     or "accept_unavailable_inventory" in payload
+                    or "save_unverified" in payload
                 )
             )
         ):
@@ -2805,6 +2828,8 @@ class ModelHubService:
         protocol_order: tuple[str, ...] | None = None
         if kind == "api_key":
             protocol_order = self._observation_protocols(vendor, payload)
+            if save_unverified and len(protocol_order) != 1:
+                raise ModelHubError("discovery_failed", detail="modelHub.errors.ambiguous_source")
 
         if oauth_ref:
             return self._source_creation_result(
@@ -2866,9 +2891,13 @@ class ModelHubService:
             }
             if "protocol" in payload:
                 observation_payload["protocol"] = payload["protocol"]
-            observation = await self._require_proven_source_payload(observation_payload)
+            observation = (
+                None if save_unverified
+                else await self._require_proven_source_payload(observation_payload)
+            )
             if (
-                observation.discovery is ObservationDiscovery.FAILED
+                observation is not None
+                and observation.discovery is ObservationDiscovery.FAILED
                 and not accept_unavailable_inventory
             ):
                 raise ModelHubError(
@@ -2877,18 +2906,20 @@ class ModelHubService:
                     detail="modelHub.errors.inventory_unavailable",
                     data={"observation": self._observation_payload(observation)},
                 )
-            source.protocol = cast(
-                Literal["anthropic", "openai_responses", "openai_chat"],
-                observation.protocol,
-            )
-            if observation.discovery is ObservationDiscovery.SUCCEEDED:
+            source.verification_pending = save_unverified
+            if observation is not None:
+                source.protocol = cast(
+                    Literal["anthropic", "openai_responses", "openai_chat"],
+                    observation.protocol,
+                )
+            if observation is not None and observation.discovery is ObservationDiscovery.SUCCEEDED:
                 self._apply_discovered_models(
                     source,
                     manual_models,
                     list(observation.models),
                     allow_empty=True,
                 )
-            elif observation.discovery is ObservationDiscovery.FAILED:
+            else:
                 catalog_efforts_by_model = bundled_catalog_reasoning_efforts_by_model()
                 for model in source.models:
                     resolution = resolve_reasoning_tiers(
@@ -2900,10 +2931,11 @@ class ModelHubService:
                     )
                     model.reasoning_efforts = list(resolution.efforts)
                     model.reasoning_efforts_source = resolution.source
-                source.state = ModelHubSourceStateConfig(
-                    status="error",
-                    detail_key="models.source.error.unclassified",
-                )
+                if observation is not None:
+                    source.state = ModelHubSourceStateConfig(
+                        status="error",
+                        detail_key="models.source.error.unclassified",
+                    )
 
             # AC-29 requires the canonical Source validator to run before any
             # permanent credential is provisioned. The placeholder is never saved.
@@ -3002,6 +3034,7 @@ class ModelHubService:
             old_revocation_recorded = False
             try:
                 source.credential_ref = replacement_ref
+                self._mark_source_unverified(source)
                 source.masked_credential = _mask_credential(key)
                 discovered = await self._discover(source)
                 if old_credential_ref != replacement_ref:
@@ -3117,6 +3150,7 @@ class ModelHubService:
                 old_revocation_recorded = False
                 try:
                     source.credential_ref = replacement_ref
+                    self._mark_source_unverified(source)
                     source.base_url = base_url
                     discovered = await self._discover(source)
                     self.revocations.add(source.id, old_credential_ref)
@@ -5299,6 +5333,10 @@ class ModelHubService:
             decision = classify_outcome(outcome, refresh_attempted=True)
         elapsed_ms = max(0, round((time.monotonic() - started_at) * 1000))
         reachable = decision.action == "return"
+        if reachable:
+            await self._verify_successful_source(
+                source.id, source.credential_ref, settlement_generation, outcome,
+            )
         error_key: Optional[str] = None
         latency_ms: Optional[int] = elapsed_ms
         if not reachable:
@@ -6228,6 +6266,43 @@ class ModelHubService:
             resolution=resolution,
         )
 
+    def _mark_source_unverified(self, source: ModelHubSourceConfig) -> None:
+        source.verification_pending = True
+        # A reauth may replace token material under the same opaque handle.
+        # Snapshot the attempt frontier without minting a synthetic attempt.
+        self._verification_barrier_generations[source.id] = self._next_settlement_generation
+
+    async def _verify_successful_source(
+        self,
+        source_id: str,
+        credential_ref: str | None,
+        generation: int | None,
+        outcome: RawCallOutcome,
+    ) -> None:
+        """Retire pending verification only for the current credential's call."""
+        if outcome.kind is not RawOutcomeKind.SUCCESS or generation is None:
+            return
+        try:
+            async with self._mutation_lock:
+                previous = self.store.load()
+                current = next((item for item in previous.sources if item.id == source_id), None)
+                if (
+                    current is None
+                    or not current.verification_pending
+                    or current.credential_ref != credential_ref
+                    or generation <= self._verification_barrier_generations.get(source_id, 0)
+                    or generation < self._latest_source_attempt_generation.get(source_id, generation)
+                ):
+                    return
+                config = self._clone_config(previous)
+                current = next(item for item in config.sources if item.id == source_id)
+                current.verification_pending = False
+                self._save_runtime_config(previous, config)
+        except OSError:
+            # Advisory bookkeeping must not turn a completed model call into a
+            # failed response. Retain pending verification for the next success.
+            logger.warning("Could not persist Model Hub verification state")
+
     async def settle_handle_outcome(
         self,
         resolved: ResolvedInvocation | None,
@@ -6260,6 +6335,9 @@ class ModelHubService:
         )
         record_attempt(outcome, decision)
         if decision.action == "return":
+            await self._verify_successful_source(
+                resolved.source_id, resolved.credential_ref, resolved.settlement_generation, outcome,
+            )
             return HandleSettlement(
                 outcome=outcome,
                 decision=decision,
@@ -6941,6 +7019,9 @@ class ModelHubService:
                     (),
                 )
             if decision.action == "return":
+                await self._verify_successful_source(
+                    source.id, source.credential_ref, settlement_generation, outcome,
+                )
                 self._emit_switch(
                     agent=event_agent,
                     model_id=model_id,

--- a/docs/plans/model-hub-contracts/README.md
+++ b/docs/plans/model-hub-contracts/README.md
@@ -71,6 +71,9 @@ No underlying engine expansion or OAuth alias substitution is part of this chang
    non-persisting API-key observation surface; API-key `POST /api/models/sources`
    performs the same observation before its independent committed credential
    provisioning, while subscription OAuth uses its vendor-specific observation flow.
+   OpenAI/Codex Hub OAuth may combine its bound official Responses endpoint with
+   an authenticated structured request error, as defined in the protocol-observation
+   ruling in `docs/plans/model-hub.md`; login success alone is insufficient.
    A typed Base URL never creates a saved protocol value. Catalog pin and declaration
    still require reachability and authentication; they never bypass those failures.
 3. Every Source/model reference is canonical and referentially valid at write time.

--- a/docs/plans/model-hub-contracts/README.md
+++ b/docs/plans/model-hub-contracts/README.md
@@ -76,6 +76,9 @@ No underlying engine expansion or OAuth alias substitution is part of this chang
    ruling in `docs/plans/model-hub.md`; login success alone is insufficient.
    A typed Base URL never creates a saved protocol value. Catalog pin and declaration
    still require reachability and authentication; they never bypass those failures.
+   Model-free validation alone does not authenticate: the transport requires
+   credential-sensitive proof as defined in the same protocol-observation ruling.
+   Neither a public model list nor the inventory waiver can supply that proof.
 3. Every Source/model reference is canonical and referentially valid at write time.
    Unchanged stale Route hops may be retained or reordered, but new or changed pairs
    must validate Source existence/eligibility, canonical identifiers and explicit retirement.

--- a/docs/plans/model-hub-contracts/README.md
+++ b/docs/plans/model-hub-contracts/README.md
@@ -69,16 +69,15 @@ No underlying engine expansion or OAuth alias substitution is part of this chang
    api-key vendor catalog pin, a user declaration on `custom`, or a matching
    protocol-shaped upstream response. `POST /api/models/sources/observe` is the
    non-persisting API-key observation surface; API-key `POST /api/models/sources`
-   performs the same observation before its independent committed credential
-   provisioning, while subscription OAuth uses its vendor-specific observation flow.
-   OpenAI/Codex Hub OAuth may combine its bound official Responses endpoint with
-   an authenticated structured request error, as defined in the protocol-observation
-   ruling in `docs/plans/model-hub.md`; login success alone is insufficient.
-   A typed Base URL never creates a saved protocol value. Catalog pin and declaration
-   still require reachability and authentication; they never bypass those failures.
-   Model-free validation alone does not authenticate: the transport requires
-   credential-sensitive proof as defined in the same protocol-observation ruling.
-   Neither a public model list nor the inventory waiver can supply that proof.
+   normally repeats observation before committed credential provisioning. Explicit
+   `save_unverified: true` permits a catalog pin or declaration without observation;
+   custom Auto still cannot be guessed. Completed Hub OAuth consent can retain its
+   bound credential under the fixed vendor protocol. These Sources carry the
+   independent `verification_pending` marker until an actual current-credential
+   model call succeeds; model discovery does not clear it. A typed Base URL never
+   supplies protocol ownership. Model-free validation, altered-credential controls
+   and public model lists do not prove authentication. See the 2026-09-07 ruling
+   in `docs/plans/model-hub.md` and the create/Source schemas for the complete policy.
 3. Every Source/model reference is canonical and referentially valid at write time.
    Unchanged stale Route hops may be retained or reordered, but new or changed pairs
    must validate Source existence/eligibility, canonical identifiers and explicit retirement.

--- a/docs/plans/model-hub-contracts/README.md
+++ b/docs/plans/model-hub-contracts/README.md
@@ -72,9 +72,11 @@ No underlying engine expansion or OAuth alias substitution is part of this chang
    normally repeats observation before committed credential provisioning. Explicit
    `save_unverified: true` permits a catalog pin or declaration without observation;
    custom Auto still cannot be guessed. Completed Hub OAuth consent can retain its
-   bound credential under the fixed vendor protocol. These Sources carry the
-   independent `verification_pending` marker until an actual current-credential
-   model call succeeds; model discovery does not clear it. A typed Base URL never
+   bound credential under the fixed vendor protocol. Every newly stored Hub
+   credential, including observed creates and native-config imports, carries an
+   opaque `verification_pending` identity until an actual matching-credential
+   model call succeeds. Its clearing is a fresh cross-process field mutation;
+   model discovery never clears it. A typed Base URL never
    supplies protocol ownership. Model-free validation, altered-credential controls
    and public model lists do not prove authentication. See the 2026-09-07 ruling
    in `docs/plans/model-hub.md` and the create/Source schemas for the complete policy.

--- a/docs/plans/model-hub-contracts/adapter-interface.py
+++ b/docs/plans/model-hub-contracts/adapter-interface.py
@@ -510,10 +510,11 @@ class EngineAdapter(Protocol):
         ``protocol_order`` either enumerates Auto-detect probes or names one
         owner-constrained protocol. A returned protocol may be established by
         a protocol-shaped upstream response, by a shipped API-key vendor pin,
-        or by a concrete `custom` declaration. The latter two require a
-        response from that exact path plus the September 4, 2026 auth ladder:
-        401/403 reject, while 2xx and request-error 400/404/422 accept even
-        if the response shape itself stays generic. `custom` Auto detect still
+        or by a concrete `custom` declaration. Authentication requires a
+        credential-sensitive response, not schema validation alone: a control
+        credential must be rejected on the protocol path, or on a protected
+        model-list path that accepts the candidate. Public inventory and the
+        inventory waiver cannot establish authentication. `custom` Auto still
         requires response-backed proof; order alone never proves a protocol.
         OpenAI/Codex Hub OAuth can combine its bound, fixed Responses endpoint
         with an authenticated structured request error; neither OAuth success

--- a/docs/plans/model-hub-contracts/adapter-interface.py
+++ b/docs/plans/model-hub-contracts/adapter-interface.py
@@ -515,6 +515,9 @@ class EngineAdapter(Protocol):
         401/403 reject, while 2xx and request-error 400/404/422 accept even
         if the response shape itself stays generic. `custom` Auto detect still
         requires response-backed proof; order alone never proves a protocol.
+        OpenAI/Codex Hub OAuth can combine its bound, fixed Responses endpoint
+        with an authenticated structured request error; neither OAuth success
+        alone nor an unknown/rejected authentication response establishes it.
         """
         ...
 

--- a/docs/plans/model-hub-contracts/adapter-interface.py
+++ b/docs/plans/model-hub-contracts/adapter-interface.py
@@ -510,15 +510,14 @@ class EngineAdapter(Protocol):
         ``protocol_order`` either enumerates Auto-detect probes or names one
         owner-constrained protocol. A returned protocol may be established by
         a protocol-shaped upstream response, by a shipped API-key vendor pin,
-        or by a concrete `custom` declaration. Authentication requires a
-        credential-sensitive response, not schema validation alone: a control
-        credential must be rejected on the protocol path, or on a protected
-        model-list path that accepts the candidate. Public inventory and the
-        inventory waiver cannot establish authentication. `custom` Auto still
+        or by a concrete `custom` declaration. Schema-validation errors,
+        altered-credential controls and public inventory cannot establish
+        authentication. A shaped success can; a bare status cannot. Auto still
         requires response-backed proof; order alone never proves a protocol.
-        OpenAI/Codex Hub OAuth can combine its bound, fixed Responses endpoint
-        with an authenticated structured request error; neither OAuth success
-        alone nor an unknown/rejected authentication response establishes it.
+        Explicit unverified API-key saving and completed Hub OAuth admission
+        belong to Source creation, not this non-persisting evidence result.
+        They retain a fixed protocol owner with verification pending and do
+        not turn an unknown/rejected observation into authentication proof.
         """
         ...
 

--- a/docs/plans/model-hub-contracts/api.md
+++ b/docs/plans/model-hub-contracts/api.md
@@ -115,12 +115,16 @@ existing uncertain health projection.
 Explicit `save_unverified: true` instead saves the catalog-pinned or user-declared
 interface without upstream observation or discovery. Custom Auto without a declaration
 is rejected before credential provisioning. Manual models remain manual; no inventory
-is invented. The Source carries `verification_pending: true`, independently of its
+is invented. The Source carries an opaque `verification_pending` marker, independently of its
 routing health, and may be configured and invoked. List/detail surfaces label it
 unverified, not healthy/in use. Successful inventory discovery never clears this flag.
-Only a successful actual invocation of the same current credential clears it; stale
-attempts and failed calls cannot verify a replacement. Credential/endpoint replacement
-sets it again. Existing Sources lacking the optional flag retain their existing state.
+Every newly stored Hub credential starts pending, including observed creates and
+native-config imports. A call captures the persisted marker before invocation; any
+successful call using the same current credential and marker clears it through a
+fresh cross-process config transaction. Newer same-credential attempts do not negate
+success. Credential/endpoint replacement generates a new marker, including same-handle
+OAuth reauthentication; old calls and failed calls cannot verify that replacement.
+Existing Sources lacking the optional marker retain their existing state.
 
 Completed Hub OAuth consent can likewise retain its bound credential under the fixed
 vendor protocol with verification pending. An explicit authentication rejection keeps

--- a/docs/plans/model-hub-contracts/api.md
+++ b/docs/plans/model-hub-contracts/api.md
@@ -92,7 +92,11 @@ response. A supplied protocol is established when authentication succeeds and ei
 `vendor` has a shipped catalog pin, the client declared that protocol on `custom`, or
 a matching protocol-shaped response proves it. The protocol probe is deliberately
 schema-invalid and names no synthetic model, so a relay can authenticate and classify it
-without selecting or invoking an upstream model. A bare-origin Base URL uses the
+without selecting or invoking an upstream model. Schema validation alone does not
+prove authentication: the model-free protocol path must reject a control credential,
+or the existing model-list path must reject the control and accept the candidate.
+Public inventory and `accept_unavailable_inventory` never supply that proof.
+A bare-origin Base URL uses the
 standard `/v1` endpoint paths, while a URL with a path is treated as the complete API
 root. The endpoint provisions an unbound engine credential only for this operation,
 returns `observation-result.schema.json`, then revokes the transient reference before

--- a/docs/plans/model-hub-contracts/api.md
+++ b/docs/plans/model-hub-contracts/api.md
@@ -92,10 +92,10 @@ response. A supplied protocol is established when authentication succeeds and ei
 `vendor` has a shipped catalog pin, the client declared that protocol on `custom`, or
 a matching protocol-shaped response proves it. The protocol probe is deliberately
 schema-invalid and names no synthetic model, so a relay can authenticate and classify it
-without selecting or invoking an upstream model. Schema validation alone does not
-prove authentication: the model-free protocol path must reject a control credential,
-or the existing model-list path must reject the control and accept the candidate.
-Public inventory and `accept_unavailable_inventory` never supply that proof.
+without selecting or invoking an upstream model. Schema validation does not prove
+authentication. Synthetic altered credentials are not used: unknown token grammars
+and middleware ordering make their rejection inconclusive. Public inventory and
+`accept_unavailable_inventory` never supply authentication proof.
 A bare-origin Base URL uses the
 standard `/v1` endpoint paths, while a URL with a path is treated as the complete API
 root. The endpoint provisions an unbound engine credential only for this operation,
@@ -103,16 +103,29 @@ returns `observation-result.schema.json`, then revokes the transient reference b
 settling. A revoke failure remains in the existing pending-revocation journal. The
 response never contains that reference or any persisted Source.
 
-For an API-key `POST /api/models/sources`, the server performs the same
+For an API-key `POST /api/models/sources` without `save_unverified: true`, the server performs the same
 server-owned observation internally before its independent committed credential
 provisioning. It accepts the create fields and optional protocol constraint, but never
 accepts protocol proof or inventory results from the caller. A null protocol
 produces no Source. A repeated observation that establishes a protocol owner but ends
 with failed inventory discovery produces no Source unless this request explicitly carries
 `accept_unavailable_inventory: true`; the accepted Source has `models: []` and the
-existing uncertain health projection. Subscription OAuth creation follows its
-vendor-specific observation flow before commit. Saved Sources use the stored protocol for
-every later operation.
+existing uncertain health projection.
+
+Explicit `save_unverified: true` instead saves the catalog-pinned or user-declared
+interface without upstream observation or discovery. Custom Auto without a declaration
+is rejected before credential provisioning. Manual models remain manual; no inventory
+is invented. The Source carries `verification_pending: true`, independently of its
+routing health, and may be configured and invoked. List/detail surfaces label it
+unverified, not healthy/in use. Successful inventory discovery never clears this flag.
+Only a successful actual invocation of the same current credential clears it; stale
+attempts and failed calls cannot verify a replacement. Credential/endpoint replacement
+sets it again. Existing Sources lacking the optional flag retain their existing state.
+
+Completed Hub OAuth consent can likewise retain its bound credential under the fixed
+vendor protocol with verification pending. An explicit authentication rejection keeps
+the existing needs-action state. Native CLI OAuth is unchanged. Saved Sources use the
+stored protocol for every later operation. No create path performs a model invocation.
 
 `source-create.schema.json` is the complete `SourceCreate` request. Its field table is
 authoritative; no Source response field may be inferred backwards into the request:

--- a/docs/plans/model-hub-contracts/observation-result.schema.json
+++ b/docs/plans/model-hub-contracts/observation-result.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "model-hub/observation-result.schema.json",
   "title": "SourceObservation",
-  "description": "Response-backed result of the unsaved Source observation. It never contains a credential reference or persisted Source state. Any upstream response proves reachability, but a bare HTTP status proves neither protocol nor authentication. Authentication is accepted only for a shaped success or a shaped request error that occurs after authentication; shaped authentication errors are rejected, while shaped server and rate-limit errors leave authentication unknown and settle as adapter_error rather than observed or ambiguous.",
+  "description": "Response-backed result of the unsaved Source observation. It never contains a credential reference or persisted Source state. Any upstream response proves reachability, but a bare HTTP status proves neither protocol nor authentication. A shaped success can establish authentication; schema errors cannot, because they can precede authentication. No synthetic credential control or public model inventory upgrades that evidence. Shaped authentication errors reject their candidate; unknown sibling candidates in Auto remain unknown. Shaped request, server and rate-limit errors leave authentication unknown and settle as adapter_error rather than observed. Explicit unverified Source creation is separate from this result and never changes its evidence.",
   "type": "object",
   "required": [
     "contract_version",

--- a/docs/plans/model-hub-contracts/source-create.schema.json
+++ b/docs/plans/model-hub-contracts/source-create.schema.json
@@ -2,15 +2,20 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "model-hub/source-create.schema.json",
   "title": "SourceCreate",
-  "description": "API-key Source creation input. It extends the unsaved observation request with display, reconciliation, and explicit unavailable-inventory consent data; the server still owns Source identity, protocol, discovered inventory, health, usage, custody metadata, and timestamps. Optional protocol restricts observation to one interface; omission selects the shipped vendor pin when one exists, otherwise only custom omission auto-detects across the supported interfaces. A supplied protocol is persisted when observation is authenticated and either vendor has a shipped catalog pin for that protocol, the client declared it on custom, or a matching protocol-shaped upstream response proves it. Auto-detect without a catalog pin still requires matching response proof. When client_nonce is present, the server reserves it atomically in process before observation or credential work; only a successful commit persists Source.client_nonce unchanged. A lost-response client reconciles through the ordinary Source list without a receipt or separate endpoint. Nonce uniqueness covers live-process reservations and live Sources; process restart or Source deletion releases it, and a later same-nonce request after the required list read is a fresh create.",
+  "description": "API-key Source creation input. The default path requires authenticated observation and a protocol established by a shipped catalog pin, a declaration on custom, or matching response proof. Explicit save_unverified consent instead persists configuration with verification pending, without observation or discovery, and requires a catalog pin or a concrete custom declaration. The server owns Source identity, discovered inventory, health, usage, custody metadata and timestamps. Both paths use canonical validation and the same custody, rollback and reconciliation lifecycle. When client_nonce is present, the server reserves it atomically in process before observation or credential work; only a successful commit persists Source.client_nonce unchanged. A lost-response client reconciles through the ordinary Source list without a receipt or separate endpoint. Nonce uniqueness covers live-process reservations and live Sources; process restart or Source deletion releases it, and a later same-nonce request after the required list read is a fresh create.",
   "type": "object",
   "required": ["vendor", "key"],
   "additionalProperties": false,
   "properties": {
+    "save_unverified": {
+      "type": "boolean",
+      "default": false,
+      "description": "Explicit consent to save configuration without upstream observation or discovery. Requires a catalog-pinned or explicitly declared protocol; custom Auto cannot be guessed. Canonical input validation, credential custody, rollback and nonce reconciliation are unchanged. Sets Source.verification_pending, preserves manual models and does not claim usability."
+    },
     "vendor": {
       "type": "string",
       "pattern": "^[a-z0-9]+(?:[._-][a-z0-9]+)*$",
-      "description": "Vendor id used by the response-backed observation."
+      "description": "Vendor id used for catalog ownership and optional observation."
     },
     "display_name": {
       "type": "string",
@@ -29,7 +34,7 @@
     },
     "protocol": {
       "enum": ["anthropic", "openai_responses", "openai_chat"],
-      "description": "Optional user-selected interface. When present, observation probes exactly this protocol. Omission selects the shipped vendor pin when one exists; otherwise on vendor custom it auto-detects across the authoritative protocol vocabulary and still requires matching response proof. Persistence requires authentication plus one of: a shipped vendor catalog pin for this protocol, a declaration on vendor custom, or matching protocol-shaped upstream response proof."
+      "description": "Optional user-selected interface. When present, observation probes exactly this protocol. Omission selects the shipped vendor pin when one exists; otherwise custom Auto requires matching response proof. Explicit unverified saving requires a catalog pin or a concrete custom declaration and never guesses a protocol."
     },
     "client_nonce": {
       "type": "string",
@@ -56,7 +61,7 @@
       "base_url": "https://relay.example/v1",
       "key": "<transient plaintext key>",
       "protocol": "openai_chat",
-      "accept_unavailable_inventory": true
+      "save_unverified": true
     }
   ]
 }

--- a/docs/plans/model-hub-contracts/source-create.schema.json
+++ b/docs/plans/model-hub-contracts/source-create.schema.json
@@ -61,6 +61,13 @@
       "base_url": "https://relay.example/v1",
       "key": "<transient plaintext key>",
       "protocol": "openai_chat",
+      "accept_unavailable_inventory": true
+    },
+    {
+      "vendor": "custom",
+      "base_url": "https://relay.example/v1",
+      "key": "<transient plaintext key>",
+      "protocol": "openai_chat",
       "save_unverified": true
     }
   ]

--- a/docs/plans/model-hub-contracts/source.schema.json
+++ b/docs/plans/model-hub-contracts/source.schema.json
@@ -20,9 +20,9 @@
   "additionalProperties": false,
   "properties": {
     "verification_pending": {
-      "type": "boolean",
-      "default": false,
-      "description": "Saved without model-call verification. Independent of routing health: configuration may be invoked, but UI must not present it as verified. Inventory discovery does not clear this marker; only a successful invocation of the same current credential does. Omission preserves legacy behavior and makes no retrospective verification claim."
+      "type": ["string", "null"],
+      "pattern": "^vp_[0-9a-f]{32}$",
+      "description": "Opaque, non-secret pending-verification identity, replaced whenever Hub credential material or endpoint is stored, including observed creates and same-handle OAuth reauthentication. Presence means not yet model-call verified, independently of routing health. An invocation captures this marker before admission; any successful call with the same current credential and marker may clear it through a fresh cross-process config mutation. Later same-credential calls do not invalidate proof. Inventory never clears it. Null or omission retains legacy behavior without a retrospective verification claim."
     },
     "id": {
       "type": "string",

--- a/docs/plans/model-hub-contracts/source.schema.json
+++ b/docs/plans/model-hub-contracts/source.schema.json
@@ -19,6 +19,11 @@
   ],
   "additionalProperties": false,
   "properties": {
+    "verification_pending": {
+      "type": "boolean",
+      "default": false,
+      "description": "Saved without model-call verification. Independent of routing health: configuration may be invoked, but UI must not present it as verified. Inventory discovery does not clear this marker; only a successful invocation of the same current credential does. Omission preserves legacy behavior and makes no retrospective verification claim."
+    },
     "id": {
       "type": "string",
       "pattern": "^src_[a-z0-9]{8,}$"

--- a/docs/plans/model-hub-ui-spec.md
+++ b/docs/plans/model-hub-ui-spec.md
@@ -3241,6 +3241,21 @@ Stated as the property rather than as three call sites: **an interface this dial
 not detect says where it came from, and the row that says it also says what detection
 is still for.**
 
+**2026-09-07 owner-approved unverified-save exit.** An explicit catalog pin or
+concrete custom declaration permits `Save unverified` (`addKey.saveUnverified`)
+from the valid initial form and observation failure/undetermined states. Reuse the
+outline footer action with the Save icon; enter the existing persisting phase with
+`save_unverified: true`. Custom Auto has no such exit until an interface is selected.
+Unknown-write reconciliation retains this consent and the nonce. Draft edits retire
+held evidence as before. The footer wraps on narrow screens. This supersedes the
+observation prerequisite in the earlier state tables, not cancellation, settlement
+or focus ownership. No upstream observation or inventory request occurs on this exit.
+Source list/detail show `sourceDetail.status.unverified` in existing advisory ink;
+error/cooldown states retain visual precedence. Adoption and model discovery cannot
+replace this label with healthy/in-use copy. Only an actual successful model call
+retires verification as defined by the Source contract. Ambiguity copy must not
+claim authentication success.
+
 **Element inventory**
 
 | Element | Displays | Data source | Interactive | On activate |
@@ -3260,7 +3275,7 @@ is still for.**
 | `WZyA8` selector | the same four interface choices, expanded in place, glyphs on concrete options | selection | yes, Auto detect remains selected until changed | Select one concrete interface; enables 重试 |
 | `Nak7y` ④ foot | 取消 / 重试 (dimmed until a concrete interface is picked) | selection | yes | — |
 | `d6bFlX` state ⑤ strip | the interface *was* identified, and the model list did not come back | observation result | no | — |
-| `x0Gzg` ⑤ foot | 取消 / 仍要添加 / 重试 — **three** buttons, the only foot in the product with three | — | yes | Dismiss / save the source without an inventory / rerun the entire observation |
+| `x0Gzg` ⑤ foot | 取消 / 仍要添加 / 重试 — three buttons | — | yes | Dismiss / save the source without an inventory / rerun the entire observation |
 | `sqZa9` success note | that the dialog closes straight into 06 | static | no | — |
 
 **Metrics** `[frame]`: dialog 560 wide, height auto in all five states — the frame

--- a/docs/plans/model-hub-vendor-preset-protocol.md
+++ b/docs/plans/model-hub-vendor-preset-protocol.md
@@ -164,6 +164,18 @@ repeats the same model-free check before persisting the Source.
 local HTTP relay with model scheduling unavailable. It covers every catalog
 preset and every concrete custom interface without using real user state.
 
+OpenAI/Codex Hub OAuth has a fixed, allowlisted Responses endpoint and an
+engine-bound credential. A structured request error accepted by the existing
+authentication parser can therefore confirm that protocol even when it names
+only the missing `model`. This ownership applies inside the OAuth transport,
+not the API-key catalog ladder or generic response parser. Rejected or unknown
+authentication and unstructured responses remain insufficient.
+
+`AUTH-SETUP-113` exercises consent completion through the real OAuth observation
+and discovery path to Source creation, including idempotent terminal polling.
+Missing-model validation succeeds; credential rejection, rate limiting, upstream
+errors, and unstructured success responses create no Source.
+
 ## Acceptance
 
 - DeepSeek official URL + valid key, vendor `deepseek`, adds as

--- a/docs/plans/model-hub-vendor-preset-protocol.md
+++ b/docs/plans/model-hub-vendor-preset-protocol.md
@@ -172,9 +172,10 @@ observation can instead verify that the existing model-list path rejects the
 control and accepts the supplied key. Public or indeterminate inventory cannot
 prove authentication, and `accept_unavailable_inventory` cannot waive it.
 Explicit credential rejection is never overridden by a vendor pin/declaration.
-The API-key control is always distinct, including punctuation-only credentials.
-It changes one character while preserving length and the preceding prefix, and
-retains the ASCII character class where possible. All requests remain model-free,
+The shared credential control is always distinct, including punctuation-only
+credentials. It preserves length and the preceding prefix, retaining the ASCII
+character class where possible. For JWTs it preserves the header and claims and
+changes signature bytes without changing signature length. All API-key requests remain model-free,
 non-redirecting, and bounded by the observation deadline.
 Status-only rejection applies only to catalog/declaration-owned candidates or
 deliberately changed control credentials. Unrecognized primary 401/403 responses
@@ -201,6 +202,13 @@ Missing-model validation succeeds; credential rejection, rate limiting, upstream
 errors, and unstructured success responses create no Source.
 Identical validation responses for candidate/control credentials also create no
 Source; the engine's local OAuth inventory is not an upstream authentication probe.
+The scenario also covers syntax checks before schema checks before signature
+verification, with valid and expired JWTs and valid/invalid opaque OAuth tokens.
+OAuth candidate/control requests share one private managed-token snapshot; no
+fabricated token format or engine-local model list can substitute for proof.
+The runtime never rewrites the token file or surfaces its content through Model
+Hub API results, events, logs or Agent configuration. Unsafe or unavailable
+managed material leaves observation unverified.
 
 ## Acceptance
 

--- a/docs/plans/model-hub-vendor-preset-protocol.md
+++ b/docs/plans/model-hub-vendor-preset-protocol.md
@@ -172,12 +172,21 @@ observation can instead verify that the existing model-list path rejects the
 control and accepts the supplied key. Public or indeterminate inventory cannot
 prove authentication, and `accept_unavailable_inventory` cannot waive it.
 Explicit credential rejection is never overridden by a vendor pin/declaration.
-The API-key control preserves key presence, prefix and length; all requests
-remain model-free, non-redirecting, and bounded by the observation deadline.
+The API-key control is always distinct, including punctuation-only credentials.
+It changes one character while preserving length and the preceding prefix, and
+retains the ASCII character class where possible. All requests remain model-free,
+non-redirecting, and bounded by the observation deadline.
+Status-only rejection applies only to catalog/declaration-owned candidates or
+deliberately changed control credentials. Unrecognized primary 401/403 responses
+remain unknown for Auto and OAuth, including the API-key inventory fallback;
+they must not reject the credential or exclude a competing protocol.
 
 `AUTH-SETUP-112` covers both authentication-before-validation and
-validation-before-authentication, with both protected and public model lists.
+validation-before-authentication, with both protected and public model lists,
+for alphanumeric and punctuation-only credentials.
 Only credential-sensitive evidence allows observe and confirm to succeed.
+`AUTH-SETUP-114` covers unrecognized Auto policy responses through observe and
+confirm, including a competing protocol that must not win by false exclusion.
 
 OpenAI/Codex Hub OAuth has a fixed, allowlisted Responses endpoint and an
 engine-bound credential. A structured request error accepted by the existing

--- a/docs/plans/model-hub-vendor-preset-protocol.md
+++ b/docs/plans/model-hub-vendor-preset-protocol.md
@@ -155,60 +155,42 @@ validation, making valid credentials impossible to add. A model-free request
 keeps observation independent of model availability and generation. The shared
 request taxonomy applies to API-key and OAuth observation alike.
 
-The protocol-owner ladder above remains unchanged: catalog pins and declarations
-still require authentication; Auto still requires response
-evidence. Inventory discovery follows successful observation, and confirmation
-repeats the same model-free check before persisting the Source.
+The owner's 2026-09-07 ruling separates configuration from verification. The
+protocol owners remain catalog pins, custom declarations and response evidence;
+explicit `save_unverified: true` may save either of the first two without an
+upstream request. Custom Auto cannot invent an owner. Canonical input validation,
+credential custody, nonce reconciliation and rollback remain unchanged.
 
-`AUTH-SETUP-112` exercises observe, confirm, and invalid-key rejection against a
-local HTTP relay with model scheduling unavailable. It covers every catalog
-preset and every concrete custom interface without using real user state.
+Schema errors never authenticate: they can precede key lookup. Synthetic controls
+were removed because unknown token grammar/checksums and collisions with another
+valid key make their results inconclusive. A public model list cannot repair
+that proof, and the inventory waiver does not waive authentication. Bare 401/403
+responses remain unknown for every owner; only shaped authentication evidence
+rejects a candidate. An unknown Auto sibling is not eliminated by another
+candidate's rejection. API-key observation remains model-free, non-redirecting
+and bounded by its deadline.
 
-Authentication is credential-sensitive (2026-09-07 amendment to the status
-ladder): schema validation may run before authorization. A successful or
-request-error response is only a candidate until the same model-free path
-rejects a control credential. If validation hides authentication, API-key
-observation can instead verify that the existing model-list path rejects the
-control and accepts the supplied key. Public or indeterminate inventory cannot
-prove authentication, and `accept_unavailable_inventory` cannot waive it.
-Explicit credential rejection is never overridden by a vendor pin/declaration.
-The shared credential control is always distinct, including punctuation-only
-credentials. It preserves length and the preceding prefix, retaining the ASCII
-character class where possible. For JWTs it preserves the header and claims and
-changes signature bytes without changing signature length. All API-key requests remain model-free,
-non-redirecting, and bounded by the observation deadline.
-Status-only rejection applies only to catalog/declaration-owned candidates or
-deliberately changed control credentials. Unrecognized primary 401/403 responses
-remain unknown for Auto and OAuth, including the API-key inventory fallback;
-they must not reject the credential or exclude a competing protocol.
+Explicit unverified saves carry `verification_pending: true` independently of
+routing health. Inventory refresh never clears it; only an actual successful
+current-credential invocation does. Credential/endpoint replacement sets it again.
+The Source remains configurable and invokable, but list/detail surfaces do not
+claim healthy/in-use status while verification is pending. The normal verified
+save path still requires response-backed authentication and protocol ownership.
 
-`AUTH-SETUP-112` covers both authentication-before-validation and
-validation-before-authentication, with both protected and public model lists,
-for alphanumeric and punctuation-only credentials.
-Only credential-sensitive evidence allows observe and confirm to succeed.
-`AUTH-SETUP-114` covers unrecognized Auto policy responses through observe and
-confirm, including a competing protocol that must not win by false exclusion.
+Completed Hub OAuth consent may retain its engine-bound credential under the fixed
+vendor protocol with verification pending. Explicit upstream authentication
+rejection keeps the existing needs-action state. The existing allowlisted
+auth-index transport substitutes the engine-held token; no private-token reader
+or fabricated OAuth control is needed. Native CLI OAuth is unchanged.
 
-OpenAI/Codex Hub OAuth has a fixed, allowlisted Responses endpoint and an
-engine-bound credential. A structured request error accepted by the existing
-authentication parser and rejected-control check can therefore confirm that protocol even when it names
-only the missing `model`. This ownership applies inside the OAuth transport,
-not the API-key catalog ladder or generic response parser. Rejected or unknown
-authentication and unstructured responses remain insufficient.
-
-`AUTH-SETUP-113` exercises consent completion through the real OAuth observation
-and discovery path to Source creation, including idempotent terminal polling.
-Missing-model validation succeeds; credential rejection, rate limiting, upstream
-errors, and unstructured success responses create no Source.
-Identical validation responses for candidate/control credentials also create no
-Source; the engine's local OAuth inventory is not an upstream authentication probe.
-The scenario also covers syntax checks before schema checks before signature
-verification, with valid and expired JWTs and valid/invalid opaque OAuth tokens.
-OAuth candidate/control requests share one private managed-token snapshot; no
-fabricated token format or engine-local model list can substitute for proof.
-The runtime never rewrites the token file or surfaces its content through Model
-Hub API results, events, logs or Agent configuration. Unsafe or unavailable
-managed material leaves observation unverified.
+`AUTH-SETUP-112` covers every catalog pin and concrete custom protocol against
+isolated HTTP middleware with both authentication/schema orders, public/protected
+inventory and alphanumeric/punctuation-only credentials. Unknown validation cannot
+authenticate, while explicit saving performs no additional upstream requests.
+`AUTH-SETUP-113` covers completed Hub OAuth admission, fixed protocol ownership,
+pending verification and idempotent polling across credential shapes and upstream
+outcomes. `AUTH-SETUP-114` covers Auto policy responses that must remain unknown
+and cannot permit unverified saving without a concrete protocol declaration.
 
 ## Acceptance
 

--- a/docs/plans/model-hub-vendor-preset-protocol.md
+++ b/docs/plans/model-hub-vendor-preset-protocol.md
@@ -147,6 +147,23 @@ invariants change.
 - G-18 / G-27 rows: probe constraint language is now only the Auto
   branch on `custom`.
 
+## Model-independent observation (2026-09-07)
+
+Protocol observation omits `model` for every interface. A fabricated model can
+enter a relay's scheduler and return capacity or upstream errors before request
+validation, making valid credentials impossible to add. A model-free request
+keeps observation independent of model availability and generation. The shared
+request taxonomy applies to API-key and OAuth observation alike.
+
+The proof ladder above remains unchanged: catalog pins and declarations still
+require authentication on their protocol path; Auto still requires response
+evidence. Inventory discovery follows successful observation, and confirmation
+repeats the same model-free check before persisting the Source.
+
+`AUTH-SETUP-112` exercises observe, confirm, and invalid-key rejection against a
+local HTTP relay with model scheduling unavailable. It covers every catalog
+preset and every concrete custom interface without using real user state.
+
 ## Acceptance
 
 - DeepSeek official URL + valid key, vendor `deepseek`, adds as

--- a/docs/plans/model-hub-vendor-preset-protocol.md
+++ b/docs/plans/model-hub-vendor-preset-protocol.md
@@ -155,8 +155,8 @@ validation, making valid credentials impossible to add. A model-free request
 keeps observation independent of model availability and generation. The shared
 request taxonomy applies to API-key and OAuth observation alike.
 
-The proof ladder above remains unchanged: catalog pins and declarations still
-require authentication on their protocol path; Auto still requires response
+The protocol-owner ladder above remains unchanged: catalog pins and declarations
+still require authentication; Auto still requires response
 evidence. Inventory discovery follows successful observation, and confirmation
 repeats the same model-free check before persisting the Source.
 
@@ -164,9 +164,24 @@ repeats the same model-free check before persisting the Source.
 local HTTP relay with model scheduling unavailable. It covers every catalog
 preset and every concrete custom interface without using real user state.
 
+Authentication is credential-sensitive (2026-09-07 amendment to the status
+ladder): schema validation may run before authorization. A successful or
+request-error response is only a candidate until the same model-free path
+rejects a control credential. If validation hides authentication, API-key
+observation can instead verify that the existing model-list path rejects the
+control and accepts the supplied key. Public or indeterminate inventory cannot
+prove authentication, and `accept_unavailable_inventory` cannot waive it.
+Explicit credential rejection is never overridden by a vendor pin/declaration.
+The API-key control preserves key presence, prefix and length; all requests
+remain model-free, non-redirecting, and bounded by the observation deadline.
+
+`AUTH-SETUP-112` covers both authentication-before-validation and
+validation-before-authentication, with both protected and public model lists.
+Only credential-sensitive evidence allows observe and confirm to succeed.
+
 OpenAI/Codex Hub OAuth has a fixed, allowlisted Responses endpoint and an
 engine-bound credential. A structured request error accepted by the existing
-authentication parser can therefore confirm that protocol even when it names
+authentication parser and rejected-control check can therefore confirm that protocol even when it names
 only the missing `model`. This ownership applies inside the OAuth transport,
 not the API-key catalog ladder or generic response parser. Rejected or unknown
 authentication and unstructured responses remain insufficient.
@@ -175,6 +190,8 @@ authentication and unstructured responses remain insufficient.
 and discovery path to Source creation, including idempotent terminal polling.
 Missing-model validation succeeds; credential rejection, rate limiting, upstream
 errors, and unstructured success responses create no Source.
+Identical validation responses for candidate/control credentials also create no
+Source; the engine's local OAuth inventory is not an upstream authentication probe.
 
 ## Acceptance
 

--- a/docs/plans/model-hub-vendor-preset-protocol.md
+++ b/docs/plans/model-hub-vendor-preset-protocol.md
@@ -170,9 +170,12 @@ rejects a candidate. An unknown Auto sibling is not eliminated by another
 candidate's rejection. API-key observation remains model-free, non-redirecting
 and bounded by its deadline.
 
-Explicit unverified saves carry `verification_pending: true` independently of
-routing health. Inventory refresh never clears it; only an actual successful
-current-credential invocation does. Credential/endpoint replacement sets it again.
+Every newly stored Hub credential carries an opaque `verification_pending` marker
+independently of routing health, including observed creates and native-config imports.
+Inventory refresh never clears it. Any actual successful invocation whose captured
+marker and credential still match the fresh Source clears it inside the shared config
+transaction. Later same-credential attempts do not negate proof. Credential/endpoint
+replacement generates a new marker, including same-handle OAuth reauthentication.
 The Source remains configurable and invokable, but list/detail surfaces do not
 claim healthy/in-use status while verification is pending. The normal verified
 save path still requires response-backed authentication and protocol ownership.

--- a/docs/plans/model-hub.md
+++ b/docs/plans/model-hub.md
@@ -355,32 +355,40 @@ rungs, documented in `docs/plans/model-hub-vendor-preset-protocol.md`:
    prove reachability and authentication on that protocol's path. Shape proof
    is not required. A wrong declaration fails on a later real call.
 
-Authentication must be credential-sensitive (2026-09-07): a validation error
-alone can precede authorization. The model-free probe must reject a control
-credential, or a protected API-key model-list endpoint must reject that control
-and accept the supplied key. Public inventory and the inventory waiver never
-establish authentication; protocol owners cannot override explicit rejection.
-The control must preserve the candidate's credential structure, not merely its
-presence. JWT controls retain the header, claims and signature length, changing
-signature bytes; opaque controls retain the preceding prefix and length.
+**Owner ruling 2026-09-07: configuration and verification are independent.**
+The three owners above still determine the interface, but explicit API-key
+`save_unverified: true` no longer requires a successful observation. It saves only
+a catalog-pinned or user-declared protocol, with canonical validation, credential
+custody, nonce reconciliation and rollback unchanged. Custom Auto without a
+declaration is refused before credential work. No upstream probe or model discovery
+is performed by this explicit save path; supplied manual models remain manual.
 
-For OpenAI/Codex Hub subscriptions, the bound OAuth transport owns the fixed
-official Responses endpoint. Model-free observation may combine that endpoint
-with a structured request error confirmed by the rejected-control check, including a
-missing-model error, to establish `openai_responses` (2026-09-07). Login success
-alone, unknown authentication, and credential rejection do not establish it.
-This does not grant endpoint ownership to user-supplied API-key URLs or relax
-`custom` Auto detection.
-Inside the private runtime, OAuth probes read the bound managed access-token
-file after path and permission checks. Candidate and control use the same
-ephemeral snapshot on the existing allowlisted engine transport and auth index;
-neither is written back or exposed through Model Hub API results, events, logs,
-or Agent configuration. Missing or unsafe material cannot establish proof.
+Schema errors may precede authentication and never authenticate a key. There is no
+synthetic credential control: unknown grammar/checksums and other valid credentials
+make both rejection and acceptance of an altered token inconclusive. Bare 401/403
+statuses likewise do not prove credential rejection. The ordinary non-persisting
+observation still reports response-backed evidence without inventing certainty.
+
+Completed Hub OAuth consent may retain its bound credential as an unverified Source
+under the fixed vendor protocol. The engine retains OAuth token custody; optional
+model-free observation uses the existing allowlisted auth-index transport and token
+substitution, not private-token reads. Explicit upstream credential rejection retains
+the existing needs-action state. Native CLI OAuth is unchanged.
+
+`Source.verification_pending` is optional persisted metadata, independent of health
+and routing eligibility. Source list/detail use the existing advisory treatment for
+this marker instead of healthy/in-use copy. Inventory discovery never clears it.
+Only an actual successful current-credential model call, including the existing
+backend probe, clears it; superseded attempts cannot verify replacement material.
+Credential/endpoint replacement sets it again. Legacy Sources retain their existing
+state without retroactive verification claims. Successful verification of one call
+does not promise that every model or operation is supported.
 
 The form exposes a vendor select first (V4 06r / 模型网关 05). Auto detect plus
-the three supported protocols remain on `custom`. A failed observation still
-stores nothing rather than guessing. Unreachable, rejected, timeout, and
-adapter-error paths still cannot save.
+the three supported protocols remain on `custom`. Observation alone never saves
+anything. The explicit unverified-save exit is available after an observation failure
+or directly from a valid declared/pinned draft; it does not turn that failure into
+proof or silently select the first Auto candidate.
 
 Once saved, `protocol` is immutable for that Source. Connectivity retest, model
 discovery, refresh, credential replacement, Base URL replacement, and restart all use

--- a/docs/plans/model-hub.md
+++ b/docs/plans/model-hub.md
@@ -360,6 +360,9 @@ alone can precede authorization. The model-free probe must reject a control
 credential, or a protected API-key model-list endpoint must reject that control
 and accept the supplied key. Public inventory and the inventory waiver never
 establish authentication; protocol owners cannot override explicit rejection.
+The control must preserve the candidate's credential structure, not merely its
+presence. JWT controls retain the header, claims and signature length, changing
+signature bytes; opaque controls retain the preceding prefix and length.
 
 For OpenAI/Codex Hub subscriptions, the bound OAuth transport owns the fixed
 official Responses endpoint. Model-free observation may combine that endpoint
@@ -368,6 +371,11 @@ missing-model error, to establish `openai_responses` (2026-09-07). Login success
 alone, unknown authentication, and credential rejection do not establish it.
 This does not grant endpoint ownership to user-supplied API-key URLs or relax
 `custom` Auto detection.
+Inside the private runtime, OAuth probes read the bound managed access-token
+file after path and permission checks. Candidate and control use the same
+ephemeral snapshot on the existing allowlisted engine transport and auth index;
+neither is written back or exposed through Model Hub API results, events, logs,
+or Agent configuration. Missing or unsafe material cannot establish proof.
 
 The form exposes a vendor select first (V4 06r / 模型网关 05). Auto detect plus
 the three supported protocols remain on `custom`. A failed observation still

--- a/docs/plans/model-hub.md
+++ b/docs/plans/model-hub.md
@@ -375,12 +375,16 @@ model-free observation uses the existing allowlisted auth-index transport and to
 substitution, not private-token reads. Explicit upstream credential rejection retains
 the existing needs-action state. Native CLI OAuth is unchanged.
 
-`Source.verification_pending` is optional persisted metadata, independent of health
-and routing eligibility. Source list/detail use the existing advisory treatment for
-this marker instead of healthy/in-use copy. Inventory discovery never clears it.
-Only an actual successful current-credential model call, including the existing
-backend probe, clears it; superseded attempts cannot verify replacement material.
-Credential/endpoint replacement sets it again. Legacy Sources retain their existing
+`Source.verification_pending` is one optional persisted opaque identity, independent
+of health and routing eligibility. Every newly stored Hub credential gets a marker,
+including observed creates and native-config imports. Source list/detail use the
+existing advisory treatment instead of healthy/in-use copy. Inventory never clears it.
+A call captures the marker before invocation; any successful same-credential call
+with that marker, including the existing backend probe, clears it in a fresh shared
+config transaction. Later same-credential attempts do not invalidate success.
+Credential/endpoint replacement generates a new marker even when OAuth reuses the
+same handle, so old calls cannot verify replacement material across processes.
+Legacy Sources retain their existing
 state without retroactive verification claims. Successful verification of one call
 does not promise that every model or operation is supported.
 

--- a/docs/plans/model-hub.md
+++ b/docs/plans/model-hub.md
@@ -355,6 +355,14 @@ rungs, documented in `docs/plans/model-hub-vendor-preset-protocol.md`:
    prove reachability and authentication on that protocol's path. Shape proof
    is not required. A wrong declaration fails on a later real call.
 
+For OpenAI/Codex Hub subscriptions, the bound OAuth transport owns the fixed
+official Responses endpoint. Model-free observation may combine that endpoint
+with a structured request error classified as authenticated, including a
+missing-model error, to establish `openai_responses` (2026-09-07). Login success
+alone, unknown authentication, and credential rejection do not establish it.
+This does not grant endpoint ownership to user-supplied API-key URLs or relax
+`custom` Auto detection.
+
 The form exposes a vendor select first (V4 06r / 模型网关 05). Auto detect plus
 the three supported protocols remain on `custom`. A failed observation still
 stores nothing rather than guessing. Unreachable, rejected, timeout, and

--- a/docs/plans/model-hub.md
+++ b/docs/plans/model-hub.md
@@ -355,9 +355,15 @@ rungs, documented in `docs/plans/model-hub-vendor-preset-protocol.md`:
    prove reachability and authentication on that protocol's path. Shape proof
    is not required. A wrong declaration fails on a later real call.
 
+Authentication must be credential-sensitive (2026-09-07): a validation error
+alone can precede authorization. The model-free probe must reject a control
+credential, or a protected API-key model-list endpoint must reject that control
+and accept the supplied key. Public inventory and the inventory waiver never
+establish authentication; protocol owners cannot override explicit rejection.
+
 For OpenAI/Codex Hub subscriptions, the bound OAuth transport owns the fixed
 official Responses endpoint. Model-free observation may combine that endpoint
-with a structured request error classified as authenticated, including a
+with a structured request error confirmed by the rejected-control check, including a
 missing-model error, to establish `openai_responses` (2026-09-07). Login success
 alone, unknown authentication, and credential rejection do not establish it.
 This does not grant endpoint ownership to user-supplied API-key URLs or relax

--- a/tests/scenarios/auth_setup/catalog.yaml
+++ b/tests/scenarios/auth_setup/catalog.yaml
@@ -125,8 +125,15 @@ scenarios:
     status: covered
     kind: negative_path
     layer: scenario
-    backend: codex
+    backend: shared
     test: tests/scenarios/auth_setup/test_auth_setup_scenarios.py::test_hub_oauth_model_free_observation_closed_loop
+  - id: AUTH-SETUP-114
+    name: Auto policy responses neither reject credentials nor falsely exclude competing protocols
+    status: covered
+    kind: negative_path
+    layer: scenario
+    backend: shared
+    test: tests/scenarios/auth_setup/test_auth_setup_scenarios.py::test_custom_auto_policy_response_cannot_reject_or_exclude_credentials
   - id: AUTH-SETUP-201
     name: Re-entering setup replaces the active flow
     status: covered

--- a/tests/scenarios/auth_setup/catalog.yaml
+++ b/tests/scenarios/auth_setup/catalog.yaml
@@ -113,6 +113,13 @@ scenarios:
     layer: scenario
     backend: shared
     test: tests/scenarios/auth_setup/test_auth_setup_scenarios.py::test_catalog_api_key_setup_observe_then_create_closed_loop
+  - id: AUTH-SETUP-112
+    name: API-key setup authenticates and confirms a Source independently of model scheduling
+    status: covered
+    kind: happy_path
+    layer: scenario
+    backend: shared
+    test: tests/scenarios/auth_setup/test_auth_setup_scenarios.py::test_api_key_setup_does_not_schedule_a_model
   - id: AUTH-SETUP-201
     name: Re-entering setup replaces the active flow
     status: covered

--- a/tests/scenarios/auth_setup/catalog.yaml
+++ b/tests/scenarios/auth_setup/catalog.yaml
@@ -120,6 +120,13 @@ scenarios:
     layer: scenario
     backend: shared
     test: tests/scenarios/auth_setup/test_auth_setup_scenarios.py::test_api_key_setup_does_not_schedule_a_model
+  - id: AUTH-SETUP-113
+    name: Hub OAuth creates a Source after model-free validation but rejects unproven authentication
+    status: covered
+    kind: negative_path
+    layer: scenario
+    backend: codex
+    test: tests/scenarios/auth_setup/test_auth_setup_scenarios.py::test_hub_oauth_model_free_observation_closed_loop
   - id: AUTH-SETUP-201
     name: Re-entering setup replaces the active flow
     status: covered

--- a/tests/scenarios/auth_setup/catalog.yaml
+++ b/tests/scenarios/auth_setup/catalog.yaml
@@ -114,14 +114,14 @@ scenarios:
     backend: shared
     test: tests/scenarios/auth_setup/test_auth_setup_scenarios.py::test_catalog_api_key_setup_observe_then_create_closed_loop
   - id: AUTH-SETUP-112
-    name: API-key setup authenticates and confirms a Source independently of model scheduling
+    name: API-key setup keeps validation unverified and explicitly saves without upstream scheduling
     status: covered
     kind: happy_path
     layer: scenario
     backend: shared
     test: tests/scenarios/auth_setup/test_auth_setup_scenarios.py::test_api_key_setup_does_not_schedule_a_model
   - id: AUTH-SETUP-113
-    name: Hub OAuth creates a Source after model-free validation but rejects unproven authentication
+    name: Hub OAuth retains completed credentials as unverified and preserves explicit rejection state
     status: covered
     kind: negative_path
     layer: scenario

--- a/tests/scenarios/auth_setup/test_auth_setup_scenarios.py
+++ b/tests/scenarios/auth_setup/test_auth_setup_scenarios.py
@@ -2697,8 +2697,9 @@ def test_catalog_api_key_setup_observe_then_create_closed_loop(monkeypatch, tmp_
 )
 @pytest.mark.parametrize("auth_before_validation", [True, False])
 @pytest.mark.parametrize("public_inventory", [False, True])
+@pytest.mark.parametrize("valid_key", ["test-model-free-key", "!@#$%^&*"])
 def test_api_key_setup_does_not_schedule_a_model(
-    monkeypatch, tmp_path, vendor, protocol, auth_before_validation, public_inventory,
+    monkeypatch, tmp_path, vendor, protocol, auth_before_validation, public_inventory, valid_key,
 ):
     """Scenario: AUTH-SETUP-112"""
     from tests.test_model_hub_api import _service
@@ -2716,7 +2717,7 @@ def test_api_key_setup_does_not_schedule_a_model(
 
     async def scenario():
         requests = []
-        valid_key = "test-model-free-key"
+        key_syntax = r"[a-z-]+" if valid_key[0].isalpha() else r"[^\w\s]+"
         paths = {
             "anthropic": "/v1/messages",
             "openai_responses": "/v1/responses",
@@ -2731,7 +2732,7 @@ def test_api_key_setup_does_not_schedule_a_model(
                 if protocol == "anthropic"
                 else request.headers.get("Authorization", "").removeprefix("Bearer ")
             )
-            if not re.fullmatch(r"[a-z-]+", supplied_key):
+            if not re.fullmatch(key_syntax, supplied_key):
                 return web.json_response({"code": "INVALID_API_KEY"}, status=401)
             if request.method == "POST" and not auth_before_validation and "model" not in body:
                 return web.json_response(
@@ -2800,7 +2801,7 @@ def test_api_key_setup_does_not_schedule_a_model(
             assert state_store.read_api_key(h.source["credential_ref"]) == valid_key
 
         async def reject_invalid_key(h):
-            invalid = {**draft, "key": "invalid-test-key"}
+            invalid = {**draft, "key": "invalid-test-key" if valid_key[0].isalpha() else "!!??"}
             result = await service.observe_source(invalid)
             assert result["observation"]["outcome"] != "observed"
             assert result["observation"]["authenticated"] != "authenticated"
@@ -2833,6 +2834,7 @@ def test_api_key_setup_does_not_schedule_a_model(
     [
         (400, {"error": {"type": "invalid_request_error", "param": "model"}}, True),
         (401, {"error": {"code": "invalid_api_key"}}, False),
+        (403, {"message": "Request blocked by regional policy"}, False),
         (429, {"error": {"type": "rate_limit_error"}}, False),
         (502, {"error": {"type": "upstream_error"}}, False),
         (200, {"ok": True}, False),
@@ -2925,6 +2927,75 @@ def test_hub_oauth_model_free_observation_closed_loop(
         ScenarioStep("materialize_source", materialize_source),
     ))
     ScenarioExpect.step_history(runner, ["start_login", "complete_consent", "materialize_source"])
+
+
+@pytest.mark.parametrize("status", [401, 403])
+@pytest.mark.parametrize("policy_body", ["<html>Request blocked</html>", '{"message":"Regional policy"}'])
+@pytest.mark.parametrize("competing_protocol", [False, True])
+def test_custom_auto_policy_response_cannot_reject_or_exclude_credentials(
+    monkeypatch, tmp_path, status, policy_body, competing_protocol,
+):
+    """Scenario: AUTH-SETUP-114"""
+    from tests.test_model_hub_api import _service
+    from vibe.model_hub_runtime.adapter import CLIProxyEngineAdapter
+    from vibe.model_hub_runtime.state import EngineStateStore
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    transport = CLIProxyEngineAdapter(
+        supervisor=Mock(), state_store=EngineStateStore(tmp_path / "engine-state"),
+    )
+    service, store, adapter = _service(tmp_path)
+    for method in ("provision_credential", "provision_transient_credential", "revoke_credential", "observe_source"):
+        monkeypatch.setattr(adapter, method, getattr(transport, method))
+
+    async def scenario():
+        paths = []
+
+        async def upstream(request):
+            assert request.method == "POST", "Unknown protocol evidence must not reach model discovery"
+            assert "model" not in await request.json()
+            paths.append(request.path)
+            if competing_protocol and request.path == "/v1/responses":
+                if request.headers.get("Authorization") != "Bearer test-policy-key":
+                    return web.Response(status=401, text="Invalid control")
+                return web.json_response(
+                    {"error": {"type": "invalid_request_error", "param": "model"}}, status=400,
+                )
+            if competing_protocol and request.path == "/v1/chat/completions":
+                return web.Response(status=404)
+            return web.Response(status=status, text=policy_body)
+
+        upstream_app = web.Application()
+        upstream_app.router.add_route("*", "/{path:.*}", upstream)
+        web_runner = web.AppRunner(upstream_app)
+        await web_runner.setup()
+        site = web.TCPSite(web_runner, "127.0.0.1", 0)
+        await site.start()
+        port = site._server.sockets[0].getsockname()[1]
+        draft = {"vendor": "custom", "base_url": f"http://127.0.0.1:{port}", "key": "test-policy-key"}
+        runner = ScenarioRunner(SimpleNamespace())
+
+        async def observe(h):
+            result = await service.observe_source(draft)
+            observation = result["observation"]
+            assert observation["outcome"] == "ambiguous"
+            assert observation["protocol"] is None
+            assert observation["authenticated"] == ("authenticated" if competing_protocol else "unknown")
+            assert not store.config.sources
+
+        async def confirm(h):
+            with pytest.raises(ModelHubError):
+                await service.create_source({"kind": "api_key", **draft, "accept_unavailable_inventory": True})
+            assert not store.config.sources
+
+        try:
+            await runner.run(ScenarioStep("observe", observe), ScenarioStep("confirm", confirm))
+            ScenarioExpect.step_history(runner, ["observe", "confirm"])
+            assert set(paths) == {"/v1/messages", "/v1/responses", "/v1/chat/completions"}
+        finally:
+            await web_runner.cleanup()
+
+    asyncio.run(scenario())
 
 
 if __name__ == "__main__":

--- a/tests/scenarios/auth_setup/test_auth_setup_scenarios.py
+++ b/tests/scenarios/auth_setup/test_auth_setup_scenarios.py
@@ -63,6 +63,7 @@ from vibe.claude_config import (
 from vibe import remote_access, show_identity, ui_server
 from vibe.ui_server import app
 from vibe.model_hub_runtime.api_key_vendors import api_key_vendor_catalog
+from vibe.model_hub_runtime.adapter import _OAUTH_ENDPOINTS
 
 
 def test_auth_setup_catalog_priorities_reference_live_scenarios():
@@ -2790,7 +2791,7 @@ def test_api_key_setup_does_not_schedule_a_model(
             h.source = store.config.sources[0].to_payload()
             assert h.source["protocol"] == protocol
             assert h.source["models"] == []
-            assert h.source["verification_pending"] is True
+            assert h.source["verification_pending"]
             assert state_store.read_api_key(h.source["credential_ref"]) == valid_key
 
         async def reject_invalid_key(h):
@@ -2837,7 +2838,7 @@ def test_api_key_setup_does_not_schedule_a_model(
     ],
 )
 @pytest.mark.parametrize("validation_before_auth", [False, True])
-@pytest.mark.parametrize("vendor", ["openai", "anthropic"])
+@pytest.mark.parametrize("vendor", tuple(_OAUTH_ENDPOINTS))
 @pytest.mark.parametrize("credential_valid", [True, False])
 def test_hub_oauth_model_free_observation_closed_loop(
     monkeypatch, tmp_path, caplog, status, body, validation_before_auth, vendor, credential_valid,
@@ -2852,13 +2853,14 @@ def test_hub_oauth_model_free_observation_closed_loop(
     api_calls = []
     inventory_calls = []
     rejected = status == 401 or (not credential_valid and not (validation_before_auth and status == 400))
-    protocol = "openai_responses" if vendor == "openai" else "anthropic"
+    is_openai = vendor in {"openai", "codex"}
+    protocol = "openai_responses" if is_openai else "anthropic"
     if vendor == "anthropic" and "error" in body:
         body = {"type": "error", **body}
     signing_key = "test-oauth-signature-key-with-32-bytes"
     bound_token = (
         jwt.encode({"sub": "account-test", "exp": time.time() + (3600 if credential_valid else -3600)}, signing_key)
-        if vendor == "openai"
+        if is_openai
         else "sk-ant-oat01-test-valid" if credential_valid else "sk-ant-oat01-test-expired"
     )
     auth_name = "oauth-test.json"
@@ -2868,23 +2870,23 @@ def test_hub_oauth_model_free_observation_closed_loop(
         if path == "/auth-files":
             return {"files": [{
                 "id": "codex-test", "auth_index": "auth-index-test",
-                "name": auth_name, "provider": "codex" if vendor == "openai" else "claude",
+                "name": auth_name, "provider": "codex" if is_openai else "claude",
                 "id_token": {"chatgpt_account_id": "account-test"},
             }]}
         if path == "/api-call":
             assert method == "POST"
             assert payload["auth_index"] == "auth-index-test"
             assert payload["url"] == (
-                "https://chatgpt.com/backend-api/codex/responses" if vendor == "openai"
+                "https://chatgpt.com/backend-api/codex/responses" if is_openai
                 else "https://api.anthropic.com/v1/messages?beta=true"
             )
-            if vendor == "openai":
+            if is_openai:
                 assert payload["header"]["Chatgpt-Account-Id"] == "account-test"
             assert "model" not in json.loads(payload["data"])
             api_calls.append(payload)
             token = payload["header"]["Authorization"].removeprefix("Bearer ").replace("$TOKEN$", bound_token)
             try:
-                if vendor == "openai":
+                if is_openai:
                     jwt.decode(token, options={"verify_signature": False})
                 elif not re.fullmatch(r"sk-ant-oat01-[a-z-]+", token):
                     raise ValueError("Malformed opaque token")
@@ -2893,7 +2895,7 @@ def test_hub_oauth_model_free_observation_closed_loop(
             if validation_before_auth and status == 400:
                 return {"status_code": status, "body": json.dumps(body)}
             try:
-                if vendor == "openai":
+                if is_openai:
                     jwt.decode(token, signing_key, algorithms=["HS256"])
                 elif token != "sk-ant-oat01-test-valid":
                     raise ValueError("Invalid opaque token")
@@ -2936,7 +2938,7 @@ def test_hub_oauth_model_free_observation_closed_loop(
         assert source["protocol"] == protocol
         assert source["supply_channel"] == "hub"
         assert source["credential_ref"] == h.credential_ref
-        assert source["verification_pending"] is True
+        assert source["verification_pending"]
         assert source["state"]["status"] == ("needs_action" if rejected else "standby")
         assert [model["id"] for model in source["models"]] == ([] if rejected else ["gpt-5.6"])
         assert service.list_sources() == [source]

--- a/tests/scenarios/auth_setup/test_auth_setup_scenarios.py
+++ b/tests/scenarios/auth_setup/test_auth_setup_scenarios.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import os
+import re
 import sys
 import tempfile
 import time
@@ -2694,7 +2695,11 @@ def test_catalog_api_key_setup_observe_then_create_closed_loop(monkeypatch, tmp_
     [(entry.id, entry.protocol) for entry in api_key_vendor_catalog()]
     + [("custom", protocol) for protocol in SOURCE_PROTOCOLS],
 )
-def test_api_key_setup_does_not_schedule_a_model(monkeypatch, tmp_path, vendor, protocol):
+@pytest.mark.parametrize("auth_before_validation", [True, False])
+@pytest.mark.parametrize("public_inventory", [False, True])
+def test_api_key_setup_does_not_schedule_a_model(
+    monkeypatch, tmp_path, vendor, protocol, auth_before_validation, public_inventory,
+):
     """Scenario: AUTH-SETUP-112"""
     from tests.test_model_hub_api import _service
     from vibe.model_hub_runtime.adapter import CLIProxyEngineAdapter
@@ -2726,7 +2731,14 @@ def test_api_key_setup_does_not_schedule_a_model(monkeypatch, tmp_path, vendor, 
                 if protocol == "anthropic"
                 else request.headers.get("Authorization", "").removeprefix("Bearer ")
             )
-            if supplied_key != valid_key:
+            if not re.fullmatch(r"[a-z-]+", supplied_key):
+                return web.json_response({"code": "INVALID_API_KEY"}, status=401)
+            if request.method == "POST" and not auth_before_validation and "model" not in body:
+                return web.json_response(
+                    {"error": {"type": "invalid_request_error", "message": "model is required"}},
+                    status=400,
+                )
+            if supplied_key != valid_key and not (request.method == "GET" and public_inventory):
                 return web.json_response({"code": "INVALID_API_KEY"}, status=401)
             if request.method == "GET":
                 return web.json_response({"data": [{"id": "relay-model"}]})
@@ -2756,17 +2768,30 @@ def test_api_key_setup_does_not_schedule_a_model(monkeypatch, tmp_path, vendor, 
         }
         harness = SimpleNamespace()
         runner = ScenarioRunner(harness)
+        authentication_observable = auth_before_validation or not public_inventory
 
         async def observe(h):
             result = await service.observe_source(draft)
             observation = result["observation"]
-            assert observation["outcome"] == "observed"
-            assert observation["protocol"] == protocol
-            assert observation["authenticated"] == "authenticated"
-            assert observation["models"] == ["relay-model"]
+            if authentication_observable:
+                assert observation["outcome"] == "observed"
+                assert observation["protocol"] == protocol
+                assert observation["authenticated"] == "authenticated"
+                assert observation["models"] == ["relay-model"]
+            else:
+                assert observation["outcome"] != "observed"
+                assert observation["authenticated"] != "authenticated"
             assert not store.config.sources
 
         async def confirm(h):
+            if not authentication_observable:
+                with pytest.raises(ModelHubError):
+                    await service.create_source({
+                        "kind": "api_key", **draft, "accept_unavailable_inventory": True,
+                    })
+                assert not store.config.sources
+                h.source = None
+                return
             await service.create_source({"kind": "api_key", **draft})
             assert len(store.config.sources) == 1
             h.source = store.config.sources[0].to_payload()
@@ -2777,10 +2802,13 @@ def test_api_key_setup_does_not_schedule_a_model(monkeypatch, tmp_path, vendor, 
         async def reject_invalid_key(h):
             invalid = {**draft, "key": "invalid-test-key"}
             result = await service.observe_source(invalid)
-            assert result["observation"]["outcome"] == "authentication_failed"
+            assert result["observation"]["outcome"] != "observed"
+            assert result["observation"]["authenticated"] != "authenticated"
             with pytest.raises(ModelHubError):
-                await service.create_source({"kind": "api_key", **invalid})
-            assert [source.to_payload() for source in store.config.sources] == [h.source]
+                await service.create_source({
+                    "kind": "api_key", **invalid, "accept_unavailable_inventory": True,
+                })
+            assert [source.to_payload() for source in store.config.sources] == ([h.source] if h.source else [])
 
         try:
             await runner.run(
@@ -2789,11 +2817,10 @@ def test_api_key_setup_does_not_schedule_a_model(monkeypatch, tmp_path, vendor, 
                 ScenarioStep("reject_invalid_key", reject_invalid_key),
             )
             ScenarioExpect.step_history(runner, ["observe", "confirm", "reject_invalid_key"])
-            assert [(method, path) for method, path, _ in requests] == [
-                ("POST", paths[protocol]), ("GET", "/v1/models"),
-                ("POST", paths[protocol]), ("GET", "/v1/models"),
-                ("POST", paths[protocol]), ("POST", paths[protocol]),
-            ]
+            assert all(
+                path == (paths[protocol] if method == "POST" else "/v1/models")
+                for method, path, _ in requests
+            )
             assert all("model" not in body for _, _, body in requests if body is not None)
         finally:
             await web_runner.cleanup()
@@ -2811,7 +2838,10 @@ def test_api_key_setup_does_not_schedule_a_model(monkeypatch, tmp_path, vendor, 
         (200, {"ok": True}, False),
     ],
 )
-def test_hub_oauth_model_free_observation_closed_loop(monkeypatch, tmp_path, status, body, creates_source):
+@pytest.mark.parametrize("validation_before_auth", [False, True])
+def test_hub_oauth_model_free_observation_closed_loop(
+    monkeypatch, tmp_path, status, body, creates_source, validation_before_auth,
+):
     """Scenario: AUTH-SETUP-113"""
     from tests.test_model_hub_api import _service
     from vibe.model_hub_runtime.adapter import CLIProxyEngineAdapter
@@ -2821,6 +2851,7 @@ def test_hub_oauth_model_free_observation_closed_loop(monkeypatch, tmp_path, sta
     state_store = EngineStateStore(tmp_path / "engine-state")
     api_calls = []
     inventory_calls = []
+    creates_source = creates_source and not validation_before_auth
 
     def management_request(method, path, *, query=None, payload=None):
         if path == "/auth-files":
@@ -2836,6 +2867,8 @@ def test_hub_oauth_model_free_observation_closed_loop(monkeypatch, tmp_path, sta
             assert payload["header"]["Chatgpt-Account-Id"] == "account-test"
             assert "model" not in json.loads(payload["data"])
             api_calls.append(payload)
+            if not validation_before_auth and payload["header"]["Authorization"] != "Bearer $TOKEN$":
+                return {"status_code": 401, "body": '{"error":{"code":"invalid_api_key"}}'}
             return {"status_code": status, "body": json.dumps(body)}
         if path == "/auth-files/models":
             assert creates_source
@@ -2883,7 +2916,7 @@ def test_hub_oauth_model_free_observation_closed_loop(monkeypatch, tmp_path, sta
                 await service.oauth_status(h.flow_id)
             assert not store.config.sources
             assert adapter.revoked == [h.credential_ref]
-        assert len(api_calls) == 1
+        assert len(api_calls) == (2 if status == 400 else 1)
         assert len(inventory_calls) == int(creates_source)
 
     asyncio.run(runner.run(

--- a/tests/scenarios/auth_setup/test_auth_setup_scenarios.py
+++ b/tests/scenarios/auth_setup/test_auth_setup_scenarios.py
@@ -9,12 +9,13 @@ import urllib.parse
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
 import jwt
 import pytest
 import yaml
+from aiohttp import web
 from cryptography.hazmat.primitives.asymmetric import rsa
 
 ROOT = Path(__file__).resolve().parents[3]
@@ -35,6 +36,7 @@ from config.v2_config import (
     V2Config,
 )
 from core.agent_auth_service import AgentAuthService
+from core.handlers.model_hub.adapter import SOURCE_PROTOCOLS
 from core.handlers.model_hub.service import ModelHubError
 from core.show_pages import ShowPageStore
 from modules.agents.codex.agent import CodexAgent
@@ -58,6 +60,7 @@ from vibe.claude_config import (
 )
 from vibe import remote_access, show_identity, ui_server
 from vibe.ui_server import app
+from vibe.model_hub_runtime.api_key_vendors import api_key_vendor_catalog
 
 
 def test_auth_setup_catalog_priorities_reference_live_scenarios():
@@ -2683,6 +2686,118 @@ def test_catalog_api_key_setup_observe_then_create_closed_loop(monkeypatch, tmp_
             "create_auth_failure",
         ],
     )
+
+
+@pytest.mark.parametrize(
+    ("vendor", "protocol"),
+    [(entry.id, entry.protocol) for entry in api_key_vendor_catalog()]
+    + [("custom", protocol) for protocol in SOURCE_PROTOCOLS],
+)
+def test_api_key_setup_does_not_schedule_a_model(monkeypatch, tmp_path, vendor, protocol):
+    """Scenario: AUTH-SETUP-112"""
+    from tests.test_model_hub_api import _service
+    from vibe.model_hub_runtime.adapter import CLIProxyEngineAdapter
+    from vibe.model_hub_runtime.state import EngineStateStore
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    state_store = EngineStateStore(tmp_path / "engine-state")
+    transport = CLIProxyEngineAdapter(supervisor=Mock(), state_store=state_store)
+    service, store, adapter = _service(tmp_path)
+    # Keep engine lifecycle simulated; exercise real credential custody, HTTP
+    # observation, inventory discovery, and Source admission together.
+    for method in ("provision_credential", "provision_transient_credential", "revoke_credential", "observe_source"):
+        monkeypatch.setattr(adapter, method, getattr(transport, method))
+
+    async def scenario():
+        requests = []
+        valid_key = "test-model-free-key"
+        paths = {
+            "anthropic": "/v1/messages",
+            "openai_responses": "/v1/responses",
+            "openai_chat": "/v1/chat/completions",
+        }
+
+        async def upstream(request):
+            body = await request.json() if request.method == "POST" else None
+            requests.append((request.method, request.path, body))
+            supplied_key = (
+                request.headers.get("x-api-key")
+                if protocol == "anthropic"
+                else request.headers.get("Authorization", "").removeprefix("Bearer ")
+            )
+            if supplied_key != valid_key:
+                return web.json_response({"code": "INVALID_API_KEY"}, status=401)
+            if request.method == "GET":
+                return web.json_response({"data": [{"id": "relay-model"}]})
+            if "model" in body:
+                return web.json_response(
+                    {"error": {"type": "rate_limit_error", "message": "No available model capacity"}},
+                    status=429,
+                )
+            return web.json_response(
+                {"error": {"type": "invalid_request_error", "message": "model is required"}},
+                status=400,
+            )
+
+        upstream_app = web.Application()
+        upstream_app.router.add_post(paths[protocol], upstream)
+        upstream_app.router.add_get("/v1/models", upstream)
+        web_runner = web.AppRunner(upstream_app)
+        await web_runner.setup()
+        site = web.TCPSite(web_runner, "127.0.0.1", 0)
+        await site.start()
+        port = site._server.sockets[0].getsockname()[1]
+        draft = {
+            "vendor": vendor,
+            "protocol": protocol,
+            "base_url": f"http://127.0.0.1:{port}",
+            "key": valid_key,
+        }
+        harness = SimpleNamespace()
+        runner = ScenarioRunner(harness)
+
+        async def observe(h):
+            result = await service.observe_source(draft)
+            observation = result["observation"]
+            assert observation["outcome"] == "observed"
+            assert observation["protocol"] == protocol
+            assert observation["authenticated"] == "authenticated"
+            assert observation["models"] == ["relay-model"]
+            assert not store.config.sources
+
+        async def confirm(h):
+            await service.create_source({"kind": "api_key", **draft})
+            assert len(store.config.sources) == 1
+            h.source = store.config.sources[0].to_payload()
+            assert h.source["protocol"] == protocol
+            assert h.source["models"][0]["id"] == "relay-model"
+            assert state_store.read_api_key(h.source["credential_ref"]) == valid_key
+
+        async def reject_invalid_key(h):
+            invalid = {**draft, "key": "invalid-test-key"}
+            result = await service.observe_source(invalid)
+            assert result["observation"]["outcome"] == "authentication_failed"
+            with pytest.raises(ModelHubError):
+                await service.create_source({"kind": "api_key", **invalid})
+            assert [source.to_payload() for source in store.config.sources] == [h.source]
+
+        try:
+            await runner.run(
+                ScenarioStep("observe", observe),
+                ScenarioStep("confirm", confirm),
+                ScenarioStep("reject_invalid_key", reject_invalid_key),
+            )
+            ScenarioExpect.step_history(runner, ["observe", "confirm", "reject_invalid_key"])
+            assert [(method, path) for method, path, _ in requests] == [
+                ("POST", paths[protocol]), ("GET", "/v1/models"),
+                ("POST", paths[protocol]), ("GET", "/v1/models"),
+                ("POST", paths[protocol]), ("POST", paths[protocol]),
+            ]
+            assert all("model" not in body for _, _, body in requests if body is not None)
+        finally:
+            await web_runner.cleanup()
+
+    asyncio.run(scenario())
 
 
 if __name__ == "__main__":

--- a/tests/scenarios/auth_setup/test_auth_setup_scenarios.py
+++ b/tests/scenarios/auth_setup/test_auth_setup_scenarios.py
@@ -2717,6 +2717,7 @@ def test_api_key_setup_does_not_schedule_a_model(
 
     async def scenario():
         requests = []
+        observed_credentials = set()
         key_syntax = r"[a-z-]+" if valid_key[0].isalpha() else r"[^\w\s]+"
         paths = {
             "anthropic": "/v1/messages",
@@ -2732,6 +2733,7 @@ def test_api_key_setup_does_not_schedule_a_model(
                 if protocol == "anthropic"
                 else request.headers.get("Authorization", "").removeprefix("Bearer ")
             )
+            observed_credentials.add(supplied_key)
             if not re.fullmatch(key_syntax, supplied_key):
                 return web.json_response({"code": "INVALID_API_KEY"}, status=401)
             if request.method == "POST" and not auth_before_validation and "model" not in body:
@@ -2769,35 +2771,26 @@ def test_api_key_setup_does_not_schedule_a_model(
         }
         harness = SimpleNamespace()
         runner = ScenarioRunner(harness)
-        authentication_observable = auth_before_validation or not public_inventory
-
         async def observe(h):
             result = await service.observe_source(draft)
             observation = result["observation"]
-            if authentication_observable:
-                assert observation["outcome"] == "observed"
-                assert observation["protocol"] == protocol
-                assert observation["authenticated"] == "authenticated"
-                assert observation["models"] == ["relay-model"]
-            else:
-                assert observation["outcome"] != "observed"
-                assert observation["authenticated"] != "authenticated"
+            assert observation["outcome"] != "observed"
+            assert observation["authenticated"] == "unknown"
             assert not store.config.sources
 
         async def confirm(h):
-            if not authentication_observable:
-                with pytest.raises(ModelHubError):
-                    await service.create_source({
-                        "kind": "api_key", **draft, "accept_unavailable_inventory": True,
-                    })
-                assert not store.config.sources
-                h.source = None
-                return
-            await service.create_source({"kind": "api_key", **draft})
+            with pytest.raises(ModelHubError):
+                await service.create_source({
+                    "kind": "api_key", **draft, "accept_unavailable_inventory": True,
+                })
+            before = len(requests)
+            await service.create_source({"kind": "api_key", **draft, "save_unverified": True})
+            assert len(requests) == before
             assert len(store.config.sources) == 1
             h.source = store.config.sources[0].to_payload()
             assert h.source["protocol"] == protocol
-            assert h.source["models"][0]["id"] == "relay-model"
+            assert h.source["models"] == []
+            assert h.source["verification_pending"] is True
             assert state_store.read_api_key(h.source["credential_ref"]) == valid_key
 
         async def reject_invalid_key(h):
@@ -2818,6 +2811,9 @@ def test_api_key_setup_does_not_schedule_a_model(
                 ScenarioStep("reject_invalid_key", reject_invalid_key),
             )
             ScenarioExpect.step_history(runner, ["observe", "confirm", "reject_invalid_key"])
+            assert observed_credentials == {
+                valid_key, "invalid-test-key" if valid_key[0].isalpha() else "!!??",
+            }
             assert all(
                 path == (paths[protocol] if method == "POST" else "/v1/models")
                 for method, path, _ in requests
@@ -2830,21 +2826,21 @@ def test_api_key_setup_does_not_schedule_a_model(
 
 
 @pytest.mark.parametrize(
-    ("status", "body", "creates_source"),
+    ("status", "body"),
     [
-        (400, {"error": {"type": "invalid_request_error", "param": "model"}}, True),
-        (401, {"error": {"code": "invalid_api_key"}}, False),
-        (403, {"message": "Request blocked by regional policy"}, False),
-        (429, {"error": {"type": "rate_limit_error"}}, False),
-        (502, {"error": {"type": "upstream_error"}}, False),
-        (200, {"ok": True}, False),
+        (400, {"error": {"type": "invalid_request_error", "param": "model"}}),
+        (401, {"error": {"code": "invalid_api_key"}}),
+        (403, {"message": "Request blocked by regional policy"}),
+        (429, {"error": {"type": "rate_limit_error"}}),
+        (502, {"error": {"type": "upstream_error"}}),
+        (200, {"ok": True}),
     ],
 )
 @pytest.mark.parametrize("validation_before_auth", [False, True])
 @pytest.mark.parametrize("vendor", ["openai", "anthropic"])
 @pytest.mark.parametrize("credential_valid", [True, False])
 def test_hub_oauth_model_free_observation_closed_loop(
-    monkeypatch, tmp_path, caplog, status, body, creates_source, validation_before_auth, vendor, credential_valid,
+    monkeypatch, tmp_path, caplog, status, body, validation_before_auth, vendor, credential_valid,
 ):
     """Scenario: AUTH-SETUP-113"""
     from tests.test_model_hub_api import _service
@@ -2855,7 +2851,7 @@ def test_hub_oauth_model_free_observation_closed_loop(
     state_store = EngineStateStore(tmp_path / "engine-state")
     api_calls = []
     inventory_calls = []
-    creates_source = creates_source and not validation_before_auth and credential_valid
+    rejected = status == 401 or (not credential_valid and not (validation_before_auth and status == 400))
     protocol = "openai_responses" if vendor == "openai" else "anthropic"
     if vendor == "anthropic" and "error" in body:
         body = {"type": "error", **body}
@@ -2919,6 +2915,7 @@ def test_hub_oauth_model_free_observation_closed_loop(
     # Simulate consent and engine lifecycle, but run the actual bound-credential
     # probe, evidence parser, discovery, and terminal Source materialization.
     monkeypatch.setattr(adapter, "observe_source", transport.observe_source)
+    monkeypatch.setattr(adapter, "discover_models", transport.discover_models)
     harness = SimpleNamespace()
     runner = ScenarioRunner(harness)
 
@@ -2933,25 +2930,22 @@ def test_hub_oauth_model_free_observation_closed_loop(
         adapter.flows[h.flow_id] = replace(flow, state="success", credential_ref=h.credential_ref)
 
     async def materialize_source(h):
-        if creates_source:
-            terminal = await service.oauth_status(h.flow_id)
-            source = terminal["source"]
-            assert terminal["flow"]["state"] == "success"
-            assert source["protocol"] == protocol
-            assert source["supply_channel"] == "hub"
-            assert source["credential_ref"] == h.credential_ref
-            assert [model["id"] for model in source["models"]] == ["gpt-5.6"]
-            assert service.list_sources() == [source]
-            assert bound_token not in json.dumps(terminal)
-            assert (await service.oauth_status(h.flow_id))["source"] == source
-            assert adapter.revoked == []
-        else:
-            with pytest.raises(ModelHubError):
-                await service.oauth_status(h.flow_id)
-            assert not store.config.sources
-            assert adapter.revoked == [h.credential_ref]
-        assert len(api_calls) == (2 if status == 400 and (credential_valid or validation_before_auth) else 1)
-        assert len(inventory_calls) == int(creates_source)
+        terminal = await service.oauth_status(h.flow_id)
+        source = terminal["source"]
+        assert terminal["flow"]["state"] == "success"
+        assert source["protocol"] == protocol
+        assert source["supply_channel"] == "hub"
+        assert source["credential_ref"] == h.credential_ref
+        assert source["verification_pending"] is True
+        assert source["state"]["status"] == ("needs_action" if rejected else "standby")
+        assert [model["id"] for model in source["models"]] == ([] if rejected else ["gpt-5.6"])
+        assert service.list_sources() == [source]
+        assert bound_token not in json.dumps(terminal)
+        assert (await service.oauth_status(h.flow_id))["source"] == source
+        assert adapter.revoked == []
+        assert len(api_calls) == 1
+        assert api_calls[0]["header"]["Authorization"] == "Bearer $TOKEN$"
+        assert len(inventory_calls) == int(not rejected)
         assert json.loads((state_store.auth_dir / auth_name).read_text())["access_token"] == bound_token
         assert bound_token not in caplog.text
 
@@ -3014,12 +3008,16 @@ def test_custom_auto_policy_response_cannot_reject_or_exclude_credentials(
             observation = result["observation"]
             assert observation["outcome"] == "ambiguous"
             assert observation["protocol"] is None
-            assert observation["authenticated"] == ("authenticated" if competing_protocol else "unknown")
+            assert observation["authenticated"] == "unknown"
             assert not store.config.sources
 
         async def confirm(h):
             with pytest.raises(ModelHubError):
                 await service.create_source({"kind": "api_key", **draft, "accept_unavailable_inventory": True})
+            before = len(paths)
+            with pytest.raises(ModelHubError):
+                await service.create_source({"kind": "api_key", **draft, "save_unverified": True})
+            assert len(paths) == before
             assert not store.config.sources
 
         try:

--- a/tests/scenarios/auth_setup/test_auth_setup_scenarios.py
+++ b/tests/scenarios/auth_setup/test_auth_setup_scenarios.py
@@ -2841,8 +2841,10 @@ def test_api_key_setup_does_not_schedule_a_model(
     ],
 )
 @pytest.mark.parametrize("validation_before_auth", [False, True])
+@pytest.mark.parametrize("vendor", ["openai", "anthropic"])
+@pytest.mark.parametrize("credential_valid", [True, False])
 def test_hub_oauth_model_free_observation_closed_loop(
-    monkeypatch, tmp_path, status, body, creates_source, validation_before_auth,
+    monkeypatch, tmp_path, caplog, status, body, creates_source, validation_before_auth, vendor, credential_valid,
 ):
     """Scenario: AUTH-SETUP-113"""
     from tests.test_model_hub_api import _service
@@ -2853,28 +2855,57 @@ def test_hub_oauth_model_free_observation_closed_loop(
     state_store = EngineStateStore(tmp_path / "engine-state")
     api_calls = []
     inventory_calls = []
-    creates_source = creates_source and not validation_before_auth
+    creates_source = creates_source and not validation_before_auth and credential_valid
+    protocol = "openai_responses" if vendor == "openai" else "anthropic"
+    if vendor == "anthropic" and "error" in body:
+        body = {"type": "error", **body}
+    signing_key = "test-oauth-signature-key-with-32-bytes"
+    bound_token = (
+        jwt.encode({"sub": "account-test", "exp": time.time() + (3600 if credential_valid else -3600)}, signing_key)
+        if vendor == "openai"
+        else "sk-ant-oat01-test-valid" if credential_valid else "sk-ant-oat01-test-expired"
+    )
+    auth_name = "oauth-test.json"
+    state_store._secure_write_json(state_store.auth_dir / auth_name, {"access_token": bound_token})
 
     def management_request(method, path, *, query=None, payload=None):
         if path == "/auth-files":
             return {"files": [{
                 "id": "codex-test", "auth_index": "auth-index-test",
-                "name": "codex-test.json", "provider": "codex",
+                "name": auth_name, "provider": "codex" if vendor == "openai" else "claude",
                 "id_token": {"chatgpt_account_id": "account-test"},
             }]}
         if path == "/api-call":
             assert method == "POST"
             assert payload["auth_index"] == "auth-index-test"
-            assert payload["url"] == "https://chatgpt.com/backend-api/codex/responses"
-            assert payload["header"]["Chatgpt-Account-Id"] == "account-test"
+            assert payload["url"] == (
+                "https://chatgpt.com/backend-api/codex/responses" if vendor == "openai"
+                else "https://api.anthropic.com/v1/messages?beta=true"
+            )
+            if vendor == "openai":
+                assert payload["header"]["Chatgpt-Account-Id"] == "account-test"
             assert "model" not in json.loads(payload["data"])
             api_calls.append(payload)
-            if not validation_before_auth and payload["header"]["Authorization"] != "Bearer $TOKEN$":
+            token = payload["header"]["Authorization"].removeprefix("Bearer ").replace("$TOKEN$", bound_token)
+            try:
+                if vendor == "openai":
+                    jwt.decode(token, options={"verify_signature": False})
+                elif not re.fullmatch(r"sk-ant-oat01-[a-z-]+", token):
+                    raise ValueError("Malformed opaque token")
+            except (jwt.PyJWTError, ValueError):
+                return {"status_code": 401, "body": '{"error":{"code":"invalid_api_key"}}'}
+            if validation_before_auth and status == 400:
+                return {"status_code": status, "body": json.dumps(body)}
+            try:
+                if vendor == "openai":
+                    jwt.decode(token, signing_key, algorithms=["HS256"])
+                elif token != "sk-ant-oat01-test-valid":
+                    raise ValueError("Invalid opaque token")
+            except (jwt.PyJWTError, ValueError):
                 return {"status_code": 401, "body": '{"error":{"code":"invalid_api_key"}}'}
             return {"status_code": status, "body": json.dumps(body)}
         if path == "/auth-files/models":
-            assert creates_source
-            assert query == {"name": "codex-test.json"}
+            assert query == {"name": auth_name}
             inventory_calls.append(query)
             return {"models": [{"id": "gpt-5.6"}]}
         raise AssertionError((method, path))
@@ -2892,13 +2923,13 @@ def test_hub_oauth_model_free_observation_closed_loop(
     runner = ScenarioRunner(harness)
 
     async def start_login(h):
-        started = await service.oauth_start({"vendor": "openai", "channel": "hub"})
+        started = await service.oauth_start({"vendor": vendor, "channel": "hub"})
         h.flow_id = started["flow"]["flow_id"]
         assert not store.config.sources
 
     async def complete_consent(h):
         flow = adapter.flows[h.flow_id]
-        h.credential_ref = state_store.bind_oauth_credential(flow.source_id, "openai", "codex-test.json")
+        h.credential_ref = state_store.bind_oauth_credential(flow.source_id, vendor, auth_name)
         adapter.flows[h.flow_id] = replace(flow, state="success", credential_ref=h.credential_ref)
 
     async def materialize_source(h):
@@ -2906,11 +2937,12 @@ def test_hub_oauth_model_free_observation_closed_loop(
             terminal = await service.oauth_status(h.flow_id)
             source = terminal["source"]
             assert terminal["flow"]["state"] == "success"
-            assert source["protocol"] == "openai_responses"
+            assert source["protocol"] == protocol
             assert source["supply_channel"] == "hub"
             assert source["credential_ref"] == h.credential_ref
             assert [model["id"] for model in source["models"]] == ["gpt-5.6"]
             assert service.list_sources() == [source]
+            assert bound_token not in json.dumps(terminal)
             assert (await service.oauth_status(h.flow_id))["source"] == source
             assert adapter.revoked == []
         else:
@@ -2918,8 +2950,10 @@ def test_hub_oauth_model_free_observation_closed_loop(
                 await service.oauth_status(h.flow_id)
             assert not store.config.sources
             assert adapter.revoked == [h.credential_ref]
-        assert len(api_calls) == (2 if status == 400 else 1)
+        assert len(api_calls) == (2 if status == 400 and (credential_valid or validation_before_auth) else 1)
         assert len(inventory_calls) == int(creates_source)
+        assert json.loads((state_store.auth_dir / auth_name).read_text())["access_token"] == bound_token
+        assert bound_token not in caplog.text
 
     asyncio.run(runner.run(
         ScenarioStep("start_login", start_login),

--- a/tests/scenarios/auth_setup/test_auth_setup_scenarios.py
+++ b/tests/scenarios/auth_setup/test_auth_setup_scenarios.py
@@ -7,6 +7,7 @@ import time
 import unittest
 import urllib.parse
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
@@ -2798,6 +2799,99 @@ def test_api_key_setup_does_not_schedule_a_model(monkeypatch, tmp_path, vendor, 
             await web_runner.cleanup()
 
     asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(
+    ("status", "body", "creates_source"),
+    [
+        (400, {"error": {"type": "invalid_request_error", "param": "model"}}, True),
+        (401, {"error": {"code": "invalid_api_key"}}, False),
+        (429, {"error": {"type": "rate_limit_error"}}, False),
+        (502, {"error": {"type": "upstream_error"}}, False),
+        (200, {"ok": True}, False),
+    ],
+)
+def test_hub_oauth_model_free_observation_closed_loop(monkeypatch, tmp_path, status, body, creates_source):
+    """Scenario: AUTH-SETUP-113"""
+    from tests.test_model_hub_api import _service
+    from vibe.model_hub_runtime.adapter import CLIProxyEngineAdapter
+    from vibe.model_hub_runtime.state import EngineStateStore
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    state_store = EngineStateStore(tmp_path / "engine-state")
+    api_calls = []
+    inventory_calls = []
+
+    def management_request(method, path, *, query=None, payload=None):
+        if path == "/auth-files":
+            return {"files": [{
+                "id": "codex-test", "auth_index": "auth-index-test",
+                "name": "codex-test.json", "provider": "codex",
+                "id_token": {"chatgpt_account_id": "account-test"},
+            }]}
+        if path == "/api-call":
+            assert method == "POST"
+            assert payload["auth_index"] == "auth-index-test"
+            assert payload["url"] == "https://chatgpt.com/backend-api/codex/responses"
+            assert payload["header"]["Chatgpt-Account-Id"] == "account-test"
+            assert "model" not in json.loads(payload["data"])
+            api_calls.append(payload)
+            return {"status_code": status, "body": json.dumps(body)}
+        if path == "/auth-files/models":
+            assert creates_source
+            assert query == {"name": "codex-test.json"}
+            inventory_calls.append(query)
+            return {"models": [{"id": "gpt-5.6"}]}
+        raise AssertionError((method, path))
+
+    client = Mock()
+    client.management_request.side_effect = management_request
+    supervisor = Mock()
+    supervisor.client.return_value = client
+    transport = CLIProxyEngineAdapter(supervisor=supervisor, state_store=state_store)
+    service, store, adapter = _service(tmp_path)
+    # Simulate consent and engine lifecycle, but run the actual bound-credential
+    # probe, evidence parser, discovery, and terminal Source materialization.
+    monkeypatch.setattr(adapter, "observe_source", transport.observe_source)
+    harness = SimpleNamespace()
+    runner = ScenarioRunner(harness)
+
+    async def start_login(h):
+        started = await service.oauth_start({"vendor": "openai", "channel": "hub"})
+        h.flow_id = started["flow"]["flow_id"]
+        assert not store.config.sources
+
+    async def complete_consent(h):
+        flow = adapter.flows[h.flow_id]
+        h.credential_ref = state_store.bind_oauth_credential(flow.source_id, "openai", "codex-test.json")
+        adapter.flows[h.flow_id] = replace(flow, state="success", credential_ref=h.credential_ref)
+
+    async def materialize_source(h):
+        if creates_source:
+            terminal = await service.oauth_status(h.flow_id)
+            source = terminal["source"]
+            assert terminal["flow"]["state"] == "success"
+            assert source["protocol"] == "openai_responses"
+            assert source["supply_channel"] == "hub"
+            assert source["credential_ref"] == h.credential_ref
+            assert [model["id"] for model in source["models"]] == ["gpt-5.6"]
+            assert service.list_sources() == [source]
+            assert (await service.oauth_status(h.flow_id))["source"] == source
+            assert adapter.revoked == []
+        else:
+            with pytest.raises(ModelHubError):
+                await service.oauth_status(h.flow_id)
+            assert not store.config.sources
+            assert adapter.revoked == [h.credential_ref]
+        assert len(api_calls) == 1
+        assert len(inventory_calls) == int(creates_source)
+
+    asyncio.run(runner.run(
+        ScenarioStep("start_login", start_login),
+        ScenarioStep("complete_consent", complete_consent),
+        ScenarioStep("materialize_source", materialize_source),
+    ))
+    ScenarioExpect.step_history(runner, ["start_login", "complete_consent", "materialize_source"])
 
 
 if __name__ == "__main__":

--- a/tests/scenarios/model_hub/test_model_hub_migration_scenarios.py
+++ b/tests/scenarios/model_hub/test_model_hub_migration_scenarios.py
@@ -965,6 +965,7 @@ def test_scan_skips_invalid_endpoint_without_blocking_valid_items(
     assert {item["backend"] for item in scan} == {"opencode"}
     result = asyncio.run(service.migration_apply([item["id"] for item in scan]))
     assert result["applied"] == 2
+    assert all(source.verification_pending for source in store.config.sources)
     assert {source.vendor for source in store.config.sources} == {
         "openrouter",
         "zhipuai",

--- a/tests/test_model_hub_api.py
+++ b/tests/test_model_hub_api.py
@@ -7564,7 +7564,7 @@ def test_completed_hub_oauth_persists_only_a_response_proven_protocol(tmp_path):
     assert adapter.revoked == []
 
 
-def test_completed_hub_oauth_rejects_unproven_protocol_before_persistence(tmp_path):
+def test_completed_hub_oauth_saves_fixed_protocol_as_unverified(tmp_path):
     service, store, adapter = _service(tmp_path)
     flow = asyncio.run(service.oauth_start({"vendor": "openai", "channel": "hub"}))["flow"]
     adapter.flows[flow["flow_id"]] = OAuthFlowState(
@@ -7583,14 +7583,12 @@ def test_completed_hub_oauth_rejects_unproven_protocol_before_persistence(tmp_pa
         models=(),
     )
 
-    with pytest.raises(ModelHubError) as exc_info:
-        asyncio.run(service.oauth_status(flow["flow_id"]))
-
-    assert exc_info.value.code == "discovery_failed"
-    assert exc_info.value.status == 422
-    assert store.config.sources == []
-    assert adapter.revoked == ["cred_oauth_unproven"]
-    assert service.oauth_flows.binding(flow["flow_id"]) is None
+    result = asyncio.run(service.oauth_status(flow["flow_id"]))
+    assert result["source"]["protocol"] == "openai_responses"
+    assert result["source"]["verification_pending"] is True
+    assert store.config.sources[0].credential_ref == "cred_oauth_unproven"
+    assert adapter.revoked == []
+    assert asyncio.run(service.oauth_status(flow["flow_id"]))["source"] == result["source"]
 
 
 def test_concurrent_completed_hub_oauth_flow_has_single_credential_owner(tmp_path):

--- a/tests/test_model_hub_api.py
+++ b/tests/test_model_hub_api.py
@@ -120,6 +120,11 @@ class MemoryStore:
     def save(self, config):
         self.config = config
 
+    def mutate(self, mutator):
+        config = copy.deepcopy(self.config)
+        if mutator(config):
+            self.save(config)
+
     def ensure_writable(self):
         if self.recovery:
             raise ModelHubError("config_recovery", status=409)
@@ -7564,7 +7569,8 @@ def test_completed_hub_oauth_persists_only_a_response_proven_protocol(tmp_path):
     assert adapter.revoked == []
 
 
-def test_completed_hub_oauth_saves_fixed_protocol_as_unverified(tmp_path):
+@pytest.mark.parametrize("observed", [False, True])
+def test_completed_hub_oauth_saves_fixed_protocol_as_unverified(tmp_path, observed):
     service, store, adapter = _service(tmp_path)
     flow = asyncio.run(service.oauth_start({"vendor": "openai", "channel": "hub"}))["flow"]
     adapter.flows[flow["flow_id"]] = OAuthFlowState(
@@ -7575,17 +7581,17 @@ def test_completed_hub_oauth_saves_fixed_protocol_as_unverified(tmp_path):
         }
     )
     adapter.observation = SourceObservation(
-        outcome=ObservationOutcome.AMBIGUOUS,
+        outcome=ObservationOutcome.OBSERVED if observed else ObservationOutcome.AMBIGUOUS,
         reachable=True,
         authenticated=True,
-        protocol=None,
-        discovery=ObservationDiscovery.NOT_ATTEMPTED,
+        protocol="openai_responses" if observed else None,
+        discovery=ObservationDiscovery.SUCCEEDED if observed else ObservationDiscovery.NOT_ATTEMPTED,
         models=(),
     )
 
     result = asyncio.run(service.oauth_status(flow["flow_id"]))
     assert result["source"]["protocol"] == "openai_responses"
-    assert result["source"]["verification_pending"] is True
+    assert result["source"]["verification_pending"]
     assert store.config.sources[0].credential_ref == "cred_oauth_unproven"
     assert adapter.revoked == []
     assert asyncio.run(service.oauth_status(flow["flow_id"]))["source"] == result["source"]

--- a/tests/test_model_hub_config.py
+++ b/tests/test_model_hub_config.py
@@ -1462,6 +1462,7 @@ def test_model_hub_config_round_trip_and_serializer_completeness(monkeypatch, tm
         "supply_channel": "hub",
         "credential_ref": "cred_serializer_test",
         "client_nonce": "scn_01j5w8z7p4n6q2rt",
+        "verification_pending": "vp_0123456789abcdef0123456789abcdef",
     }
     hub_payload = {
         "sources": [source_example],

--- a/tests/test_model_hub_l3.py
+++ b/tests/test_model_hub_l3.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ast
 import asyncio
+import copy
 import inspect
 import json
 import re
@@ -743,6 +744,11 @@ class MemoryStore:
 
     def requested_model(self, backend: str) -> str:
         return self.requested_models.get(backend, "")
+
+    def mutate(self, mutator):
+        config = copy.deepcopy(self.config)
+        if mutator(config):
+            self.save(config)
 
 
 class _EngineObservation:

--- a/tests/test_model_hub_l3.py
+++ b/tests/test_model_hub_l3.py
@@ -6695,6 +6695,8 @@ def test_qwen_catalog_pin_observation_accepts_wrapperless_authenticated_validati
 
         async def capture_probe(request: web.Request) -> web.Response:
             requests.append(request.path)
+            if request.headers.get("Authorization") != "Bearer test-qwen-key":
+                return web.json_response({"code": "INVALID_API_KEY"}, status=401)
             if request.path == _PROTOCOL_OBSERVATION_TAXONOMY["openai_chat"].request_path:
                 return web.json_response(
                     {
@@ -6746,7 +6748,7 @@ def test_qwen_catalog_pin_observation_accepts_wrapperless_authenticated_validati
     assert observed.model_ids == ("qwen-plus",)
     assert requests == [
         _PROTOCOL_OBSERVATION_TAXONOMY[protocol].request_path
-        for protocol in SOURCE_PROTOCOLS
+        for protocol in (*SOURCE_PROTOCOLS, "openai_chat")
     ]
     assert inventory_kwargs["vendor"] == "qwen"
     assert inventory_kwargs["protocol"] == "openai_chat"
@@ -6773,6 +6775,8 @@ def test_openrouter_catalog_pin_observation_accepts_nested_numeric_authenticated
 
         async def capture_probe(request: web.Request) -> web.Response:
             requests.append(request.path)
+            if request.headers.get("Authorization") != "Bearer test-openrouter-key":
+                return web.json_response({"code": "INVALID_API_KEY"}, status=401)
             if request.path == _PROTOCOL_OBSERVATION_TAXONOMY["openai_chat"].request_path:
                 return web.json_response(
                     {
@@ -6826,7 +6830,7 @@ def test_openrouter_catalog_pin_observation_accepts_nested_numeric_authenticated
     assert observed.model_ids == ("openrouter/auto",)
     assert requests == [
         _PROTOCOL_OBSERVATION_TAXONOMY[protocol].request_path
-        for protocol in SOURCE_PROTOCOLS
+        for protocol in (*SOURCE_PROTOCOLS, "openai_chat")
     ]
     assert inventory_kwargs["vendor"] == "openrouter"
     assert inventory_kwargs["protocol"] == "openai_chat"
@@ -6852,7 +6856,7 @@ def _catalog_owner_status_body(vendor: str, status: int) -> dict[str, object]:
         return {
             "error": {
                 "code": 400,
-                "message": "invalid API key",
+                "message": "messages is required",
             }
         }
     return {
@@ -6888,6 +6892,9 @@ def _run_catalog_pin_observation(
 
         async def capture_probe(request: web.Request) -> web.Response:
             requests.append(request.path)
+            supplied = request.headers.get("x-api-key") or request.headers.get("Authorization", "").removeprefix("Bearer ")
+            if supplied != f"test-{vendor}-{status}":
+                return web.json_response({"code": "INVALID_API_KEY"}, status=401)
             return web.json_response(body, status=status)
 
         app = web.Application()
@@ -6930,7 +6937,7 @@ def _run_catalog_pin_observation(
 
 
 @pytest.mark.parametrize(("vendor", "protocol"), CATALOG_API_KEY_VENDOR_PROTOCOL_CASES)
-def test_catalog_pin_observation_accepts_any_nonempty_json_400_response(
+def test_catalog_pin_observation_accepts_credential_sensitive_json_400_response(
     tmp_path: Path,
     vendor: str,
     protocol: str,
@@ -6947,7 +6954,7 @@ def test_catalog_pin_observation_accepts_any_nonempty_json_400_response(
     assert observed.protocol == protocol
     assert observed.authenticated is True
     assert observed.model_ids == (f"{vendor}/auto",)
-    assert requests == [_PROTOCOL_OBSERVATION_TAXONOMY[protocol].request_path]
+    assert requests == [_PROTOCOL_OBSERVATION_TAXONOMY[protocol].request_path] * 2
     assert inventory_kwargs is not None
     assert inventory_kwargs["vendor"] == vendor
     assert inventory_kwargs["protocol"] == protocol
@@ -7110,17 +7117,19 @@ def test_source_observation_catalog_pin_and_declaration_still_require_authentica
 @pytest.mark.parametrize(
     ("status", "initial_authentication", "expected_outcome", "expected_authenticated"),
     [
-        (400, _AuthenticationEvidence.REJECTED, "observed", True),
-        (401, _AuthenticationEvidence.ACCEPTED, "authentication_failed", False),
+        (400, _AuthenticationEvidence.REJECTED, "authentication_failed", False),
+        (400, _AuthenticationEvidence.UNKNOWN, "ambiguous", None),
+        (401, _AuthenticationEvidence.REJECTED, "authentication_failed", False),
+        (400, _AuthenticationEvidence.ACCEPTED, "observed", True),
     ],
-    ids=("request_error_accepts", "auth_error_rejects"),
+    ids=("explicit_rejection", "unverified_validation", "auth_error_rejects", "verified_validation"),
 )
-def test_custom_declared_observation_uses_owner_status_before_parser_verdict(
+def test_custom_declared_observation_preserves_transport_authentication_verdict(
     tmp_path: Path,
     status: int,
     initial_authentication: _AuthenticationEvidence,
     expected_outcome: str,
-    expected_authenticated: bool,
+    expected_authenticated: bool | None,
 ) -> None:
     base_url = "https://relay.example/v1"
     state_store = EngineStateStore(tmp_path / f"engine-state-custom-declared-{status}")
@@ -7204,6 +7213,8 @@ def test_oauth_observation_uses_the_bound_auth_index_and_requires_response_proof
             }
         if path == "/api-call":
             api_calls.append(payload)
+            if payload["header"]["Authorization"] != "Bearer $TOKEN$":
+                return {"status_code": 401, "body": '{"error":{"code":"invalid_api_key"}}'}
             return {
                 "status_code": 400,
                 "header": {},
@@ -7241,7 +7252,7 @@ def test_oauth_observation_uses_the_bound_auth_index_and_requires_response_proof
     assert observed.outcome.value == "observed"
     assert observed.protocol == "openai_responses"
     assert observed.model_ids == ("gpt-5.6",)
-    assert len(api_calls) == 1
+    assert len(api_calls) == 2
     assert api_calls[0]["auth_index"] == "auth-index-test"
     assert api_calls[0]["header"]["Chatgpt-Account-Id"] == "account-test"
     assert api_calls[0]["url"].endswith("/responses")
@@ -7884,7 +7895,11 @@ def test_protocol_observation_consumers_cannot_classify_from_status_codes() -> N
         node
         for node in ast.walk(tree)
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
-        and node.name != "_parse_protocol_authenticated_evidence"
+        and node.name not in {
+            "_parse_protocol_authenticated_evidence",
+            "_owner_authentication_candidate",
+            "_authenticate_protected_inventory",
+        }
     ):
         for branch in (node for node in ast.walk(function) if isinstance(node, (ast.If, ast.IfExp))):
             condition = ast.unparse(branch.test)

--- a/tests/test_model_hub_l3.py
+++ b/tests/test_model_hub_l3.py
@@ -96,8 +96,11 @@ from modules.agents.model_hub import (
 from storage.models import agent_sessions, messages, metadata
 from vibe.i18n import t as i18n_t
 from vibe.model_hub_runtime.adapter import (
+    _authenticate_protected_inventory,
     _AuthenticationEvidence,
     CLIProxyEngineAdapter,
+    _control_api_key,
+    _owner_authentication_candidate,
     _parse_protocol_authenticated_evidence,
     _probe_protocol_response,
     _PROTOCOL_OBSERVATION_TAXONOMY,
@@ -7182,6 +7185,57 @@ def test_custom_declared_observation_preserves_transport_authentication_verdict(
         inventory_probe.assert_not_awaited()
 
 
+@pytest.mark.parametrize("secret", [chr(code) * 3 for code in range(33, 127)] + ["", "\u00e9\u00e9", "\u4e2d\u6587", "sk-proj-!A!"])
+def test_api_key_control_is_distinct_for_the_complete_opaque_input_domain(secret: str) -> None:
+    control = _control_api_key(secret)
+    assert control != secret
+    assert control
+    if secret:
+        assert len(control) == len(secret)
+        changes = [(before, after) for before, after in zip(secret, control) if before != after]
+        assert len(changes) == 1
+        before, after = changes[0]
+        for first, last in (("0", "9"), ("a", "z"), ("A", "Z")):
+            if first <= before <= last:
+                assert first <= after <= last
+
+
+@pytest.mark.parametrize("protocol", SOURCE_PROTOCOLS)
+@pytest.mark.parametrize("status", [401, 403])
+@pytest.mark.parametrize("owner_scoped", [False, True])
+@pytest.mark.parametrize("is_control", [False, True])
+@pytest.mark.parametrize("body", ['{"message":"Regional policy"}', '{"error":{"code":"invalid_api_key"}}'])
+def test_authentication_status_interpretation_preserves_evidence_role(
+    protocol, status, owner_scoped, is_control, body,
+) -> None:
+    parsed = _parse_protocol_authenticated_evidence(protocol, status, body)
+    evidence = _owner_authentication_candidate(parsed, owner_scoped=owner_scoped, is_control=is_control)
+    expected = (
+        _AuthenticationEvidence.REJECTED
+        if owner_scoped or is_control or "invalid_api_key" in body
+        else _AuthenticationEvidence.UNKNOWN
+    )
+    assert evidence.authentication is expected
+
+
+@pytest.mark.parametrize("owner_scoped", [False, True])
+@pytest.mark.parametrize("status", [401, 403])
+def test_inventory_primary_status_requires_a_protocol_owner(owner_scoped, status) -> None:
+    with patch(
+        "vibe.model_hub_runtime.adapter.probe_models",
+        new=AsyncMock(side_effect=[
+            EngineClientError("Control rejected", status_code=401),
+            EngineClientError("Unknown primary response", status_code=status),
+        ]),
+    ) as inventory:
+        evidence = asyncio.run(_authenticate_protected_inventory(
+            vendor="custom", protocol="openai_responses", base_url="https://relay.example",
+            secret="test-key", control_secret="test-control", owner_scoped=owner_scoped,
+        ))
+    assert evidence is (_AuthenticationEvidence.REJECTED if owner_scoped else _AuthenticationEvidence.UNKNOWN)
+    assert [call.kwargs["secret"] for call in inventory.await_args_list] == ["test-control", "test-key"]
+
+
 @pytest.mark.parametrize("vendor", ["openai", "codex"])
 @pytest.mark.parametrize("error_param", ["input", "model", None])
 def test_oauth_observation_uses_the_bound_auth_index_and_requires_response_proof(
@@ -7264,22 +7318,27 @@ def test_oauth_observation_uses_the_bound_auth_index_and_requires_response_proof
         if path == "/auth-files":
             return management_request(method, path, query=query, payload=payload)
         if path == "/api-call":
-            return {"status_code": 200, "header": {}, "body": '{"ok":true}'}
+            return {"status_code": unknown_status, "header": {}, "body": unknown_body}
         raise AssertionError((method, path))
 
     client.management_request.side_effect = ambiguous_management_request
-    ambiguous = asyncio.run(
-        adapter.observe_source(
-            vendor,
-            None,
-            credential_ref,
-            SOURCE_PROTOCOLS,
+    for unknown_status, unknown_body in (
+        (200, '{"ok":true}'),
+        (401, "<html>Request blocked</html>"),
+        (403, '{"message":"Regional policy"}'),
+    ):
+        ambiguous = asyncio.run(
+            adapter.observe_source(
+                vendor,
+                None,
+                credential_ref,
+                SOURCE_PROTOCOLS,
+            )
         )
-    )
 
-    assert ambiguous.outcome.value == "ambiguous"
-    assert ambiguous.protocol is None
-    assert ambiguous.authenticated is None
+        assert ambiguous.outcome.value == "ambiguous"
+        assert ambiguous.protocol is None
+        assert ambiguous.authenticated is None
 
 
 def test_oauth_observation_does_not_use_api_key_catalog_pins_without_shape_proof(

--- a/tests/test_model_hub_l3.py
+++ b/tests/test_model_hub_l3.py
@@ -4,6 +4,7 @@ import ast
 import asyncio
 import inspect
 import json
+import re
 import tempfile
 import threading
 from collections import deque
@@ -16,7 +17,9 @@ from typing import cast
 from unittest.mock import AsyncMock, Mock, patch
 
 import aiohttp
+import jwt
 import pytest
+import yaml
 from aiohttp import web
 from jsonschema import Draft7Validator, FormatChecker
 from sqlalchemy import create_engine, delete, select
@@ -99,7 +102,7 @@ from vibe.model_hub_runtime.adapter import (
     _authenticate_protected_inventory,
     _AuthenticationEvidence,
     CLIProxyEngineAdapter,
-    _control_api_key,
+    _control_credential,
     _owner_authentication_candidate,
     _parse_protocol_authenticated_evidence,
     _probe_protocol_response,
@@ -7187,7 +7190,7 @@ def test_custom_declared_observation_preserves_transport_authentication_verdict(
 
 @pytest.mark.parametrize("secret", [chr(code) * 3 for code in range(33, 127)] + ["", "\u00e9\u00e9", "\u4e2d\u6587", "sk-proj-!A!"])
 def test_api_key_control_is_distinct_for_the_complete_opaque_input_domain(secret: str) -> None:
-    control = _control_api_key(secret)
+    control = _control_credential(secret)
     assert control != secret
     assert control
     if secret:
@@ -7198,6 +7201,43 @@ def test_api_key_control_is_distinct_for_the_complete_opaque_input_domain(secret
         for first, last in (("0", "9"), ("a", "z"), ("A", "Z")):
             if first <= before <= last:
                 assert first <= after <= last
+
+
+@pytest.mark.parametrize("expired", [False, True])
+@pytest.mark.parametrize("algorithm", ["HS256", "RS256"])
+def test_structured_credential_control_changes_signature_not_claims(expired: bool, algorithm: str) -> None:
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    signing_key = (
+        rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        if algorithm == "RS256" else "test-credential-control-key-with-32-bytes"
+    )
+    verification_key = signing_key.public_key() if algorithm == "RS256" else signing_key
+    claims = {"sub": "account-test", "exp": 1 if expired else 4000000000, "scope": "model.read"}
+    token = jwt.encode(claims, signing_key, algorithm=algorithm, headers={"kid": "test-key"})
+    control = _control_credential(token)
+    assert jwt.get_unverified_header(control) == jwt.get_unverified_header(token)
+    assert jwt.decode(control, options={"verify_signature": False}) == claims
+    assert len(control) == len(token)
+    assert control.rpartition(".")[0] == token.rpartition(".")[0]
+    with pytest.raises(jwt.InvalidSignatureError):
+        jwt.decode(control, verification_key, algorithms=[algorithm], options={"verify_exp": False})
+
+
+def test_auth_setup_executable_scenarios_are_registered() -> None:
+    root = Path(__file__).parent / "scenarios/auth_setup"
+    catalog = yaml.safe_load((root / "catalog.yaml").read_text())
+    registered = {entry["id"]: entry for entry in catalog["scenarios"]}
+    tree = ast.parse((root / "test_auth_setup_scenarios.py").read_text())
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        doc = ast.get_docstring(node) or ""
+        match = re.match(r"Scenario:\s+(AUTH-SETUP-\d+)\b", doc)
+        if match:
+            scenario_id = match.group(1)
+            assert scenario_id in registered, (scenario_id, node.name)
+            assert registered[scenario_id]["test"].endswith("::" + node.name)
 
 
 @pytest.mark.parametrize("protocol", SOURCE_PROTOCOLS)
@@ -7249,6 +7289,7 @@ def test_oauth_observation_uses_the_bound_auth_index_and_requires_response_proof
         vendor,
         "codex-test.json",
     )
+    state_store._secure_write_json(state_store.auth_dir / "codex-test.json", {"access_token": "test-oauth-token"})
     client = Mock()
     api_calls: list[dict] = []
 
@@ -7267,7 +7308,7 @@ def test_oauth_observation_uses_the_bound_auth_index_and_requires_response_proof
             }
         if path == "/api-call":
             api_calls.append(payload)
-            if payload["header"]["Authorization"] != "Bearer $TOKEN$":
+            if payload["header"]["Authorization"] != "Bearer test-oauth-token":
                 return {"status_code": 401, "body": '{"error":{"code":"invalid_api_key"}}'}
             return {
                 "status_code": 400,

--- a/tests/test_model_hub_l3.py
+++ b/tests/test_model_hub_l3.py
@@ -99,11 +99,8 @@ from modules.agents.model_hub import (
 from storage.models import agent_sessions, messages, metadata
 from vibe.i18n import t as i18n_t
 from vibe.model_hub_runtime.adapter import (
-    _authenticate_protected_inventory,
     _AuthenticationEvidence,
     CLIProxyEngineAdapter,
-    _control_credential,
-    _owner_authentication_candidate,
     _parse_protocol_authenticated_evidence,
     _probe_protocol_response,
     _PROTOCOL_OBSERVATION_TAXONOMY,
@@ -6681,7 +6678,7 @@ def test_source_observation_accepts_catalog_pin_and_custom_declaration_without_s
     assert inventory_probe.await_args.kwargs["protocol"] == "openai_chat"
 
 
-def test_qwen_catalog_pin_observation_accepts_wrapperless_authenticated_validation_response(
+def test_qwen_catalog_pin_validation_remains_unverified(
     tmp_path: Path,
 ) -> None:
     state_store = EngineStateStore(tmp_path / "engine-state")
@@ -6740,28 +6737,26 @@ def test_qwen_catalog_pin_observation_accepts_wrapperless_authenticated_validati
                     credential_ref,
                     SOURCE_PROTOCOLS,
                 )
-                assert inventory_probe.await_args is not None
-                inventory_kwargs = dict(inventory_probe.await_args.kwargs)
+                inventory_probe.assert_not_awaited()
+                inventory_kwargs = {}
         finally:
             await runner.cleanup()
         return requests, observed, inventory_kwargs
 
     requests, observed, inventory_kwargs = asyncio.run(scenario())
 
-    assert observed.outcome.value == "observed"
-    assert observed.protocol == "openai_chat"
-    assert observed.authenticated is True
-    assert observed.model_ids == ("qwen-plus",)
+    assert observed.outcome.value == "ambiguous"
+    assert observed.protocol is None
+    assert observed.authenticated is None
+    assert observed.model_ids == ()
     assert requests == [
         _PROTOCOL_OBSERVATION_TAXONOMY[protocol].request_path
-        for protocol in (*SOURCE_PROTOCOLS, "openai_chat")
+        for protocol in SOURCE_PROTOCOLS
     ]
-    assert inventory_kwargs["vendor"] == "qwen"
-    assert inventory_kwargs["protocol"] == "openai_chat"
-    assert inventory_kwargs["base_url"] is None
+    assert inventory_kwargs == {}
 
 
-def test_openrouter_catalog_pin_observation_accepts_nested_numeric_authenticated_validation_response(
+def test_openrouter_catalog_pin_numeric_validation_remains_unverified(
     tmp_path: Path,
 ) -> None:
     state_store = EngineStateStore(tmp_path / "engine-state")
@@ -6822,25 +6817,23 @@ def test_openrouter_catalog_pin_observation_accepts_nested_numeric_authenticated
                     credential_ref,
                     SOURCE_PROTOCOLS,
                 )
-                assert inventory_probe.await_args is not None
-                inventory_kwargs = dict(inventory_probe.await_args.kwargs)
+                inventory_probe.assert_not_awaited()
+                inventory_kwargs = {}
         finally:
             await runner.cleanup()
         return requests, observed, inventory_kwargs
 
     requests, observed, inventory_kwargs = asyncio.run(scenario())
 
-    assert observed.outcome.value == "observed"
-    assert observed.protocol == "openai_chat"
-    assert observed.authenticated is True
-    assert observed.model_ids == ("openrouter/auto",)
+    assert observed.outcome.value == "ambiguous"
+    assert observed.protocol is None
+    assert observed.authenticated is None
+    assert observed.model_ids == ()
     assert requests == [
         _PROTOCOL_OBSERVATION_TAXONOMY[protocol].request_path
-        for protocol in (*SOURCE_PROTOCOLS, "openai_chat")
+        for protocol in SOURCE_PROTOCOLS
     ]
-    assert inventory_kwargs["vendor"] == "openrouter"
-    assert inventory_kwargs["protocol"] == "openai_chat"
-    assert inventory_kwargs["base_url"] is None
+    assert inventory_kwargs == {}
 
 
 def _catalog_owner_status_body(vendor: str, status: int) -> dict[str, object]:
@@ -6943,7 +6936,7 @@ def _run_catalog_pin_observation(
 
 
 @pytest.mark.parametrize(("vendor", "protocol"), CATALOG_API_KEY_VENDOR_PROTOCOL_CASES)
-def test_catalog_pin_observation_accepts_credential_sensitive_json_400_response(
+def test_catalog_pin_json_400_does_not_prove_authentication(
     tmp_path: Path,
     vendor: str,
     protocol: str,
@@ -6956,19 +6949,16 @@ def test_catalog_pin_observation_accepts_credential_sensitive_json_400_response(
         body=_catalog_owner_status_body(vendor, 400),
     )
 
-    assert observed.outcome.value == "observed"
-    assert observed.protocol == protocol
-    assert observed.authenticated is True
-    assert observed.model_ids == (f"{vendor}/auto",)
-    assert requests == [_PROTOCOL_OBSERVATION_TAXONOMY[protocol].request_path] * 2
-    assert inventory_kwargs is not None
-    assert inventory_kwargs["vendor"] == vendor
-    assert inventory_kwargs["protocol"] == protocol
-    assert inventory_kwargs["base_url"] is None
+    assert observed.outcome.value == "ambiguous"
+    assert observed.protocol is None
+    assert observed.authenticated is None
+    assert observed.model_ids == ()
+    assert requests == [_PROTOCOL_OBSERVATION_TAXONOMY[protocol].request_path]
+    assert inventory_kwargs is None
 
 
 @pytest.mark.parametrize(("vendor", "protocol"), CATALOG_API_KEY_VENDOR_PROTOCOL_CASES)
-def test_catalog_pin_observation_rejects_any_json_401_response(
+def test_catalog_pin_unknown_json_401_is_not_credential_rejection(
     tmp_path: Path,
     vendor: str,
     protocol: str,
@@ -6981,9 +6971,9 @@ def test_catalog_pin_observation_rejects_any_json_401_response(
         body=_catalog_owner_status_body(vendor, 401),
     )
 
-    assert observed.outcome.value == "authentication_failed"
+    assert observed.outcome.value == "ambiguous"
     assert observed.protocol is None
-    assert observed.authenticated is False
+    assert observed.authenticated is None
     assert observed.model_ids == ()
     assert requests == [_PROTOCOL_OBSERVATION_TAXONOMY[protocol].request_path]
     assert inventory_kwargs is None
@@ -7188,42 +7178,6 @@ def test_custom_declared_observation_preserves_transport_authentication_verdict(
         inventory_probe.assert_not_awaited()
 
 
-@pytest.mark.parametrize("secret", [chr(code) * 3 for code in range(33, 127)] + ["", "\u00e9\u00e9", "\u4e2d\u6587", "sk-proj-!A!"])
-def test_api_key_control_is_distinct_for_the_complete_opaque_input_domain(secret: str) -> None:
-    control = _control_credential(secret)
-    assert control != secret
-    assert control
-    if secret:
-        assert len(control) == len(secret)
-        changes = [(before, after) for before, after in zip(secret, control) if before != after]
-        assert len(changes) == 1
-        before, after = changes[0]
-        for first, last in (("0", "9"), ("a", "z"), ("A", "Z")):
-            if first <= before <= last:
-                assert first <= after <= last
-
-
-@pytest.mark.parametrize("expired", [False, True])
-@pytest.mark.parametrize("algorithm", ["HS256", "RS256"])
-def test_structured_credential_control_changes_signature_not_claims(expired: bool, algorithm: str) -> None:
-    from cryptography.hazmat.primitives.asymmetric import rsa
-
-    signing_key = (
-        rsa.generate_private_key(public_exponent=65537, key_size=2048)
-        if algorithm == "RS256" else "test-credential-control-key-with-32-bytes"
-    )
-    verification_key = signing_key.public_key() if algorithm == "RS256" else signing_key
-    claims = {"sub": "account-test", "exp": 1 if expired else 4000000000, "scope": "model.read"}
-    token = jwt.encode(claims, signing_key, algorithm=algorithm, headers={"kid": "test-key"})
-    control = _control_credential(token)
-    assert jwt.get_unverified_header(control) == jwt.get_unverified_header(token)
-    assert jwt.decode(control, options={"verify_signature": False}) == claims
-    assert len(control) == len(token)
-    assert control.rpartition(".")[0] == token.rpartition(".")[0]
-    with pytest.raises(jwt.InvalidSignatureError):
-        jwt.decode(control, verification_key, algorithms=[algorithm], options={"verify_exp": False})
-
-
 def test_auth_setup_executable_scenarios_are_registered() -> None:
     root = Path(__file__).parent / "scenarios/auth_setup"
     catalog = yaml.safe_load((root / "catalog.yaml").read_text())
@@ -7242,38 +7196,17 @@ def test_auth_setup_executable_scenarios_are_registered() -> None:
 
 @pytest.mark.parametrize("protocol", SOURCE_PROTOCOLS)
 @pytest.mark.parametrize("status", [401, 403])
-@pytest.mark.parametrize("owner_scoped", [False, True])
-@pytest.mark.parametrize("is_control", [False, True])
 @pytest.mark.parametrize("body", ['{"message":"Regional policy"}', '{"error":{"code":"invalid_api_key"}}'])
 def test_authentication_status_interpretation_preserves_evidence_role(
-    protocol, status, owner_scoped, is_control, body,
+    protocol, status, body,
 ) -> None:
-    parsed = _parse_protocol_authenticated_evidence(protocol, status, body)
-    evidence = _owner_authentication_candidate(parsed, owner_scoped=owner_scoped, is_control=is_control)
+    evidence = _parse_protocol_authenticated_evidence(protocol, status, body)
     expected = (
         _AuthenticationEvidence.REJECTED
-        if owner_scoped or is_control or "invalid_api_key" in body
+        if "invalid_api_key" in body
         else _AuthenticationEvidence.UNKNOWN
     )
     assert evidence.authentication is expected
-
-
-@pytest.mark.parametrize("owner_scoped", [False, True])
-@pytest.mark.parametrize("status", [401, 403])
-def test_inventory_primary_status_requires_a_protocol_owner(owner_scoped, status) -> None:
-    with patch(
-        "vibe.model_hub_runtime.adapter.probe_models",
-        new=AsyncMock(side_effect=[
-            EngineClientError("Control rejected", status_code=401),
-            EngineClientError("Unknown primary response", status_code=status),
-        ]),
-    ) as inventory:
-        evidence = asyncio.run(_authenticate_protected_inventory(
-            vendor="custom", protocol="openai_responses", base_url="https://relay.example",
-            secret="test-key", control_secret="test-control", owner_scoped=owner_scoped,
-        ))
-    assert evidence is (_AuthenticationEvidence.REJECTED if owner_scoped else _AuthenticationEvidence.UNKNOWN)
-    assert [call.kwargs["secret"] for call in inventory.await_args_list] == ["test-control", "test-key"]
 
 
 @pytest.mark.parametrize("vendor", ["openai", "codex"])
@@ -7289,7 +7222,6 @@ def test_oauth_observation_uses_the_bound_auth_index_and_requires_response_proof
         vendor,
         "codex-test.json",
     )
-    state_store._secure_write_json(state_store.auth_dir / "codex-test.json", {"access_token": "test-oauth-token"})
     client = Mock()
     api_calls: list[dict] = []
 
@@ -7308,8 +7240,7 @@ def test_oauth_observation_uses_the_bound_auth_index_and_requires_response_proof
             }
         if path == "/api-call":
             api_calls.append(payload)
-            if payload["header"]["Authorization"] != "Bearer test-oauth-token":
-                return {"status_code": 401, "body": '{"error":{"code":"invalid_api_key"}}'}
+            assert payload["header"]["Authorization"] == "Bearer $TOKEN$"
             return {
                 "status_code": 400,
                 "header": {},
@@ -7344,10 +7275,11 @@ def test_oauth_observation_uses_the_bound_auth_index_and_requires_response_proof
         )
     )
 
-    assert observed.outcome.value == "observed"
-    assert observed.protocol == "openai_responses"
-    assert observed.model_ids == ("gpt-5.6",)
-    assert len(api_calls) == 2
+    assert observed.outcome.value == ("adapter_error" if error_param == "input" else "ambiguous")
+    assert observed.authenticated is None
+    assert observed.protocol is None
+    assert observed.model_ids == ()
+    assert len(api_calls) == 1
     assert api_calls[0]["auth_index"] == "auth-index-test"
     assert api_calls[0]["header"]["Chatgpt-Account-Id"] == "account-test"
     assert api_calls[0]["url"].endswith("/responses")
@@ -7525,7 +7457,7 @@ def test_protocol_evidence_parser_requires_candidate_specific_response_shapes(
         json.dumps(request_error_body),
     ) == _ProtocolEvidence(
         protocol=_ProtocolProof.PROVEN,
-        authentication=_AuthenticationEvidence.ACCEPTED,
+        authentication=_AuthenticationEvidence.UNKNOWN,
     )
     assert _parse_protocol_authenticated_evidence(
         protocol,
@@ -7554,7 +7486,7 @@ def test_protocol_evidence_parser_requires_candidate_specific_response_shapes(
             ANTHROPIC_RELAY_REQUEST_ERROR_PAYLOAD,
             _ProtocolEvidence(
                 protocol=_ProtocolProof.UNPROVEN,
-                authentication=_AuthenticationEvidence.ACCEPTED,
+                authentication=_AuthenticationEvidence.UNKNOWN,
                 shape=_ProtocolObservationShape.GENERIC_REQUEST_ERROR,
             ),
         ),
@@ -7663,7 +7595,7 @@ def test_protocol_evidence_table_defaults_shaped_non_auth_rows_to_unknown(
         ),
     ],
 )
-def test_anthropic_protocol_evidence_table_accepts_authenticated_model_errors(
+def test_anthropic_protocol_model_errors_leave_authentication_unknown(
     protocol: str,
     status: int,
     body: dict,
@@ -7674,7 +7606,7 @@ def test_anthropic_protocol_evidence_table_accepts_authenticated_model_errors(
         json.dumps(body),
     ) == _ProtocolEvidence(
         protocol=_ProtocolProof.PROVEN,
-        authentication=_AuthenticationEvidence.ACCEPTED,
+        authentication=_AuthenticationEvidence.UNKNOWN,
     )
 
 
@@ -7713,7 +7645,7 @@ def test_anthropic_protocol_evidence_table_accepts_authenticated_model_errors(
         ),
     ],
 )
-def test_openai_model_errors_without_family_param_record_accepted_but_unproven_evidence(
+def test_openai_model_errors_without_family_param_leave_authentication_unknown(
     protocol: str,
     status: int,
     body: dict,
@@ -7724,13 +7656,13 @@ def test_openai_model_errors_without_family_param_record_accepted_but_unproven_e
         json.dumps(body),
     ) == _ProtocolEvidence(
         protocol=_ProtocolProof.UNPROVEN,
-        authentication=_AuthenticationEvidence.ACCEPTED,
+        authentication=_AuthenticationEvidence.UNKNOWN,
         shape=_ProtocolObservationShape.GENERIC_REQUEST_ERROR,
     )
 
 
 @pytest.mark.parametrize("protocol", ("openai_responses", "openai_chat"))
-def test_openai_request_error_without_family_param_records_accepted_but_unproven_evidence(
+def test_openai_request_error_without_family_param_leaves_authentication_unknown(
     protocol: str,
 ) -> None:
     assert _parse_protocol_authenticated_evidence(
@@ -7746,12 +7678,12 @@ def test_openai_request_error_without_family_param_records_accepted_but_unproven
         ),
     ) == _ProtocolEvidence(
         protocol=_ProtocolProof.UNPROVEN,
-        authentication=_AuthenticationEvidence.ACCEPTED,
+        authentication=_AuthenticationEvidence.UNKNOWN,
         shape=_ProtocolObservationShape.GENERIC_REQUEST_ERROR,
     )
 
 
-def test_qwen_wrapperless_invalid_parameter_request_error_counts_as_authenticated_openai_chat() -> None:
+def test_qwen_wrapperless_validation_leaves_authentication_unknown() -> None:
     assert _parse_protocol_authenticated_evidence(
         "openai_chat",
         400,
@@ -7763,7 +7695,7 @@ def test_qwen_wrapperless_invalid_parameter_request_error_counts_as_authenticate
         ),
     ) == _ProtocolEvidence(
         protocol=_ProtocolProof.UNPROVEN,
-        authentication=_AuthenticationEvidence.ACCEPTED,
+        authentication=_AuthenticationEvidence.UNKNOWN,
         shape=_ProtocolObservationShape.GENERIC_REQUEST_ERROR,
     )
 
@@ -7997,8 +7929,6 @@ def test_protocol_observation_consumers_cannot_classify_from_status_codes() -> N
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
         and node.name not in {
             "_parse_protocol_authenticated_evidence",
-            "_owner_authentication_candidate",
-            "_authenticate_protected_inventory",
         }
     ):
         for branch in (node for node in ast.walk(function) if isinstance(node, (ast.If, ast.IfExp))):

--- a/tests/test_model_hub_l3.py
+++ b/tests/test_model_hub_l3.py
@@ -7173,13 +7173,17 @@ def test_custom_declared_observation_uses_owner_status_before_parser_verdict(
         inventory_probe.assert_not_awaited()
 
 
+@pytest.mark.parametrize("vendor", ["openai", "codex"])
+@pytest.mark.parametrize("error_param", ["input", "model", None])
 def test_oauth_observation_uses_the_bound_auth_index_and_requires_response_proof(
     tmp_path: Path,
+    vendor: str,
+    error_param: str | None,
 ) -> None:
     state_store = EngineStateStore(tmp_path / "engine-state")
     credential_ref = state_store.bind_oauth_credential(
         "src_oauthproof",
-        "openai",
+        vendor,
         "codex-test.json",
     )
     client = Mock()
@@ -7207,7 +7211,7 @@ def test_oauth_observation_uses_the_bound_auth_index_and_requires_response_proof
                     {
                         "error": {
                             "type": "invalid_request_error",
-                            "param": "input",
+                            "param": error_param,
                         }
                     }
                 ),
@@ -7227,7 +7231,7 @@ def test_oauth_observation_uses_the_bound_auth_index_and_requires_response_proof
 
     observed = asyncio.run(
         adapter.observe_source(
-            "openai",
+            vendor,
             None,
             credential_ref,
             SOURCE_PROTOCOLS,
@@ -7255,7 +7259,7 @@ def test_oauth_observation_uses_the_bound_auth_index_and_requires_response_proof
     client.management_request.side_effect = ambiguous_management_request
     ambiguous = asyncio.run(
         adapter.observe_source(
-            "openai",
+            vendor,
             None,
             credential_ref,
             SOURCE_PROTOCOLS,

--- a/tests/test_model_hub_l3.py
+++ b/tests/test_model_hub_l3.py
@@ -7837,12 +7837,10 @@ def test_protocol_observation_consumers_cannot_classify_from_status_codes() -> N
     assert _PROTOCOL_OBSERVATION_TAXONOMY["openai_responses"].request_path != _PROTOCOL_OBSERVATION_TAXONOMY[
         "openai_chat"
     ].request_path
-    assert _PROTOCOL_OBSERVATION_TAXONOMY["openai_responses"].request_body == {
-        "model": "__avibe_model_hub_probe__"
-    }
-    assert _PROTOCOL_OBSERVATION_TAXONOMY["openai_chat"].request_body == {
-        "model": "__avibe_model_hub_probe__"
-    }
+    assert all(
+        "model" not in taxonomy.request_body
+        for taxonomy in _PROTOCOL_OBSERVATION_TAXONOMY.values()
+    )
     consumers = {
         node.name: node
         for node in ast.walk(tree)

--- a/tests/test_model_hub_resolution.py
+++ b/tests/test_model_hub_resolution.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import hashlib
 import json
 from collections import deque
@@ -90,6 +91,11 @@ class MemoryStore:
 
     def requested_model(self, backend: str) -> str:
         return self.requested_models.get(backend, "")
+
+    def mutate(self, mutator):
+        config = copy.deepcopy(self.config)
+        if mutator(config):
+            self.save(config)
 
 
 def test_source_settlement_authority_never_downgrades_a_decided_error() -> None:
@@ -1995,7 +2001,7 @@ def test_credential_cleanup_settlement_has_one_durable_boundary():
     assert raw_cleanup_callers == {"_require_credential_cleanup"}
 
 
-def test_every_persisting_source_path_requires_response_backed_protocol_evidence():
+def test_source_admission_uses_explicit_owners_and_keeps_verified_paths_proven():
     from ast import AsyncFunctionDef, Attribute, Call, Name, parse, walk
     from pathlib import Path
 
@@ -2051,9 +2057,11 @@ def test_every_persisting_source_path_requires_response_backed_protocol_evidence
     assert "_require_proven_source_payload" in calls(
         migration_functions["apply_native_migration"]
     )
-    assert "_require_proven_observation" in calls(
-        service_functions["_create_oauth_source"]
-    )
+    oauth_calls = calls(service_functions["_create_oauth_source"])
+    assert "_observe_provisioned_credential" in oauth_calls
+    assert "_mark_source_unverified" in oauth_calls
+    assert "_mark_source_unverified" in calls(service_functions["create_source"])
+    assert "_mark_source_unverified" in calls(migration_functions["apply_native_migration"])
 
 
 def test_manual_model_delete_ignores_preexisting_unrelated_gap(tmp_path):

--- a/tests/test_model_hub_runtime.py
+++ b/tests/test_model_hub_runtime.py
@@ -1780,6 +1780,33 @@ def test_state_rejects_unsafe_inputs_and_auth_permissions(tmp_path: Path) -> Non
     assert stat.S_IMODE(auth_file.stat().st_mode) == 0o600
 
 
+@pytest.mark.parametrize("invalid_state", [None, "missing", "no_token", "invalid_json", "permissions", "symlink", "path_escape"])
+def test_oauth_probe_reads_only_private_bound_material(tmp_path: Path, invalid_state) -> None:
+    store = EngineStateStore(tmp_path / "state")
+    name = "../outside.json" if invalid_state == "path_escape" else "oauth-test.json"
+    credential_ref = store.bind_oauth_credential("src_oauthprobe", "openai", name)
+    path = store.auth_dir / "oauth-test.json"
+    token = "test-private-oauth-token"
+    if invalid_state == "symlink":
+        outside = tmp_path / "outside.json"
+        outside.write_text(json.dumps({"access_token": token}))
+        store.auth_dir.mkdir(mode=0o700)
+        path.symlink_to(outside)
+    elif invalid_state != "missing":
+        store._secure_write_json(path, {} if invalid_state == "no_token" else {"access_token": token})
+        if invalid_state == "invalid_json":
+            path.write_text("not-json")
+        if invalid_state == "permissions":
+            path.chmod(0o644)
+    before = path.read_bytes() if path.exists() else None
+    if invalid_state is None:
+        assert store.read_oauth_access_token(credential_ref) == token
+    else:
+        with pytest.raises(EngineStateError):
+            store.read_oauth_access_token(credential_ref)
+    assert (path.read_bytes() if path.exists() else None) == before
+
+
 def test_source_record_requires_valid_reasoning_state() -> None:
     payload = {
         "source_id": "src_fixture123",

--- a/tests/test_model_hub_runtime.py
+++ b/tests/test_model_hub_runtime.py
@@ -1780,33 +1780,6 @@ def test_state_rejects_unsafe_inputs_and_auth_permissions(tmp_path: Path) -> Non
     assert stat.S_IMODE(auth_file.stat().st_mode) == 0o600
 
 
-@pytest.mark.parametrize("invalid_state", [None, "missing", "no_token", "invalid_json", "permissions", "symlink", "path_escape"])
-def test_oauth_probe_reads_only_private_bound_material(tmp_path: Path, invalid_state) -> None:
-    store = EngineStateStore(tmp_path / "state")
-    name = "../outside.json" if invalid_state == "path_escape" else "oauth-test.json"
-    credential_ref = store.bind_oauth_credential("src_oauthprobe", "openai", name)
-    path = store.auth_dir / "oauth-test.json"
-    token = "test-private-oauth-token"
-    if invalid_state == "symlink":
-        outside = tmp_path / "outside.json"
-        outside.write_text(json.dumps({"access_token": token}))
-        store.auth_dir.mkdir(mode=0o700)
-        path.symlink_to(outside)
-    elif invalid_state != "missing":
-        store._secure_write_json(path, {} if invalid_state == "no_token" else {"access_token": token})
-        if invalid_state == "invalid_json":
-            path.write_text("not-json")
-        if invalid_state == "permissions":
-            path.chmod(0o644)
-    before = path.read_bytes() if path.exists() else None
-    if invalid_state is None:
-        assert store.read_oauth_access_token(credential_ref) == token
-    else:
-        with pytest.raises(EngineStateError):
-            store.read_oauth_access_token(credential_ref)
-    assert (path.read_bytes() if path.exists() else None) == before
-
-
 def test_source_record_requires_valid_reasoning_state() -> None:
     payload = {
         "source_id": "src_fixture123",

--- a/tests/test_model_hub_unverified.py
+++ b/tests/test_model_hub_unverified.py
@@ -1,14 +1,18 @@
 """Unverified configuration is persistable, never authentication evidence."""
 
 import asyncio
+import copy
+import multiprocessing
+import os
+from pathlib import Path
 from dataclasses import replace
 from unittest.mock import AsyncMock
 
 import pytest
 
-from config.v2_config import ModelHubSourceConfig
+from config.v2_config import ModelHubSourceConfig, V2Config, config_write_transaction
 from core.handlers.model_hub.adapter import RawCallOutcome, RawOutcomeKind, SOURCE_PROTOCOLS
-from core.handlers.model_hub.service import ModelHubError
+from core.handlers.model_hub.service import ModelHubError, V2ModelHubConfigStore
 from tests.test_model_hub_api import _assert_valid, _service
 from vibe.model_hub_runtime.api_key_vendors import api_key_vendor_catalog
 
@@ -40,7 +44,7 @@ def test_unverified_save_uses_declared_owner_without_upstream_work(tmp_path, own
         draft.pop("protocol")
     created = asyncio.run(service.create_source(draft))["source"]
     _assert_valid("source.schema.json", created)
-    assert created["verification_pending"] is True
+    assert created["verification_pending"]
     assert created["models"] == []
     assert created["state"]["status"] == "standby"
     assert created["client_nonce"] == draft["client_nonce"]
@@ -78,7 +82,7 @@ def test_unverified_create_rolls_back_custody_and_releases_nonce(tmp_path):
     assert adapter.revoked == ["cred_test001"]
     adapter.fail_sync = False
     created = asyncio.run(service.create_source(_draft()))["source"]
-    assert created["verification_pending"] is True
+    assert created["verification_pending"]
     assert len(store.config.sources) == 1
 
 
@@ -87,7 +91,7 @@ def test_inventory_never_clears_pending_verification(tmp_path):
     source = asyncio.run(service.create_source(_draft()))["source"]
     refreshed = asyncio.run(service.refresh_source(source["id"]))["source"]
     assert refreshed["models"]
-    assert refreshed["verification_pending"] is True
+    assert refreshed["verification_pending"] == source["verification_pending"]
     assert ModelHubSourceConfig.from_payload(store.config.sources[0].to_payload()).verification_pending
 
 
@@ -96,7 +100,6 @@ def test_verification_bookkeeping_io_failure_preserves_success_and_pending_state
 
     async def scenario():
         source = (await service.create_source(_draft()))["source"]
-        generation = service._reserve_settlement_generation(source["id"])
         outcome = RawCallOutcome(
             kind=RawOutcomeKind.SUCCESS, http_status=200, error_code=None,
             redacted_message=None, stream_started=False, model_id="test-model", source_id=source["id"],
@@ -104,8 +107,8 @@ def test_verification_bookkeeping_io_failure_preserves_success_and_pending_state
         def fail_save(_config):
             raise OSError("Disk unavailable")
         monkeypatch.setattr(store, "save", fail_save)
-        await service._verify_successful_source(source["id"], source["credential_ref"], generation, outcome)
-        assert store.config.sources[0].verification_pending is True
+        await service._verify_successful_source(source["id"], source["credential_ref"], source["verification_pending"], outcome)
+        assert store.config.sources[0].verification_pending == source["verification_pending"]
 
     asyncio.run(scenario())
 
@@ -122,7 +125,7 @@ def test_only_current_successful_invocation_retires_verification(tmp_path, kind,
             error_code=None, redacted_message=None, stream_started=False,
             source_id=source["id"], model_id="test-model",
         )
-        generation = service._reserve_settlement_generation(source["id"])
+        service._reserve_settlement_generation(source["id"])
         if current == "replaced":
             store.config.sources[0].credential_ref = "cred_replacement"
         elif current == "same_handle_reauth":
@@ -131,9 +134,10 @@ def test_only_current_successful_invocation_retires_verification(tmp_path, kind,
             service._reserve_settlement_generation(source["id"])
         elif current == "deleted":
             store.config.sources.clear()
-        await service._verify_successful_source(source["id"], source["credential_ref"], generation, outcome)
+        await service._verify_successful_source(source["id"], source["credential_ref"], source["verification_pending"], outcome)
         if current != "deleted":
-            assert store.config.sources[0].verification_pending is not (current == "same" and kind is RawOutcomeKind.SUCCESS)
+            verified = current in {"same", "newer_attempt"} and kind is RawOutcomeKind.SUCCESS
+            assert (store.config.sources[0].verification_pending is None) == verified
 
     asyncio.run(scenario())
 
@@ -153,13 +157,87 @@ def test_model_call_consumers_retire_pending_verification(tmp_path, path):
             if path == "stream":
                 # Exercise the downstream-consumed settlement independently of
                 # the resolver's buffered-success path, with the same identity.
-                store.config.sources[0].verification_pending = True
+                store.config.sources[0].verification_pending = resolved.verification_pending
                 handle = await adapter.invoke(source["id"], "claude-opus-4-6", {}, False, "claude")
                 outcome = replace(await handle.outcome(), stream_started=True)
                 await service.settle_handle_outcome(
                     resolved, outcome, termination_origin="upstream_terminal", record_attempt=lambda *_args: None,
                 )
-        assert store.config.sources[0].verification_pending is False
+        assert store.config.sources[0].verification_pending is None
         assert "verification_pending" not in service.list_sources()[0]
 
     asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("unverified", [False, True])
+def test_new_api_key_credentials_always_start_pending(tmp_path, unverified):
+    service, _store, _adapter = _service(tmp_path)
+    created = asyncio.run(service.create_source(_draft(save_unverified=unverified)))["source"]
+    _assert_valid("source.schema.json", created)
+    assert created["verification_pending"]
+
+
+def _settle_in_controller(config_home, captured, attempted, done):
+    os.environ["AVIBE_HOME"] = config_home
+
+    class SignallingStore(V2ModelHubConfigStore):
+        def mutate(self, mutator):
+            attempted.set()
+            super().mutate(mutator)
+
+    service, _store, _adapter = _service(Path(config_home) / "controller")
+    service.store = SignallingStore()
+    outcome = RawCallOutcome(
+        kind=RawOutcomeKind.SUCCESS, http_status=200, error_code=None,
+        redacted_message=None, stream_started=False, model_id="test-model", source_id=captured["id"],
+    )
+    asyncio.run(service._verify_successful_source(
+        captured["id"], captured["credential_ref"], captured["verification_pending"], outcome,
+    ))
+    done.set()
+
+
+@pytest.mark.parametrize("replacement", ["none", "same_handle", "new_handle"])
+def test_controller_verification_preserves_fresh_web_config_and_credential_identity(tmp_path, monkeypatch, replacement):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    service, store, _adapter = _service(tmp_path)
+    captured = asyncio.run(service.create_source(_draft()))["source"]
+    config = V2Config.default()
+    config.model_hub = store.load()
+    config.save()
+    ctx = multiprocessing.get_context("spawn")
+    attempted, done = ctx.Event(), ctx.Event()
+    controller = ctx.Process(target=_settle_in_controller, args=(str(tmp_path), captured, attempted, done))
+    try:
+        with config_write_transaction() as fresh:
+            controller.start()
+            assert attempted.wait(timeout=15), "controller never reached the verification transaction"
+            assert not done.wait(timeout=1), "controller bypassed Web's cross-process lock"
+            current = fresh.model_hub.sources[0]
+            current.display_name = "Edited in Web"
+            if replacement != "none":
+                service._mark_source_unverified(current)
+                if replacement == "new_handle":
+                    current.credential_ref = "cred_web_replacement"
+            pending = current.verification_pending
+            peer = copy.deepcopy(current)
+            peer.id = "src_webadded01"
+            peer.client_nonce = None
+            peer.credential_ref = "cred_web_added"
+            fresh.model_hub.sources.append(peer)
+            fresh.model_hub.agents["codex"].sources.order = [peer.id, current.id]
+            fresh.language = "zh"
+        controller.join(timeout=15)
+        assert controller.exitcode == 0
+        assert done.is_set()
+    finally:
+        if controller.is_alive():
+            controller.terminate()
+            controller.join(timeout=5)
+    updated = V2Config.load()
+    current = updated.model_hub.sources[0]
+    assert current.verification_pending == (None if replacement == "none" else pending)
+    assert current.display_name == "Edited in Web"
+    assert updated.model_hub.sources[1].to_payload() == peer.to_payload()
+    assert updated.model_hub.agents["codex"].sources.order == [peer.id, current.id]
+    assert updated.language == "zh"

--- a/tests/test_model_hub_unverified.py
+++ b/tests/test_model_hub_unverified.py
@@ -1,0 +1,165 @@
+"""Unverified configuration is persistable, never authentication evidence."""
+
+import asyncio
+from dataclasses import replace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from config.v2_config import ModelHubSourceConfig
+from core.handlers.model_hub.adapter import RawCallOutcome, RawOutcomeKind, SOURCE_PROTOCOLS
+from core.handlers.model_hub.service import ModelHubError
+from tests.test_model_hub_api import _assert_valid, _service
+from vibe.model_hub_runtime.api_key_vendors import api_key_vendor_catalog
+
+
+def _draft(**changes):
+    return {
+        "kind": "api_key",
+        "vendor": "custom",
+        "protocol": "openai_chat",
+        "base_url": "https://relay.example/v1",
+        "key": "unverified-test-key",
+        "client_nonce": "scn_unverified00000001",
+        "save_unverified": True,
+        **changes,
+    }
+
+
+@pytest.mark.parametrize(
+    "owner",
+    [{"vendor": entry.id} for entry in api_key_vendor_catalog()]
+    + [{"vendor": "custom", "protocol": protocol} for protocol in SOURCE_PROTOCOLS],
+)
+def test_unverified_save_uses_declared_owner_without_upstream_work(tmp_path, owner):
+    service, store, adapter = _service(tmp_path)
+    adapter.observe_source = AsyncMock(side_effect=AssertionError("unexpected observation"))
+    adapter.discover_models = AsyncMock(side_effect=AssertionError("unexpected inventory"))
+    draft = _draft(**owner)
+    if owner["vendor"] != "custom":
+        draft.pop("protocol")
+    created = asyncio.run(service.create_source(draft))["source"]
+    _assert_valid("source.schema.json", created)
+    assert created["verification_pending"] is True
+    assert created["models"] == []
+    assert created["state"]["status"] == "standby"
+    assert created["client_nonce"] == draft["client_nonce"]
+    assert adapter.credential_count == 1
+    assert len(store.config.sources) == 1
+    adapter.observe_source.assert_not_awaited()
+    adapter.discover_models.assert_not_awaited()
+    with pytest.raises(ModelHubError):
+        asyncio.run(service.create_source(draft))
+    assert adapter.credential_count == 1
+
+
+@pytest.mark.parametrize("invalid", [
+    {"protocol": None}, {"protocol": "unknown"}, {"key": " "},
+    {"base_url": "file:///tmp/credentials"}, {"save_unverified": "true"},
+    {"verification_pending": False}, {"vendor": "openai", "protocol": "anthropic"},
+])
+def test_unverified_consent_cannot_bypass_input_or_owner_validation(tmp_path, invalid):
+    service, store, adapter = _service(tmp_path)
+    draft = _draft(**invalid)
+    if draft.get("protocol") is None:
+        draft.pop("protocol")
+    with pytest.raises(ModelHubError):
+        asyncio.run(service.create_source(draft))
+    assert store.config.sources == []
+    assert adapter.credential_count == 0
+
+
+def test_unverified_create_rolls_back_custody_and_releases_nonce(tmp_path):
+    service, store, adapter = _service(tmp_path)
+    adapter.fail_sync = True
+    with pytest.raises(ModelHubError):
+        asyncio.run(service.create_source(_draft()))
+    assert not store.config.sources
+    assert adapter.revoked == ["cred_test001"]
+    adapter.fail_sync = False
+    created = asyncio.run(service.create_source(_draft()))["source"]
+    assert created["verification_pending"] is True
+    assert len(store.config.sources) == 1
+
+
+def test_inventory_never_clears_pending_verification(tmp_path):
+    service, store, _adapter = _service(tmp_path)
+    source = asyncio.run(service.create_source(_draft()))["source"]
+    refreshed = asyncio.run(service.refresh_source(source["id"]))["source"]
+    assert refreshed["models"]
+    assert refreshed["verification_pending"] is True
+    assert ModelHubSourceConfig.from_payload(store.config.sources[0].to_payload()).verification_pending
+
+
+def test_verification_bookkeeping_io_failure_preserves_success_and_pending_state(tmp_path, monkeypatch):
+    service, store, _adapter = _service(tmp_path)
+
+    async def scenario():
+        source = (await service.create_source(_draft()))["source"]
+        generation = service._reserve_settlement_generation(source["id"])
+        outcome = RawCallOutcome(
+            kind=RawOutcomeKind.SUCCESS, http_status=200, error_code=None,
+            redacted_message=None, stream_started=False, model_id="test-model", source_id=source["id"],
+        )
+        def fail_save(_config):
+            raise OSError("Disk unavailable")
+        monkeypatch.setattr(store, "save", fail_save)
+        await service._verify_successful_source(source["id"], source["credential_ref"], generation, outcome)
+        assert store.config.sources[0].verification_pending is True
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("kind", list(RawOutcomeKind))
+@pytest.mark.parametrize("current", ["same", "replaced", "same_handle_reauth", "newer_attempt", "deleted"])
+def test_only_current_successful_invocation_retires_verification(tmp_path, kind, current):
+    service, store, _adapter = _service(tmp_path)
+
+    async def scenario():
+        source = (await service.create_source(_draft()))["source"]
+        outcome = RawCallOutcome(
+            kind=kind, http_status=200 if kind is RawOutcomeKind.SUCCESS else 400,
+            error_code=None, redacted_message=None, stream_started=False,
+            source_id=source["id"], model_id="test-model",
+        )
+        generation = service._reserve_settlement_generation(source["id"])
+        if current == "replaced":
+            store.config.sources[0].credential_ref = "cred_replacement"
+        elif current == "same_handle_reauth":
+            service._mark_source_unverified(store.config.sources[0])
+        elif current == "newer_attempt":
+            service._reserve_settlement_generation(source["id"])
+        elif current == "deleted":
+            store.config.sources.clear()
+        await service._verify_successful_source(source["id"], source["credential_ref"], generation, outcome)
+        if current != "deleted":
+            assert store.config.sources[0].verification_pending is not (current == "same" and kind is RawOutcomeKind.SUCCESS)
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("path", ["resolve", "probe", "stream"])
+def test_model_call_consumers_retire_pending_verification(tmp_path, path):
+    service, store, adapter = _service(tmp_path)
+
+    async def scenario():
+        source = (await service.create_source(_draft(vendor="anthropic", protocol="anthropic")))["source"]
+        await service.refresh_source(source["id"])
+        if path == "probe":
+            result = await service.probe_agent("claude", "claude-opus-4-6")
+            assert result["reachable"] is True
+        else:
+            resolved = await service.resolve(backend="claude", model_id="claude-opus-4-6", request={})
+            if path == "stream":
+                # Exercise the downstream-consumed settlement independently of
+                # the resolver's buffered-success path, with the same identity.
+                store.config.sources[0].verification_pending = True
+                handle = await adapter.invoke(source["id"], "claude-opus-4-6", {}, False, "claude")
+                outcome = replace(await handle.outcome(), stream_started=True)
+                await service.settle_handle_outcome(
+                    resolved, outcome, termination_origin="upstream_terminal", record_attempt=lambda *_args: None,
+                )
+        assert store.config.sources[0].verification_pending is False
+        assert "verification_pending" not in service.list_sources()[0]
+
+    asyncio.run(scenario())

--- a/ui/src/components/settings/models/AddApiKeyDialog.test.tsx
+++ b/ui/src/components/settings/models/AddApiKeyDialog.test.tsx
@@ -215,7 +215,7 @@ describe('AddApiKeyDialog', () => {
   it('saves only a selected interface as unverified without observing', async () => {
     const observe = vi.spyOn(modelsApi, 'observeApiKeySource');
     const create = vi.spyOn(modelsApi, 'createApiKeySource').mockResolvedValue({
-      source: { ...source, verification_pending: true }, added_to: [], adopted_by: [],
+      source: { ...source, verification_pending: 'vp_0123456789abcdef0123456789abcdef' }, added_to: [], adopted_by: [],
     });
     const { onAdded } = renderDialog();
     const user = await fillCredentials();
@@ -233,7 +233,7 @@ describe('AddApiKeyDialog', () => {
   it('retains unverified consent and nonce while reconciling an unknown write', async () => {
     const create = vi.spyOn(modelsApi, 'createApiKeySource')
       .mockRejectedValueOnce(new Error('Connection interrupted'))
-      .mockResolvedValue({ source: { ...source, verification_pending: true }, added_to: [], adopted_by: [] });
+      .mockResolvedValue({ source: { ...source, verification_pending: 'vp_0123456789abcdef0123456789abcdef' }, added_to: [], adopted_by: [] });
     vi.spyOn(modelsApi, 'listSources').mockResolvedValue([]);
     const observe = vi.spyOn(modelsApi, 'observeApiKeySource');
     const { onAdded } = renderDialog();

--- a/ui/src/components/settings/models/AddApiKeyDialog.test.tsx
+++ b/ui/src/components/settings/models/AddApiKeyDialog.test.tsx
@@ -212,6 +212,42 @@ afterEach(() => {
 });
 
 describe('AddApiKeyDialog', () => {
+  it('saves only a selected interface as unverified without observing', async () => {
+    const observe = vi.spyOn(modelsApi, 'observeApiKeySource');
+    const create = vi.spyOn(modelsApi, 'createApiKeySource').mockResolvedValue({
+      source: { ...source, verification_pending: true }, added_to: [], adopted_by: [],
+    });
+    const { onAdded } = renderDialog();
+    const user = await fillCredentials();
+    expect(screen.queryByRole('button', { name: 'Save unverified' })).toBeNull();
+    await openManualProtocol(user);
+    await user.click(screen.getByRole('button', { name: 'OpenAI Chat Completions' }));
+    await user.click(screen.getByRole('button', { name: 'Save unverified' }));
+    await waitFor(() => expect(onAdded).toHaveBeenCalledTimes(1));
+    expect(create).toHaveBeenCalledWith(expect.objectContaining({
+      protocol: 'openai_chat', save_unverified: true, key: 'secret-key',
+    }));
+    expect(observe).not.toHaveBeenCalled();
+  });
+
+  it('retains unverified consent and nonce while reconciling an unknown write', async () => {
+    const create = vi.spyOn(modelsApi, 'createApiKeySource')
+      .mockRejectedValueOnce(new Error('Connection interrupted'))
+      .mockResolvedValue({ source: { ...source, verification_pending: true }, added_to: [], adopted_by: [] });
+    vi.spyOn(modelsApi, 'listSources').mockResolvedValue([]);
+    const observe = vi.spyOn(modelsApi, 'observeApiKeySource');
+    const { onAdded } = renderDialog();
+    const user = await fillCredentials();
+    await selectVendor(user, preset('openai_chat').id);
+    await user.click(screen.getByRole('button', { name: 'Save unverified' }));
+    await user.click(await screen.findByRole('button', { name: RETRY }));
+    await waitFor(() => expect(onAdded).toHaveBeenCalledTimes(1));
+    expect(create).toHaveBeenCalledTimes(2);
+    expect(create.mock.calls[1][0]).toEqual(create.mock.calls[0][0]);
+    expect(create.mock.calls[1][0].save_unverified).toBe(true);
+    expect(observe).not.toHaveBeenCalled();
+  });
+
   it('detects without persisting, names the protocol, and drops the report when credentials change', async () => {
     vi.spyOn(modelsApi, 'observeApiKeySource').mockResolvedValueOnce(observed());
     const create = vi.spyOn(modelsApi, 'createApiKeySource');
@@ -353,7 +389,7 @@ describe('AddApiKeyDialog', () => {
     await user.click(screen.getByRole('button', { name: /^Retry$|^重试$/i }));
 
     await waitFor(() => expect(observe).toHaveBeenCalledTimes(2));
-    expect(await screen.findByText(/cannot tell which interface|无法判断是哪种接口/i)).toBeTruthy();
+    expect(await screen.findByText(i18n.t('settings.models.addKey.undetermined.title'))).toBeTruthy();
     expect(screen.queryByRole('button', { name: /Add anyway|仍要添加/i })).toBeNull();
   });
 
@@ -722,7 +758,7 @@ describe('AddApiKeyDialog', () => {
     await clickDetect(user);
     await clickConfirm(user);
 
-    expect(await screen.findByText(/cannot tell which interface|无法判断是哪种接口/i)).toBeTruthy();
+    expect(await screen.findByText(i18n.t('settings.models.addKey.undetermined.title'))).toBeTruthy();
     expect(screen.queryByText(i18n.t('settings.models.addKey.fail.unclassified'))).toBeNull();
   });
 
@@ -1232,7 +1268,7 @@ describe('AddApiKeyDialog · vendor', () => {
     const hint = row?.querySelector('.model-hub-add-key-hint');
     expect(statement?.textContent).toMatch(/Anthropic Messages/);
     expect(statement?.textContent).toMatch(/Built-in catalog/);
-    expect(hint?.textContent).toMatch(/no longer has to prove the interface|不再需要靠返回结构证明接口/);
+    expect(hint?.textContent).toBe(i18n.t('settings.models.addKey.protocol.catalogPinned.hint'));
     // A sibling of the statement's line, not a child of it.
     expect(hint?.parentElement).toBe(row);
     expect(statement?.contains(hint ?? null)).toBe(false);

--- a/ui/src/components/settings/models/AddApiKeyDialog.tsx
+++ b/ui/src/components/settings/models/AddApiKeyDialog.tsx
@@ -8,6 +8,7 @@ import {
   EyeOff,
   Info,
   LoaderCircle,
+  Save,
   TriangleAlert,
   X,
 } from 'lucide-react';
@@ -66,11 +67,13 @@ type Phase =
       messageKey: string | null;
       protocol: SourceProtocol | undefined;
       acceptUnavailableInventory: boolean;
+      saveUnverified: boolean;
     }
   | {
       kind: 'save_unconfirmed';
       protocol: SourceProtocol | undefined;
       acceptUnavailableInventory: boolean;
+      saveUnverified: boolean;
     };
 
 const INITIAL_PHASE: Phase = { kind: 'form', report: null };
@@ -361,6 +364,7 @@ export const AddApiKeyDialog: React.FC<AddApiKeyDialogProps> = (props) => {
   const draft = React.useCallback((
     protocol?: SourceProtocol,
     acceptUnavailableInventory = false,
+    saveUnverified = false,
   ): ApiKeySourceCreate => ({
     kind: 'api_key',
     vendor,
@@ -373,16 +377,18 @@ export const AddApiKeyDialog: React.FC<AddApiKeyDialogProps> = (props) => {
     client_nonce: clientNonce.current,
     ...(protocol ? { protocol } : {}),
     ...(acceptUnavailableInventory ? { accept_unavailable_inventory: true } : {}),
+    ...(saveUnverified ? { save_unverified: true } : {}),
   }), [apiKey, baseUrl, displayName, vendor]);
 
   const persist = React.useCallback(async (
     seq: ContinuationTicket,
     protocol?: SourceProtocol,
     acceptUnavailableInventory = false,
+    saveUnverified = false,
   ) => {
     if (continuation.settle(seq, () => setPhase({ kind: 'working', origin: 'add', stage: 'persist' })) === 'stale') return;
     try {
-      const created = await modelsApi.createApiKeySource(draft(protocol, acceptUnavailableInventory));
+      const created = await modelsApi.createApiKeySource(draft(protocol, acceptUnavailableInventory, saveUnverified));
       createdDelivery.settle(continuation, seq, created);
     } catch (error) {
       const failure = apiFailure(error);
@@ -409,8 +415,9 @@ export const AddApiKeyDialog: React.FC<AddApiKeyDialogProps> = (props) => {
               messageKey: failureMessageKey(failure),
               protocol,
               acceptUnavailableInventory,
+              saveUnverified,
             }
-          : { kind: 'save_unconfirmed', protocol, acceptUnavailableInventory });
+          : { kind: 'save_unconfirmed', protocol, acceptUnavailableInventory, saveUnverified });
       });
     }
   }, [continuation, createdDelivery, draft]);
@@ -594,7 +601,7 @@ export const AddApiKeyDialog: React.FC<AddApiKeyDialogProps> = (props) => {
         return;
       }
       if (reconciliation.kind === 'absent') {
-        await persist(seq, phase.protocol, phase.acceptUnavailableInventory);
+        await persist(seq, phase.protocol, phase.acceptUnavailableInventory, phase.saveUnverified);
       }
       return;
     }
@@ -603,6 +610,7 @@ export const AddApiKeyDialog: React.FC<AddApiKeyDialogProps> = (props) => {
         continuation.begin(),
         phase.protocol,
         phase.acceptUnavailableInventory,
+        phase.saveUnverified,
       );
       return;
     }
@@ -985,7 +993,7 @@ export const AddApiKeyDialog: React.FC<AddApiKeyDialogProps> = (props) => {
           </div>
         )}
 
-        <footer className="model-hub-add-key-foot model-hub-fill-05 flex flex-row items-center justify-end border-t border-border">
+        <footer className="model-hub-add-key-foot model-hub-fill-05 flex flex-row flex-wrap items-center justify-end border-t border-border">
           {replaceMode ? (
             <>
               <Button
@@ -1034,6 +1042,18 @@ export const AddApiKeyDialog: React.FC<AddApiKeyDialogProps> = (props) => {
               {phase.kind === 'inventory' && (
                 <Button type="button" variant="outline" className="model-hub-add-key-action" onClick={() => void addAnyway()}>
                   {t('settings.models.addKey.addAnyway')}
+                </Button>
+              )}
+              {constrainedProtocol && (phase.kind === 'undetermined' || phase.kind === 'failure' || (phase.kind === 'form' && !phase.report)) && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="model-hub-add-key-action"
+                  disabled={!canSubmit}
+                  onClick={() => void persist(continuation.begin(), constrainedProtocol, false, true)}
+                >
+                  <Save className="size-3 shrink-0" />
+                  {t('settings.models.addKey.saveUnverified')}
                 </Button>
               )}
               {phase.kind === 'form' && !phase.report && (

--- a/ui/src/components/settings/models/SourceDetailPanel.tsx
+++ b/ui/src/components/settings/models/SourceDetailPanel.tsx
@@ -893,6 +893,7 @@ export const SourceDetailPanel: React.FC<{
     known: adoptedBy !== undefined,
     backends: adoptedBackends,
     native: source.supply_channel === 'native_cli',
+    verificationPending: source.verification_pending,
   });
   // One authority picks the remedy and another total Record names its concrete
   // control. In particular, `retest` points at the existing refetch button; it is

--- a/ui/src/components/settings/models/SourceDetailPanel.tsx
+++ b/ui/src/components/settings/models/SourceDetailPanel.tsx
@@ -893,7 +893,7 @@ export const SourceDetailPanel: React.FC<{
     known: adoptedBy !== undefined,
     backends: adoptedBackends,
     native: source.supply_channel === 'native_cli',
-    verificationPending: source.verification_pending,
+    verificationPending: Boolean(source.verification_pending),
   });
   // One authority picks the remedy and another total Record names its concrete
   // control. In particular, `retest` points at the existing refetch button; it is

--- a/ui/src/components/settings/models/SourceRow.tsx
+++ b/ui/src/components/settings/models/SourceRow.tsx
@@ -33,7 +33,7 @@ export const SourceRow: React.FC<{
     known: adoptedBy !== undefined,
     backends: adoptedBackends,
     native: source.supply_channel === 'native_cli',
-    verificationPending: source.verification_pending,
+    verificationPending: Boolean(source.verification_pending),
   });
   const kindKey = source.supply_channel === 'native_cli'
     ? 'nativeCredential'

--- a/ui/src/components/settings/models/SourceRow.tsx
+++ b/ui/src/components/settings/models/SourceRow.tsx
@@ -33,13 +33,14 @@ export const SourceRow: React.FC<{
     known: adoptedBy !== undefined,
     backends: adoptedBackends,
     native: source.supply_channel === 'native_cli',
+    verificationPending: source.verification_pending,
   });
   const kindKey = source.supply_channel === 'native_cli'
     ? 'nativeCredential'
     : source.kind === 'subscription'
       ? 'subscription'
       : 'apiKey';
-  const adopted = (source.state.status === 'active' || source.state.status === 'standby') && (adoptedBy?.length ?? 0) > 0;
+  const adopted = !source.verification_pending && (source.state.status === 'active' || source.state.status === 'standby') && (adoptedBy?.length ?? 0) > 0;
   return (
     <button
       type="button"

--- a/ui/src/components/settings/models/sourceStatePresentation.test.ts
+++ b/ui/src/components/settings/models/sourceStatePresentation.test.ts
@@ -21,6 +21,20 @@ const state = (status: SourceStatus, over: Partial<SourceState> = {}): SourceSta
 });
 
 describe('sourceStatePresentation', () => {
+  it.each(['card', 'detail'] as const)('keeps unverified %s sources distinct from adopted healthy sources', (surface) => {
+    for (const status of SOURCE_STATUSES) {
+      const current = state(status);
+      const adoption = { known: true, backends: ['Codex'], native: false };
+      const presentation = sourceStatePresentation(current, surface, 'en', 0, { ...adoption, verificationPending: true });
+      if (status === 'active' || status === 'standby') {
+        expect(presentation.key).toBe('settings.models.sourceDetail.status.unverified');
+        expect(presentation.dotClass).toBe('bg-gold');
+      } else {
+        expect(presentation).toEqual(sourceStatePresentation(current, surface, 'en', 0, adoption));
+      }
+    }
+  });
+
   it('omits attribution when the source projection does not carry it', () => {
     expect(sourceStatePresentation(state('active'), 'card', 'en', 0).key).toBeNull();
     expect(sourceStatePresentation(state('active'), 'detail', 'en', 0).key).toBeNull();

--- a/ui/src/components/settings/models/sourceStatePresentation.ts
+++ b/ui/src/components/settings/models/sourceStatePresentation.ts
@@ -97,8 +97,15 @@ export const sourceStatePresentation = (
   surface: SourceStateSurface,
   locale: string,
   now: number = Date.now(),
-  adoption: { known: boolean; backends: string[]; native: boolean } = { known: false, backends: [], native: false },
+  adoption: { known: boolean; backends: string[]; native: boolean; verificationPending?: boolean } = { known: false, backends: [], native: false },
 ): SourceStatePresentation => {
+  if (adoption.verificationPending && (state.status === 'active' || state.status === 'standby')) {
+    return {
+      key: 'settings.models.sourceDetail.status.unverified',
+      textClass: 'model-hub-ink-gold',
+      dotClass: 'bg-gold',
+    };
+  }
   if (state.status === 'active' && !adoption.known) {
     return { key: null, textClass: 'text-muted', dotClass: 'bg-muted' };
   }

--- a/ui/src/components/settings/models/types.ts
+++ b/ui/src/components/settings/models/types.ts
@@ -130,6 +130,8 @@ export type Source = {
   supply_channel: SupplyChannel;
   billing: 'monthly' | 'metered';
   state: SourceState;
+  /** Saved configuration whose current credential has not completed a model call. */
+  verification_pending?: boolean;
   usage?: SourceUsage;
   /** Subscription identity for the row's mono sub-line (e.g. "me@gmail.com").
    *  Never secret material; may be null. */
@@ -851,7 +853,7 @@ export type ApiKeySourceObservation = {
   protocol?: SourceProtocol;
 };
 
-/** POST /api/models/sources — api_key create observes again before persisting. */
+/** POST /api/models/sources — observation is bypassed only by explicit consent. */
 export type ApiKeySourceCreate = {
   kind: 'api_key';
   vendor: string;
@@ -864,6 +866,8 @@ export type ApiKeySourceCreate = {
   protocol?: SourceProtocol;
   /** Explicit consent for a repeated, protocol-proven inventory failure. */
   accept_unavailable_inventory?: boolean;
+  /** Save a catalog-pinned or declared interface without calling the upstream. */
+  save_unverified?: boolean;
 };
 
 /**

--- a/ui/src/components/settings/models/types.ts
+++ b/ui/src/components/settings/models/types.ts
@@ -130,8 +130,8 @@ export type Source = {
   supply_channel: SupplyChannel;
   billing: 'monthly' | 'metered';
   state: SourceState;
-  /** Saved configuration whose current credential has not completed a model call. */
-  verification_pending?: boolean;
+  /** Opaque pending-verification identity; presence means no successful model call yet. */
+  verification_pending?: string | null;
   usage?: SourceUsage;
   /** Subscription identity for the row's mono sub-line (e.g. "me@gmail.com").
    *  Never secret material; may be null. */

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -1422,7 +1422,7 @@
       },
       "addKey": {
         "title": "Add API key",
-        "subtitle": "Detect the connection and interface first, then confirm to add",
+        "subtitle": "API key and model interface",
         "field": {
           "vendor": "Vendor",
           "vendor.custom": "Custom · compatible endpoint",
@@ -1431,7 +1431,7 @@
           "vendor.empty": "No vendor by that name",
           "name": "Name (optional)",
           "protocol": "Interface type",
-          "protocol.hint": "Use Auto detect when unsure; choose a type to declare that interface. If authentication succeeds it can be added, a wrong choice can fail at runtime, and the saved type cannot be changed",
+          "protocol.hint": "A declared interface is not proof of credential validity or model compatibility",
           "baseUrl": "Base URL",
           "baseUrl.hint": "API root, such as https://api.example.com/v1; a bare host uses the standard /v1 path",
           "apiKey": "API key",
@@ -1450,7 +1450,7 @@
         "saving": "Saving…",
         "saving.detail": "Saving this source",
         "fail": {
-          "subtitle": "Identifying the interface is a precondition of Add · fix what the line below names, then retry",
+          "subtitle": "Model-call verification is still pending",
           "auth": "The upstream rejected this credential",
           "auth.detail": "Check the API key, interface type, and the Base URL's API root path",
           "address": "Wrong address: 404 Not Found",
@@ -1463,8 +1463,8 @@
         },
         "retry": "Retry",
         "undetermined": {
-          "title": "Connected and authenticated — but we cannot tell which interface it speaks",
-          "detail": "This response shape matches no interface we know. Choose a concrete type and retry: if authentication succeeds on that path it can be added, but a wrong choice can fail at runtime and the saved type cannot be changed"
+          "title": "Connected, but not fully verified",
+          "detail": "The response does not establish both the interface and credential validity"
         },
         "protocol": {
           "auto": "Auto detect",
@@ -1475,13 +1475,14 @@
           "detecting": "Identifying the interface…",
           "manual": "Manually specify interface type",
           "catalogPinned": "Built-in catalog",
-          "catalogPinned.hint": "Detection authenticates the key and fetches models; it no longer has to prove the interface by its response shape",
+          "catalogPinned.hint": "Interface supplied by the built-in catalog; credential verification is separate",
           "declared": "Manually specified"
         },
         "inventory": {
           "title": "The interface is identified — but its model list did not come back this time"
         },
         "addAnyway": "Add anyway",
+        "saveUnverified": "Save unverified",
         "success": {
           "title": "Done → the dialog closes and you land on Source details · Models",
           "detail": "The model list, refetch and reasoning tiers are all maintained there"
@@ -1669,6 +1670,7 @@
           "error": "Error",
           "standbyHintLabel": "What this status means",
           "standbyHint": "This source is healthy. It reads as in use once a backend in Gateway mode serves a route through it.",
+          "unverified": "Not yet verified",
           "listUpdated": "· model list updated {{time}}"
         },
         "summary_one": "{{host}} · {{count}} model",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -1422,7 +1422,7 @@
       },
       "addKey": {
         "title": "添加 API Key",
-        "subtitle": "先检测连接与接口，确认后添加",
+        "subtitle": "API Key 与模型接口",
         "field": {
           "vendor": "服务商",
           "vendor.custom": "自定义 · 兼容端点",
@@ -1431,7 +1431,7 @@
           "vendor.empty": "没有同名的服务商",
           "name": "名称(可选)",
           "protocol": "接口类型",
-          "protocol.hint": "不确定时用自动探测；已知类型时可直接声明所选接口。该路径鉴权成功即可添加；选错了运行时可能失败，而且保存后不可更改",
+          "protocol.hint": "指定接口不代表凭证有效，也不代表实际模型调用兼容",
           "baseUrl": "Base URL",
           "baseUrl.hint": "填写 API 根地址，例如 https://api.example.com/v1；只填域名时使用标准 /v1 路径",
           "apiKey": "API Key",
@@ -1450,7 +1450,7 @@
         "saving": "保存中…",
         "saving.detail": "正在保存这个供应商",
         "fail": {
-          "subtitle": "认出接口是「添加」的前置条件 · 先按下面这条修,再重试",
+          "subtitle": "实际模型调用仍未验证",
           "auth": "供应商拒绝了这个凭据",
           "auth.detail": "检查 API Key、接口类型和 Base URL 的 API 根路径",
           "address": "地址不对:404 Not Found",
@@ -1463,8 +1463,8 @@
         },
         "retry": "重试",
         "undetermined": {
-          "title": "连上了、也通过了鉴权 —— 但认不出它说哪种接口",
-          "detail": "这次返回结构对不上任何一种已知接口。请选择一个明确类型后重试：只要该路径鉴权成功即可添加；但选错了运行时可能失败，而且保存后不可更改"
+          "title": "已连接，但尚未完成验证",
+          "detail": "这次响应不足以同时确认接口类型和凭证有效性"
         },
         "protocol": {
           "auto": "自动探测",
@@ -1475,13 +1475,14 @@
           "detecting": "识别接口中…",
           "manual": "手动指定接口类型",
           "catalogPinned": "内置目录",
-          "catalogPinned.hint": "检测会验证密钥并拉取模型；不再需要靠返回结构证明接口",
+          "catalogPinned.hint": "接口由内置目录指定；凭证是否有效仍需单独验证",
           "declared": "手动指定"
         },
         "inventory": {
           "title": "接口已经识别，但这次没有拿到模型清单"
         },
         "addAnyway": "仍要添加",
+        "saveUnverified": "未验证保存",
         "success": {
           "title": "添加成功，接下来进入供应商详情",
           "detail": "模型列表、重新拉取和推理强度档位都在那里维护"
@@ -1669,6 +1670,7 @@
           "error": "异常",
           "standbyHintLabel": "这个状态是什么意思",
           "standbyHint": "这个供应商当前可用。当模型网关中的某个后端通过它调用模型时，它就会显示为使用中。",
+          "unverified": "尚未验证",
           "listUpdated": "· 模型列表更新于 {{time}}"
         },
         "summary_one": "{{host}} · {{count}} 个模型",

--- a/vibe/model_hub_runtime/adapter.py
+++ b/vibe/model_hub_runtime/adapter.py
@@ -13,6 +13,7 @@ from enum import Enum
 from typing import Any, Callable, Mapping, Sequence
 
 import aiohttp
+import jwt
 
 from config.v2_config import normalize_model_hub_base_url
 from core.handlers.model_hub.adapter import (
@@ -140,9 +141,9 @@ class _ProtocolObservationTaxonomy:
     """One protocol's request shape and response evidence table.
 
     The request path and body are part of the same authority as the response
-    taxonomy. OpenAI probes deliberately provide the common ``model`` field
-    while omitting the candidate-specific ``input`` or ``messages`` field, so
-    each endpoint reaches its own protocol-shaped validation error.
+    taxonomy. Every probe omits ``model`` so observation does not request model
+    scheduling. A validation error supplies only provisional authentication;
+    the transport must independently establish credential-sensitive evidence.
     """
 
     request_path: str
@@ -621,7 +622,17 @@ def _owner_authentication_candidate(
     return evidence
 
 
-def _control_api_key(secret: str) -> str:
+def _control_credential(secret: str) -> str:
+    prefix, separator, signature = secret.rpartition(".")
+    if separator and signature:
+        try:
+            jwt.decode(secret, options={"verify_signature": False})
+        except jwt.PyJWTError:
+            pass
+        else:
+            # Preserve JWT header, claims and signature length. Change the first
+            # sextet so this cannot alter only unused base64 padding bits.
+            return prefix + "." + ("B" if signature[0] == "A" else "A") + signature[1:]
     # Preserve the existing prefix, length and ASCII character class where
     # possible, without ever reusing punctuation-only or other opaque keys.
     for index in range(len(secret) - 1, -1, -1):
@@ -706,7 +717,7 @@ async def _probe_protocol_response(
             evidence = await request(headers)
             if evidence.authentication is not _AuthenticationEvidence.ACCEPTED:
                 return evidence
-            control_secret = _control_api_key(secret)
+            control_secret = _control_credential(secret)
             control_headers = dict(headers)
             if protocol == "anthropic":
                 control_headers["x-api-key"] = control_secret
@@ -879,6 +890,8 @@ def _probe_oauth_protocol_response(
     auth: _AuthRecord,
     vendor: str,
     protocol: str,
+    state_store: EngineStateStore,
+    credential_ref: str,
 ) -> _ProtocolEvidence:
     """Probe one allowlisted OAuth upstream through the engine-held credential."""
 
@@ -888,7 +901,6 @@ def _probe_oauth_protocol_response(
     if vendor == "anthropic" and protocol == "anthropic":
         url = f"https://api.anthropic.com{taxonomy.oauth_path or taxonomy.request_path}"
         headers = {
-            "Authorization": "Bearer $TOKEN$",
             "Accept": "application/json",
             "Content-Type": "application/json",
             "Anthropic-Version": "2023-06-01",
@@ -898,7 +910,6 @@ def _probe_oauth_protocol_response(
     elif vendor in {"openai", "codex"} and protocol == "openai_responses":
         url = f"https://chatgpt.com{taxonomy.oauth_path or taxonomy.request_path}"
         headers = {
-            "Authorization": "Bearer $TOKEN$",
             "Accept": "application/json",
             "Content-Type": "application/json",
             "Originator": "codex-tui",
@@ -910,6 +921,13 @@ def _probe_oauth_protocol_response(
             "OAuth credential does not support this protocol path",
             status_code=404,
         )
+    try:
+        token = state_store.read_oauth_access_token(credential_ref)
+    except EngineStateError:
+        raise EngineClientError("OAuth probe credential is unavailable", error_type="credential_unavailable") from None
+    # Both requests must use one snapshot; engine substitution could refresh or
+    # replace the candidate between deriving the control and sending the probe.
+    headers["Authorization"] = f"Bearer {token}"
     def request(probe_headers: dict[str, str], *, is_control: bool = False) -> _ProtocolEvidence:
         payload = client.management_request(
             "POST",
@@ -940,7 +958,7 @@ def _probe_oauth_protocol_response(
     evidence = request(headers)
     if evidence.authentication is _AuthenticationEvidence.ACCEPTED:
         control = request(
-            {**headers, "Authorization": f"Bearer avibe-control-{secrets.token_hex(16)}"}, is_control=True,
+            {**headers, "Authorization": f"Bearer {_control_credential(token)}"}, is_control=True,
         )
         if control.authentication is not _AuthenticationEvidence.REJECTED:
             return replace(evidence, authentication=_AuthenticationEvidence.UNKNOWN)
@@ -1744,6 +1762,8 @@ class CLIProxyEngineAdapter:
                         auth=oauth_auth,
                         vendor=normalized_vendor,
                         protocol=protocol,
+                        state_store=self.state_store,
+                        credential_ref=credential_ref,
                     )
             except EngineClientError as exc:
                 failures.append(exc)

--- a/vibe/model_hub_runtime/adapter.py
+++ b/vibe/model_hub_runtime/adapter.py
@@ -858,12 +858,23 @@ def _probe_oauth_protocol_response(
             error_type="invalid_json",
         )
     body = payload.get("body")
-    return _parse_protocol_authenticated_evidence(
+    evidence = _parse_protocol_authenticated_evidence(
         protocol,
         status,
         body if isinstance(body, str) else "",
         vendor=vendor,
     )
+    if (
+        protocol == "openai_responses"
+        and evidence.protocol is _ProtocolProof.UNPROVEN
+        and evidence.authentication is _AuthenticationEvidence.ACCEPTED
+        and evidence.shape is _ProtocolObservationShape.GENERIC_REQUEST_ERROR
+    ):
+        # The bound OAuth credential reaches only the fixed Codex Responses
+        # endpoint above. Its authenticated missing-model error need not name
+        # a Responses-specific field; custom API-key URLs have no such proof.
+        return replace(evidence, protocol=_ProtocolProof.PROVEN)
+    return evidence
 
 
 @dataclass

--- a/vibe/model_hub_runtime/adapter.py
+++ b/vibe/model_hub_runtime/adapter.py
@@ -495,13 +495,14 @@ def _parse_protocol_authenticated_evidence(
     vendor: str | None = None,
     request_root: str | None = None,
 ) -> _ProtocolEvidence:
-    """Classify response-shaped protocol proof and table-driven auth evidence.
+    """Classify protocol shape and provisional authentication evidence.
 
     This parser never upgrades a generic response into a protocol owner on its
     own. ``observe_source()`` may later apply the September 4, 2026 owner-based
     ladder for shipped vendor pins and concrete `custom` declarations after the
-    constrained path has responded. `custom` Auto detect still relies on this
-    parser's response evidence alone.
+    constrained path has responded. The transport still requires a rejected
+    control before accepting authentication. `custom` Auto detect relies on
+    this parser's protocol evidence, never a caller-owned endpoint identity.
     """
 
     def evidence(
@@ -606,12 +607,45 @@ def _parse_protocol_authenticated_evidence(
     )
 
 
+def _owner_authentication_candidate(evidence: _ProtocolEvidence, *, owner_scoped: bool) -> _ProtocolEvidence:
+    if evidence.status in _AUTHENTICATION_ERROR_STATUSES:
+        return replace(evidence, authentication=_AuthenticationEvidence.REJECTED)
+    if (
+        owner_scoped
+        and evidence.authentication is _AuthenticationEvidence.UNKNOWN
+        and evidence.status in (_SUCCESS_STATUSES | _REQUEST_ERROR_STATUSES)
+    ):
+        return replace(evidence, authentication=_AuthenticationEvidence.ACCEPTED)
+    return evidence
+
+
+async def _authenticate_protected_inventory(
+    *, vendor: str, protocol: str, base_url: str | None, secret: str, control_secret: str,
+) -> _AuthenticationEvidence:
+    # A public model list proves neither key validity nor protocol identity.
+    try:
+        await probe_models(vendor=vendor, protocol=protocol, base_url=base_url, secret=control_secret)
+    except EngineClientError as exc:
+        if exc.status_code not in _AUTHENTICATION_ERROR_STATUSES:
+            return _AuthenticationEvidence.UNKNOWN
+    else:
+        return _AuthenticationEvidence.UNKNOWN
+    try:
+        await probe_models(vendor=vendor, protocol=protocol, base_url=base_url, secret=secret)
+    except EngineClientError as exc:
+        if exc.status_code in _AUTHENTICATION_ERROR_STATUSES:
+            return _AuthenticationEvidence.REJECTED
+        return _AuthenticationEvidence.UNKNOWN
+    return _AuthenticationEvidence.ACCEPTED
+
+
 async def _probe_protocol_response(
     *,
     vendor: str,
     protocol: str,
     base_url: str | None,
     secret: str,
+    owner_scoped: bool = False,
     timeout: float = 15.0,
 ) -> _ProtocolEvidence:
     """Require a response from the candidate protocol's distinct request path."""
@@ -638,22 +672,53 @@ async def _probe_protocol_response(
             "Accept": "application/json",
         }
     client_timeout = aiohttp.ClientTimeout(total=timeout)
-    try:
+    async def observe() -> _ProtocolEvidence:
         async with aiohttp.ClientSession(timeout=client_timeout) as session:
-            async with session.post(
-                url,
-                headers=headers,
-                json=dict(taxonomy.request_body),
-                allow_redirects=False,
-            ) as response:
-                body = await response.content.read(64 * 1024)
-                return _parse_protocol_authenticated_evidence(
-                    protocol,
-                    response.status,
-                    body,
-                    vendor=vendor,
-                    request_root=root,
-                )
+            async def request(probe_headers: dict[str, str]) -> _ProtocolEvidence:
+                async with session.post(
+                    url,
+                    headers=probe_headers,
+                    json=dict(taxonomy.request_body),
+                    allow_redirects=False,
+                ) as response:
+                    body = await response.content.read(64 * 1024)
+                    return _owner_authentication_candidate(
+                        _parse_protocol_authenticated_evidence(
+                            protocol, response.status, body, vendor=vendor, request_root=root,
+                        ),
+                        owner_scoped=owner_scoped,
+                    )
+
+            evidence = await request(headers)
+            if evidence.authentication is not _AuthenticationEvidence.ACCEPTED:
+                return evidence
+            # Keep presence, prefix, length and character class for gateways
+            # that reject malformed keys before validating the request body.
+            control_secret = secret
+            for index in range(len(secret) - 1, -1, -1):
+                for first, last in (("0", "9"), ("a", "z"), ("A", "Z")):
+                    if first <= secret[index] <= last:
+                        changed = chr(ord(first) + 1) if secret[index] == first else first
+                        control_secret = secret[:index] + changed + secret[index + 1:]
+                        break
+                if control_secret != secret:
+                    break
+            control_headers = dict(headers)
+            if protocol == "anthropic":
+                control_headers["x-api-key"] = control_secret
+            else:
+                control_headers["Authorization"] = f"Bearer {control_secret}"
+            control = await request(control_headers)
+            if control.authentication is _AuthenticationEvidence.REJECTED:
+                return evidence
+            authentication = await _authenticate_protected_inventory(
+                vendor=vendor, protocol=protocol, base_url=base_url,
+                secret=secret, control_secret=control_secret,
+            )
+            return replace(evidence, authentication=authentication)
+
+    try:
+        return await asyncio.wait_for(observe(), timeout=timeout)
     except asyncio.TimeoutError:
         raise EngineClientError("protocol observation timed out", error_type="timeout") from None
     except aiohttp.ClientError:
@@ -840,30 +905,37 @@ def _probe_oauth_protocol_response(
             "OAuth credential does not support this protocol path",
             status_code=404,
         )
-    payload = client.management_request(
-        "POST",
-        "/api-call",
-        payload={
-            "auth_index": auth.auth_index,
-            "method": "POST",
-            "url": url,
-            "header": headers,
-            "data": json.dumps(taxonomy.request_body, separators=(",", ":")),
-        },
-    )
-    status = payload.get("status_code")
-    if not isinstance(status, int) or isinstance(status, bool):
-        raise EngineClientError(
-            "protocol observation returned an invalid status",
-            error_type="invalid_json",
+    def request(probe_headers: dict[str, str]) -> _ProtocolEvidence:
+        payload = client.management_request(
+            "POST",
+            "/api-call",
+            payload={
+                "auth_index": auth.auth_index,
+                "method": "POST",
+                "url": url,
+                "header": probe_headers,
+                "data": json.dumps(taxonomy.request_body, separators=(",", ":")),
+            },
         )
-    body = payload.get("body")
-    evidence = _parse_protocol_authenticated_evidence(
-        protocol,
-        status,
-        body if isinstance(body, str) else "",
-        vendor=vendor,
-    )
+        status = payload.get("status_code")
+        if not isinstance(status, int) or isinstance(status, bool):
+            raise EngineClientError(
+                "protocol observation returned an invalid status",
+                error_type="invalid_json",
+            )
+        body = payload.get("body")
+        return _owner_authentication_candidate(
+            _parse_protocol_authenticated_evidence(
+                protocol, status, body if isinstance(body, str) else "", vendor=vendor,
+            ),
+            owner_scoped=False,
+        )
+
+    evidence = request(headers)
+    if evidence.authentication is _AuthenticationEvidence.ACCEPTED:
+        control = request({**headers, "Authorization": f"Bearer avibe-control-{secrets.token_hex(16)}"})
+        if control.authentication is not _AuthenticationEvidence.REJECTED:
+            return replace(evidence, authentication=_AuthenticationEvidence.UNKNOWN)
     if (
         protocol == "openai_responses"
         and evidence.protocol is _ProtocolProof.UNPROVEN
@@ -1591,12 +1663,12 @@ class CLIProxyEngineAdapter:
         ``protocol_order`` orders attempts only. A protocol-specific response
         with accepted authentication proves the current attempt and terminates
         observation. A shipped vendor catalog pin or a concrete `custom`
-        declaration also terminates observation once that exact protocol path
-        returns an owner-scoped auth status: 401/403 reject, while 2xx and
-        request-error 400/404/422 accept even when the response shape stays
-        generic. A shaped credential rejection is recorded while later
-        candidates continue on Auto detect. Vendor, URL, and order never create
-        a conclusion on their own; `custom` Auto still requires response-backed
+        declaration also terminates observation once the transport establishes
+        credential-sensitive authentication. A validation response is only a
+        candidate until a control credential is rejected on that path or a
+        protected model-list path accepts the candidate. A shaped rejection is
+        recorded while later candidates continue on Auto detect. Vendor, URL,
+        and order never create a conclusion on their own; `custom` Auto still requires response-backed
         proof, and exhausting that path without one remains ambiguous.
         """
 
@@ -1641,6 +1713,12 @@ class CLIProxyEngineAdapter:
         for protocol in protocol_order:
             if protocol not in SOURCE_PROTOCOLS:
                 raise EngineStateError("unsupported source protocol")
+            owner_scoped_protocol = _protocol_is_persistable_without_shape_proof(
+                credential_kind=str(credential_kind),
+                vendor=normalized_vendor,
+                protocol=protocol,
+                protocol_order=protocol_order,
+            )
             try:
                 if credential_kind == "api_key":
                     evidence = await _probe_protocol_response(
@@ -1648,6 +1726,7 @@ class CLIProxyEngineAdapter:
                         protocol=protocol,
                         base_url=base_url,
                         secret=secret or "",
+                        owner_scoped=owner_scoped_protocol,
                     )
                 else:
                     assert oauth_auth is not None
@@ -1661,33 +1740,6 @@ class CLIProxyEngineAdapter:
             except EngineClientError as exc:
                 failures.append(exc)
                 continue
-            owner_scoped_protocol = _protocol_is_persistable_without_shape_proof(
-                credential_kind=str(credential_kind),
-                vendor=normalized_vendor,
-                protocol=protocol,
-                protocol_order=protocol_order,
-            )
-            owner_rejected = (
-                owner_scoped_protocol
-                and evidence.status in _AUTHENTICATION_ERROR_STATUSES
-            )
-            owner_accepted = (
-                owner_scoped_protocol
-                and (
-                    evidence.status in _SUCCESS_STATUSES
-                    or evidence.status in _REQUEST_ERROR_STATUSES
-                )
-            )
-            if owner_rejected:
-                evidence = replace(
-                    evidence,
-                    authentication=_AuthenticationEvidence.REJECTED,
-                )
-            elif owner_accepted:
-                evidence = replace(
-                    evidence,
-                    authentication=_AuthenticationEvidence.ACCEPTED,
-                )
             if evidence.authentication is _AuthenticationEvidence.REJECTED:
                 received_rejection = True
                 ruled_out_protocols.add(protocol)

--- a/vibe/model_hub_runtime/adapter.py
+++ b/vibe/model_hub_runtime/adapter.py
@@ -607,8 +607,10 @@ def _parse_protocol_authenticated_evidence(
     )
 
 
-def _owner_authentication_candidate(evidence: _ProtocolEvidence, *, owner_scoped: bool) -> _ProtocolEvidence:
-    if evidence.status in _AUTHENTICATION_ERROR_STATUSES:
+def _owner_authentication_candidate(
+    evidence: _ProtocolEvidence, *, owner_scoped: bool, is_control: bool = False,
+) -> _ProtocolEvidence:
+    if (owner_scoped or is_control) and evidence.status in _AUTHENTICATION_ERROR_STATUSES:
         return replace(evidence, authentication=_AuthenticationEvidence.REJECTED)
     if (
         owner_scoped
@@ -619,8 +621,19 @@ def _owner_authentication_candidate(evidence: _ProtocolEvidence, *, owner_scoped
     return evidence
 
 
+def _control_api_key(secret: str) -> str:
+    # Preserve the existing prefix, length and ASCII character class where
+    # possible, without ever reusing punctuation-only or other opaque keys.
+    for index in range(len(secret) - 1, -1, -1):
+        for first, last in (("0", "9"), ("a", "z"), ("A", "Z")):
+            if first <= secret[index] <= last:
+                changed = chr(ord(first) + 1) if secret[index] == first else first
+                return secret[:index] + changed + secret[index + 1:]
+    return secret[:-1] + ("?" if secret.endswith("!") else "!")
+
+
 async def _authenticate_protected_inventory(
-    *, vendor: str, protocol: str, base_url: str | None, secret: str, control_secret: str,
+    *, vendor: str, protocol: str, base_url: str | None, secret: str, control_secret: str, owner_scoped: bool,
 ) -> _AuthenticationEvidence:
     # A public model list proves neither key validity nor protocol identity.
     try:
@@ -633,7 +646,7 @@ async def _authenticate_protected_inventory(
     try:
         await probe_models(vendor=vendor, protocol=protocol, base_url=base_url, secret=secret)
     except EngineClientError as exc:
-        if exc.status_code in _AUTHENTICATION_ERROR_STATUSES:
+        if owner_scoped and exc.status_code in _AUTHENTICATION_ERROR_STATUSES:
             return _AuthenticationEvidence.REJECTED
         return _AuthenticationEvidence.UNKNOWN
     return _AuthenticationEvidence.ACCEPTED
@@ -674,7 +687,7 @@ async def _probe_protocol_response(
     client_timeout = aiohttp.ClientTimeout(total=timeout)
     async def observe() -> _ProtocolEvidence:
         async with aiohttp.ClientSession(timeout=client_timeout) as session:
-            async def request(probe_headers: dict[str, str]) -> _ProtocolEvidence:
+            async def request(probe_headers: dict[str, str], *, is_control: bool = False) -> _ProtocolEvidence:
                 async with session.post(
                     url,
                     headers=probe_headers,
@@ -687,33 +700,25 @@ async def _probe_protocol_response(
                             protocol, response.status, body, vendor=vendor, request_root=root,
                         ),
                         owner_scoped=owner_scoped,
+                        is_control=is_control,
                     )
 
             evidence = await request(headers)
             if evidence.authentication is not _AuthenticationEvidence.ACCEPTED:
                 return evidence
-            # Keep presence, prefix, length and character class for gateways
-            # that reject malformed keys before validating the request body.
-            control_secret = secret
-            for index in range(len(secret) - 1, -1, -1):
-                for first, last in (("0", "9"), ("a", "z"), ("A", "Z")):
-                    if first <= secret[index] <= last:
-                        changed = chr(ord(first) + 1) if secret[index] == first else first
-                        control_secret = secret[:index] + changed + secret[index + 1:]
-                        break
-                if control_secret != secret:
-                    break
+            control_secret = _control_api_key(secret)
             control_headers = dict(headers)
             if protocol == "anthropic":
                 control_headers["x-api-key"] = control_secret
             else:
                 control_headers["Authorization"] = f"Bearer {control_secret}"
-            control = await request(control_headers)
+            control = await request(control_headers, is_control=True)
             if control.authentication is _AuthenticationEvidence.REJECTED:
                 return evidence
             authentication = await _authenticate_protected_inventory(
                 vendor=vendor, protocol=protocol, base_url=base_url,
                 secret=secret, control_secret=control_secret,
+                owner_scoped=owner_scoped,
             )
             return replace(evidence, authentication=authentication)
 
@@ -905,7 +910,7 @@ def _probe_oauth_protocol_response(
             "OAuth credential does not support this protocol path",
             status_code=404,
         )
-    def request(probe_headers: dict[str, str]) -> _ProtocolEvidence:
+    def request(probe_headers: dict[str, str], *, is_control: bool = False) -> _ProtocolEvidence:
         payload = client.management_request(
             "POST",
             "/api-call",
@@ -929,11 +934,14 @@ def _probe_oauth_protocol_response(
                 protocol, status, body if isinstance(body, str) else "", vendor=vendor,
             ),
             owner_scoped=False,
+            is_control=is_control,
         )
 
     evidence = request(headers)
     if evidence.authentication is _AuthenticationEvidence.ACCEPTED:
-        control = request({**headers, "Authorization": f"Bearer avibe-control-{secrets.token_hex(16)}"})
+        control = request(
+            {**headers, "Authorization": f"Bearer avibe-control-{secrets.token_hex(16)}"}, is_control=True,
+        )
         if control.authentication is not _AuthenticationEvidence.REJECTED:
             return replace(evidence, authentication=_AuthenticationEvidence.UNKNOWN)
     if (

--- a/vibe/model_hub_runtime/adapter.py
+++ b/vibe/model_hub_runtime/adapter.py
@@ -289,6 +289,8 @@ def _openai_evidence_rules(
     )
 
 
+# Omit the model so observation stops at request validation, before a relay
+# schedules upstream capacity or applies model-specific availability limits.
 _PROTOCOL_OBSERVATION_TAXONOMY = {
     "anthropic": _ProtocolObservationTaxonomy(
         request_path="/v1/messages",
@@ -344,7 +346,7 @@ _PROTOCOL_OBSERVATION_TAXONOMY = {
     ),
     "openai_responses": _ProtocolObservationTaxonomy(
         request_path="/v1/responses",
-        request_body={"model": "__avibe_model_hub_probe__"},
+        request_body={},
         oauth_path="/backend-api/codex/responses",
         evidence_rules=_openai_evidence_rules(
             frozenset({"response"}),
@@ -353,7 +355,7 @@ _PROTOCOL_OBSERVATION_TAXONOMY = {
     ),
     "openai_chat": _ProtocolObservationTaxonomy(
         request_path="/v1/chat/completions",
-        request_body={"model": "__avibe_model_hub_probe__"},
+        request_body={},
         oauth_path=None,
         evidence_rules=_openai_evidence_rules(
             frozenset({"chat.completion", "chat.completion.chunk"}),

--- a/vibe/model_hub_runtime/adapter.py
+++ b/vibe/model_hub_runtime/adapter.py
@@ -13,7 +13,6 @@ from enum import Enum
 from typing import Any, Callable, Mapping, Sequence
 
 import aiohttp
-import jwt
 
 from config.v2_config import normalize_model_hub_base_url
 from core.handlers.model_hub.adapter import (
@@ -142,8 +141,8 @@ class _ProtocolObservationTaxonomy:
 
     The request path and body are part of the same authority as the response
     taxonomy. Every probe omits ``model`` so observation does not request model
-    scheduling. A validation error supplies only provisional authentication;
-    the transport must independently establish credential-sensitive evidence.
+    scheduling. Schema validation never proves authentication, regardless of
+    whether the interface has a catalog owner or a user declaration.
     """
 
     request_path: str
@@ -254,13 +253,13 @@ def _openai_evidence_rules(
             error_identifiers=_REQUEST_ERROR_IDENTIFIERS,
             error_params=request_params,
             protocol=_ProtocolProof.PROVEN,
-            authentication=_AuthenticationEvidence.ACCEPTED,
+            authentication=_AuthenticationEvidence.UNKNOWN,
         ),
         _ProtocolEvidenceRule(
             statuses=_REQUEST_ERROR_STATUSES,
             error_identifiers=_MODEL_ERROR_IDENTIFIERS,
             protocol=_ProtocolProof.UNPROVEN,
-            authentication=_AuthenticationEvidence.ACCEPTED,
+            authentication=_AuthenticationEvidence.UNKNOWN,
             shape=_ProtocolObservationShape.GENERIC_REQUEST_ERROR,
         ),
         _ProtocolEvidenceRule(
@@ -317,7 +316,7 @@ _PROTOCOL_OBSERVATION_TAXONOMY = {
                 top_level_values=frozenset({"error"}),
                 error_identifiers=_REQUEST_ERROR_IDENTIFIERS | _MODEL_ERROR_IDENTIFIERS,
                 protocol=_ProtocolProof.PROVEN,
-                authentication=_AuthenticationEvidence.ACCEPTED,
+                authentication=_AuthenticationEvidence.UNKNOWN,
             ),
             _ProtocolEvidenceRule(
                 statuses=_AUTHENTICATION_ERROR_STATUSES,
@@ -496,14 +495,10 @@ def _parse_protocol_authenticated_evidence(
     vendor: str | None = None,
     request_root: str | None = None,
 ) -> _ProtocolEvidence:
-    """Classify protocol shape and provisional authentication evidence.
+    """Classify protocol shape without treating schema validation as login.
 
-    This parser never upgrades a generic response into a protocol owner on its
-    own. ``observe_source()`` may later apply the September 4, 2026 owner-based
-    ladder for shipped vendor pins and concrete `custom` declarations after the
-    constrained path has responded. The transport still requires a rejected
-    control before accepting authentication. `custom` Auto detect relies on
-    this parser's protocol evidence, never a caller-owned endpoint identity.
+    A missing-model error can precede authentication. Neither a declaration nor
+    a differently rejected credential can upgrade it into authentication proof.
     """
 
     def evidence(
@@ -554,7 +549,7 @@ def _parse_protocol_authenticated_evidence(
         if wrapperless == "accepted":
             return evidence(
                 protocol=_ProtocolProof.UNPROVEN,
-                authentication=_AuthenticationEvidence.ACCEPTED,
+                authentication=_AuthenticationEvidence.UNKNOWN,
                 shape=_ProtocolObservationShape.GENERIC_REQUEST_ERROR,
             )
         if wrapperless == "rejected":
@@ -581,7 +576,7 @@ def _parse_protocol_authenticated_evidence(
         if wrapperless == "accepted":
             return evidence(
                 protocol=_ProtocolProof.UNPROVEN,
-                authentication=_AuthenticationEvidence.ACCEPTED,
+                authentication=_AuthenticationEvidence.UNKNOWN,
                 shape=_ProtocolObservationShape.GENERIC_REQUEST_ERROR,
             )
         if isinstance(error, dict):
@@ -593,7 +588,7 @@ def _parse_protocol_authenticated_evidence(
             ):
                 return evidence(
                     protocol=_ProtocolProof.UNPROVEN,
-                    authentication=_AuthenticationEvidence.ACCEPTED,
+                    authentication=_AuthenticationEvidence.UNKNOWN,
                     shape=_ProtocolObservationShape.GENERIC_REQUEST_ERROR,
                 )
     if _response_shape_proves_protocol(protocol, payload):
@@ -608,68 +603,12 @@ def _parse_protocol_authenticated_evidence(
     )
 
 
-def _owner_authentication_candidate(
-    evidence: _ProtocolEvidence, *, owner_scoped: bool, is_control: bool = False,
-) -> _ProtocolEvidence:
-    if (owner_scoped or is_control) and evidence.status in _AUTHENTICATION_ERROR_STATUSES:
-        return replace(evidence, authentication=_AuthenticationEvidence.REJECTED)
-    if (
-        owner_scoped
-        and evidence.authentication is _AuthenticationEvidence.UNKNOWN
-        and evidence.status in (_SUCCESS_STATUSES | _REQUEST_ERROR_STATUSES)
-    ):
-        return replace(evidence, authentication=_AuthenticationEvidence.ACCEPTED)
-    return evidence
-
-
-def _control_credential(secret: str) -> str:
-    prefix, separator, signature = secret.rpartition(".")
-    if separator and signature:
-        try:
-            jwt.decode(secret, options={"verify_signature": False})
-        except jwt.PyJWTError:
-            pass
-        else:
-            # Preserve JWT header, claims and signature length. Change the first
-            # sextet so this cannot alter only unused base64 padding bits.
-            return prefix + "." + ("B" if signature[0] == "A" else "A") + signature[1:]
-    # Preserve the existing prefix, length and ASCII character class where
-    # possible, without ever reusing punctuation-only or other opaque keys.
-    for index in range(len(secret) - 1, -1, -1):
-        for first, last in (("0", "9"), ("a", "z"), ("A", "Z")):
-            if first <= secret[index] <= last:
-                changed = chr(ord(first) + 1) if secret[index] == first else first
-                return secret[:index] + changed + secret[index + 1:]
-    return secret[:-1] + ("?" if secret.endswith("!") else "!")
-
-
-async def _authenticate_protected_inventory(
-    *, vendor: str, protocol: str, base_url: str | None, secret: str, control_secret: str, owner_scoped: bool,
-) -> _AuthenticationEvidence:
-    # A public model list proves neither key validity nor protocol identity.
-    try:
-        await probe_models(vendor=vendor, protocol=protocol, base_url=base_url, secret=control_secret)
-    except EngineClientError as exc:
-        if exc.status_code not in _AUTHENTICATION_ERROR_STATUSES:
-            return _AuthenticationEvidence.UNKNOWN
-    else:
-        return _AuthenticationEvidence.UNKNOWN
-    try:
-        await probe_models(vendor=vendor, protocol=protocol, base_url=base_url, secret=secret)
-    except EngineClientError as exc:
-        if owner_scoped and exc.status_code in _AUTHENTICATION_ERROR_STATUSES:
-            return _AuthenticationEvidence.REJECTED
-        return _AuthenticationEvidence.UNKNOWN
-    return _AuthenticationEvidence.ACCEPTED
-
-
 async def _probe_protocol_response(
     *,
     vendor: str,
     protocol: str,
     base_url: str | None,
     secret: str,
-    owner_scoped: bool = False,
     timeout: float = 15.0,
 ) -> _ProtocolEvidence:
     """Require a response from the candidate protocol's distinct request path."""
@@ -698,40 +637,16 @@ async def _probe_protocol_response(
     client_timeout = aiohttp.ClientTimeout(total=timeout)
     async def observe() -> _ProtocolEvidence:
         async with aiohttp.ClientSession(timeout=client_timeout) as session:
-            async def request(probe_headers: dict[str, str], *, is_control: bool = False) -> _ProtocolEvidence:
-                async with session.post(
-                    url,
-                    headers=probe_headers,
-                    json=dict(taxonomy.request_body),
-                    allow_redirects=False,
-                ) as response:
-                    body = await response.content.read(64 * 1024)
-                    return _owner_authentication_candidate(
-                        _parse_protocol_authenticated_evidence(
-                            protocol, response.status, body, vendor=vendor, request_root=root,
-                        ),
-                        owner_scoped=owner_scoped,
-                        is_control=is_control,
-                    )
-
-            evidence = await request(headers)
-            if evidence.authentication is not _AuthenticationEvidence.ACCEPTED:
-                return evidence
-            control_secret = _control_credential(secret)
-            control_headers = dict(headers)
-            if protocol == "anthropic":
-                control_headers["x-api-key"] = control_secret
-            else:
-                control_headers["Authorization"] = f"Bearer {control_secret}"
-            control = await request(control_headers, is_control=True)
-            if control.authentication is _AuthenticationEvidence.REJECTED:
-                return evidence
-            authentication = await _authenticate_protected_inventory(
-                vendor=vendor, protocol=protocol, base_url=base_url,
-                secret=secret, control_secret=control_secret,
-                owner_scoped=owner_scoped,
-            )
-            return replace(evidence, authentication=authentication)
+            async with session.post(
+                url,
+                headers=headers,
+                json=dict(taxonomy.request_body),
+                allow_redirects=False,
+            ) as response:
+                body = await response.content.read(64 * 1024)
+                return _parse_protocol_authenticated_evidence(
+                    protocol, response.status, body, vendor=vendor, request_root=root,
+                )
 
     try:
         return await asyncio.wait_for(observe(), timeout=timeout)
@@ -890,8 +805,6 @@ def _probe_oauth_protocol_response(
     auth: _AuthRecord,
     vendor: str,
     protocol: str,
-    state_store: EngineStateStore,
-    credential_ref: str,
 ) -> _ProtocolEvidence:
     """Probe one allowlisted OAuth upstream through the engine-held credential."""
 
@@ -921,14 +834,8 @@ def _probe_oauth_protocol_response(
             "OAuth credential does not support this protocol path",
             status_code=404,
         )
-    try:
-        token = state_store.read_oauth_access_token(credential_ref)
-    except EngineStateError:
-        raise EngineClientError("OAuth probe credential is unavailable", error_type="credential_unavailable") from None
-    # Both requests must use one snapshot; engine substitution could refresh or
-    # replace the candidate between deriving the control and sending the probe.
-    headers["Authorization"] = f"Bearer {token}"
-    def request(probe_headers: dict[str, str], *, is_control: bool = False) -> _ProtocolEvidence:
+    headers["Authorization"] = "Bearer $TOKEN$"
+    def request(probe_headers: dict[str, str]) -> _ProtocolEvidence:
         payload = client.management_request(
             "POST",
             "/api-call",
@@ -947,32 +854,11 @@ def _probe_oauth_protocol_response(
                 error_type="invalid_json",
             )
         body = payload.get("body")
-        return _owner_authentication_candidate(
-            _parse_protocol_authenticated_evidence(
-                protocol, status, body if isinstance(body, str) else "", vendor=vendor,
-            ),
-            owner_scoped=False,
-            is_control=is_control,
+        return _parse_protocol_authenticated_evidence(
+            protocol, status, body if isinstance(body, str) else "", vendor=vendor,
         )
 
-    evidence = request(headers)
-    if evidence.authentication is _AuthenticationEvidence.ACCEPTED:
-        control = request(
-            {**headers, "Authorization": f"Bearer {_control_credential(token)}"}, is_control=True,
-        )
-        if control.authentication is not _AuthenticationEvidence.REJECTED:
-            return replace(evidence, authentication=_AuthenticationEvidence.UNKNOWN)
-    if (
-        protocol == "openai_responses"
-        and evidence.protocol is _ProtocolProof.UNPROVEN
-        and evidence.authentication is _AuthenticationEvidence.ACCEPTED
-        and evidence.shape is _ProtocolObservationShape.GENERIC_REQUEST_ERROR
-    ):
-        # The bound OAuth credential reaches only the fixed Codex Responses
-        # endpoint above. Its authenticated missing-model error need not name
-        # a Responses-specific field; custom API-key URLs have no such proof.
-        return replace(evidence, protocol=_ProtocolProof.PROVEN)
-    return evidence
+    return request(headers)
 
 
 @dataclass
@@ -1689,10 +1575,9 @@ class CLIProxyEngineAdapter:
         ``protocol_order`` orders attempts only. A protocol-specific response
         with accepted authentication proves the current attempt and terminates
         observation. A shipped vendor catalog pin or a concrete `custom`
-        declaration also terminates observation once the transport establishes
-        credential-sensitive authentication. A validation response is only a
-        candidate until a control credential is rejected on that path or a
-        protected model-list path accepts the candidate. A shaped rejection is
+        declaration also terminates observation after a shaped success.
+        Schema errors remain unverified; explicit unverified saving belongs to
+        Source creation, not this observation. A shaped rejection is
         recorded while later candidates continue on Auto detect. Vendor, URL,
         and order never create a conclusion on their own; `custom` Auto still requires response-backed
         proof, and exhausting that path without one remains ambiguous.
@@ -1752,7 +1637,6 @@ class CLIProxyEngineAdapter:
                         protocol=protocol,
                         base_url=base_url,
                         secret=secret or "",
-                        owner_scoped=owner_scoped_protocol,
                     )
                 else:
                     assert oauth_auth is not None
@@ -1762,8 +1646,6 @@ class CLIProxyEngineAdapter:
                         auth=oauth_auth,
                         vendor=normalized_vendor,
                         protocol=protocol,
-                        state_store=self.state_store,
-                        credential_ref=credential_ref,
                     )
             except EngineClientError as exc:
                 failures.append(exc)
@@ -1870,15 +1752,6 @@ class CLIProxyEngineAdapter:
                 discovery=ObservationDiscovery.NOT_ATTEMPTED,
                 models=(),
             )
-        if received_rejection:
-            return make_source_observation(
-                outcome=ObservationOutcome.AUTHENTICATION_FAILED,
-                reachable=True,
-                authenticated=False,
-                protocol=None,
-                discovery=ObservationDiscovery.NOT_ATTEMPTED,
-                models=(),
-            )
         if received_proven_unknown:
             return make_source_observation(
                 outcome=ObservationOutcome.ADAPTER_ERROR,
@@ -1888,11 +1761,20 @@ class CLIProxyEngineAdapter:
                 discovery=ObservationDiscovery.NOT_ATTEMPTED,
                 models=(),
             )
-        if received_unproven_response:
+        if received_unproven_response and not considered_protocols.issubset(ruled_out_protocols):
             return make_source_observation(
                 outcome=ObservationOutcome.AMBIGUOUS,
                 reachable=True,
                 authenticated=None,
+                protocol=None,
+                discovery=ObservationDiscovery.NOT_ATTEMPTED,
+                models=(),
+            )
+        if received_rejection:
+            return make_source_observation(
+                outcome=ObservationOutcome.AUTHENTICATION_FAILED,
+                reachable=True,
+                authenticated=False,
                 protocol=None,
                 discovery=ObservationDiscovery.NOT_ATTEMPTED,
                 models=(),

--- a/vibe/model_hub_runtime/state.py
+++ b/vibe/model_hub_runtime/state.py
@@ -418,19 +418,6 @@ class EngineStateStore:
         value = payload.get("auth_name") if payload.get("kind") == "oauth" else None
         return str(value) if value else None
 
-    def read_oauth_access_token(self, credential_ref: str) -> str:
-        """Read one bound managed token for an ephemeral runtime probe pair."""
-        with self._lock:
-            name = _validated_oauth_auth_name(self.oauth_auth_name(credential_ref) or "")
-            self.audit_auth_permissions()
-            path = self.auth_dir / name
-            self._assert_private_file(path, "OAuth credential permissions are unsafe")
-            payload = self._read_json(path) or {}
-            token = payload.get("access_token")
-            if not isinstance(token, str) or not token.strip():
-                raise EngineStateError("OAuth access token is unavailable")
-            return token.strip()
-
     def oauth_credential_ref(self, auth_name: str) -> str | None:
         normalized = auth_name.strip()
         with self._lock:
@@ -445,7 +432,15 @@ class EngineStateStore:
 
     def delete_oauth_auth_file(self, auth_name: str) -> None:
         """Delete one managed OAuth file without requiring a running engine."""
-        normalized = _validated_oauth_auth_name(auth_name)
+        normalized = auth_name.strip()
+        if (
+            not normalized
+            or "\x00" in normalized
+            or "\\" in normalized
+            or Path(normalized).name != normalized
+            or not normalized.lower().endswith(".json")
+        ):
+            raise EngineStateError("invalid OAuth auth file name")
         with self._lock:
             self.audit_auth_permissions(enforce=True)
             path = self.auth_dir / normalized
@@ -581,19 +576,6 @@ class EngineStateStore:
             return
         if not stat.S_ISREG(mode) or stat.S_IMODE(mode) != 0o600:
             raise EngineStateError(message)
-
-
-def _validated_oauth_auth_name(value: str) -> str:
-    normalized = value.strip()
-    if (
-        not normalized
-        or "\x00" in normalized
-        or "\\" in normalized
-        or Path(normalized).name != normalized
-        or not normalized.lower().endswith(".json")
-    ):
-        raise EngineStateError("invalid OAuth auth file name")
-    return normalized
 
 
 def _safe_identifier(value: str) -> str:

--- a/vibe/model_hub_runtime/state.py
+++ b/vibe/model_hub_runtime/state.py
@@ -418,6 +418,19 @@ class EngineStateStore:
         value = payload.get("auth_name") if payload.get("kind") == "oauth" else None
         return str(value) if value else None
 
+    def read_oauth_access_token(self, credential_ref: str) -> str:
+        """Read one bound managed token for an ephemeral runtime probe pair."""
+        with self._lock:
+            name = _validated_oauth_auth_name(self.oauth_auth_name(credential_ref) or "")
+            self.audit_auth_permissions()
+            path = self.auth_dir / name
+            self._assert_private_file(path, "OAuth credential permissions are unsafe")
+            payload = self._read_json(path) or {}
+            token = payload.get("access_token")
+            if not isinstance(token, str) or not token.strip():
+                raise EngineStateError("OAuth access token is unavailable")
+            return token.strip()
+
     def oauth_credential_ref(self, auth_name: str) -> str | None:
         normalized = auth_name.strip()
         with self._lock:
@@ -432,15 +445,7 @@ class EngineStateStore:
 
     def delete_oauth_auth_file(self, auth_name: str) -> None:
         """Delete one managed OAuth file without requiring a running engine."""
-        normalized = auth_name.strip()
-        if (
-            not normalized
-            or "\x00" in normalized
-            or "\\" in normalized
-            or Path(normalized).name != normalized
-            or not normalized.lower().endswith(".json")
-        ):
-            raise EngineStateError("invalid OAuth auth file name")
+        normalized = _validated_oauth_auth_name(auth_name)
         with self._lock:
             self.audit_auth_permissions(enforce=True)
             path = self.auth_dir / normalized
@@ -576,6 +581,19 @@ class EngineStateStore:
             return
         if not stat.S_ISREG(mode) or stat.S_IMODE(mode) != 0o600:
             raise EngineStateError(message)
+
+
+def _validated_oauth_auth_name(value: str) -> str:
+    normalized = value.strip()
+    if (
+        not normalized
+        or "\x00" in normalized
+        or "\\" in normalized
+        or Path(normalized).name != normalized
+        or not normalized.lower().endswith(".json")
+    ):
+        raise EngineStateError("invalid OAuth auth file name")
+    return normalized
 
 
 def _safe_identifier(value: str) -> str:


### PR DESCRIPTION
## Capability

Provider observation no longer sends fabricated model IDs that can enter a relay's scheduler and fail on model capacity before discovery. All protocol probes omit `model`.

Per the owner's September 7 decision, saving configuration is separate from proving usability. The API-key form now offers **Save unverified** for a catalog-pinned or explicitly declared interface. This sends `save_unverified: true`, skips upstream observation/discovery, preserves canonical input validation, credential custody, nonce reconciliation and rollback, and persists an opaque `verification_pending` marker. Custom Auto still requires a concrete declaration before this save path is available.

Source list/detail show **Not yet verified** rather than healthy/in-use status. Every newly stored Hub credential starts pending, including observed creates and native-config imports. The configuration remains invokable; inventory refresh never verifies it. A real invocation captures the persisted marker, and any successful same-credential call with that marker may clear it inside the existing cross-process config transaction. Concurrent newer calls do not invalidate that evidence. Credential/endpoint replacement generates a new marker, including same-handle OAuth reauthentication; old calls cannot verify replacement material. Advisory clearing does not overwrite concurrent source additions or route edits. Legacy Sources retain their existing behavior.

Completed Hub OAuth consent can similarly retain its engine-bound credential under the fixed vendor protocol with verification pending. Explicit upstream credential rejection retains needs-action state. Native CLI OAuth is unchanged.

## Evidence Boundary

Schema validation can precede authentication, so missing-model errors remain unknown. Synthetic credential controls and their protected-inventory fallback have been removed: unknown grammar/checksums and collisions with another valid credential make both their rejection and acceptance inconclusive. OAuth returns to engine-held token substitution on the existing fixed allowlisted auth-index transport; no private OAuth token reader remains.

Bare 401/403 responses never reject credentials by status alone, and unknown Auto candidates are not eliminated by another protocol's rejection. Observation remains non-persisting and does not turn explicit saving into authentication evidence. The normal observation-gated create path and inventory waiver remain distinct.

## Validation

- AUTH-SETUP-112: 120 isolated HTTP/service cases across every catalog pin and concrete custom protocol, both authentication/schema orders, public/protected inventories and alphanumeric/punctuation-only credentials. No probe names a model or sends an altered credential. Unknown validation cannot authenticate; explicit saving adds no upstream requests.
- AUTH-SETUP-113: 72 bound-credential OAuth completion cases across every supported OAuth vendor/alias, both protocol families, JWT/opaque credential shapes, middleware ordering and upstream outcomes. Fixed protocol, pending verification, explicit rejection, unchanged credential files and idempotent polling are covered, including legacy `codex`.
- AUTH-SETUP-114: eight custom Auto policy-response cases preserve unknown evidence and reject undeclared unverified saving before custody work. Catalog closure includes every executable scenario ID.
- Focused unit/contract coverage includes canonical input validation, nonce reconciliation, custody rollback, discovery preserving pending state, current/stale credential settlement, successful-call consumers, and advisory persistence failure. Real spawned controller processes settle while Web holds the shared config transaction: both same-handle and new-handle replacement remain pending, while concurrent source additions, route edits and other settings survive.
- All Model Hub unit suites, auth setup, migration/configured-route scenarios and config transaction suites: **2117 passed, 1 existing xfailed**. The three stale CI contract fixtures are corrected: inventory-waiver example, complete optional-field serialization and OAuth admission policy.
- Models UI: **1280 tests passed across 82 files**. UI build, test typecheck, lint baseline, Ruff, diff checks and Model Hub authority closure passed.
- Isolated browser preview verified English/Chinese add-save-pending flows at 1280x900 and 390x844. Preview API requests were blocked and its backend proxy pointed to an unused port; the running Avibe was never contacted. Preview scaffolding and server were removed afterward.
- Historical upstream verification before authentication hardening: OpenAI Responses observation and discovery of 15 models with an existing credential, without persisting a Source. Per owner instruction, no live credential probes were repeated for these later corrections; their evidence is isolated regression testing.

## Known by Design

1. Unverified saving may retain an invalid or unreachable configuration by explicit consent; it never claims authentication or working model support. A later real call supplies evidence and normal error handling.
2. Custom Auto cannot choose an interface without evidence. Select a concrete interface to save unverified.
3. Explicit API-key saving does not fetch models. Existing refresh/manual-model workflows populate inventory afterward without changing verification status. Successful verification of one call does not promise every model or operation works.
4. Completed Hub OAuth consent retains configuration rather than discarding valid custody merely because model-free validation is inconclusive. Explicit upstream rejection remains needs-action.

## Review Circuit Breaker

Six findings-bearing heads were inspected with complete thread/comment pagination. The original repeated class is that altered-credential responses do not universally prove authentication. After independently reproducing a checksum-before-lookup false positive, the orchestrator stopped iterative control patches; the owner authorized unverified saving. That proof mechanism is removed, not randomized. The first admission-revision review exposed local-attempt identity and whole-snapshot persistence assumptions; the follow-up replaces the in-memory barrier with one persisted marker and fresh cross-process mutation, covers every create/import owner and OAuth alias, and treats verification as monotonic evidence rather than latest-attempt health. Counts remain cumulative, and subsequent reviews retain the repeated-class and three-findings-head post-rewrite breakers.

Dependencies: none. No new package or engine endpoint. Source/create contracts and English/Chinese UI copy are updated together.

Residual verification: packaged UI/local Incus acceptance is deferred. The running local Avibe installation is intentionally unchanged. Merged as a3cc88d32f992ba1a251753dd4eed5ffddcba78a after the current-head Codex pass, all 17 expected lint CI jobs succeeded, zero unresolved threads and CLEAN merge state were checked together. No local update, restart, main-checkout fast-forward or deployment was performed.
