### PR TITLE
feat(model-hub): curated vendor order and gemini preset

### DIFF
--- a/tests/test_model_hub_runtime.py
+++ b/tests/test_model_hub_runtime.py
@@ -1971,6 +1971,45 @@ def test_openai_compatibility_engine_base_url_uses_configured_api_root(
 
 
 @pytest.mark.parametrize(
+    ("official_base_url", "protocol"),
+    [
+        pytest.param(entry.official_base_url, entry.protocol, id=entry.id)
+        for entry in api_key_vendor_catalog()
+    ],
+)
+def test_catalog_official_base_url_composes_one_probe_endpoint(
+    official_base_url: str,
+    protocol: str,
+) -> None:
+    """Every shipped row probes its own API root plus exactly one endpoint.
+
+    A vendor documents its root however it likes: an origin (DeepSeek), an
+    origin plus ``/v1`` (most of them), or a versioned compatibility prefix
+    (Gemini's ``/v1beta/openai``). The protocol taxonomy states its path from
+    the origin instead, so composition has to reach the endpoint without
+    repeating a version segment or dropping part of the root — and a row whose
+    root shape nobody checked would silently probe an address the vendor 404s.
+    """
+
+    taxonomy = runtime_adapter_module._PROTOCOL_OBSERVATION_TAXONOMY[protocol]
+    composed = client_module.upstream_api_url(official_base_url, taxonomy.request_path)
+
+    # The root is carried verbatim — nothing rewritten, nothing dropped.
+    assert composed.startswith(f"{official_base_url}/")
+    # The endpoint's resource is reached: the taxonomy path past its version.
+    resource = f"/{taxonomy.request_path.strip('/').split('/', 1)[1]}"
+    assert composed.endswith(resource)
+    # And one version segment in the whole path, whichever side supplied it.
+    segments = urlsplit(composed).path.strip("/").split("/")
+    versions = [
+        segment
+        for segment in segments
+        if segment.startswith("v") and segment[1:2].isdigit()
+    ]
+    assert len(versions) == 1, composed
+
+
+@pytest.mark.parametrize(
     ("vendor", "protocol", "expected_base_url"),
     API_KEY_VENDOR_RUNTIME_CASES,
 )

--- a/ui/src/components/settings/models/AddApiKeyDialog.test.tsx
+++ b/ui/src/components/settings/models/AddApiKeyDialog.test.tsx
@@ -165,14 +165,14 @@ const vendorOptionName = (id: string) => (id === CUSTOM_VENDOR
   ? i18n.t('settings.models.addKey.field.vendor.custom')
   : apiKeyVendorPreset(id)?.label ?? id);
 
-/** The order the menu should read in: the shipped catalog A–Z by the name on the
- *  row, then the entry that is not a vendor. Derived from the file rather than
- *  listed, so a vendor added to the catalog is expected in its alphabetical
- *  place instead of wherever the file happens to put it. */
+/** The order the menu should read in: the shipped catalog verbatim, then the
+ *  entry that is not a vendor. The property is menu order == file order, so the
+ *  ranking itself is asserted nowhere — it is a product decision that belongs in
+ *  `vibe/data/api_key_vendors.json` alone, and a list restated here would make
+ *  every reordering a two-file edit while proving nothing the file cannot say.
+ *  What this does catch is the menu re-deriving an order of its own. */
 const offeredInOrder = (): string[] => [
-  ...API_KEY_VENDOR_PRESETS
-    .map((row) => row.id)
-    .sort((one, other) => vendorOptionName(one).localeCompare(vendorOptionName(other), 'en', { sensitivity: 'base' })),
+  ...API_KEY_VENDOR_PRESETS.map((row) => row.id),
   CUSTOM_VENDOR,
 ];
 
@@ -1070,8 +1070,8 @@ describe('AddApiKeyDialog · vendor', () => {
 
     await user.click(vendorField());
     const rows = await screen.findAllByRole('option');
-    // A–Z by the name on the row, with 自定义 at the bottom: it is the absence of
-    // a vendor, so it belongs after them rather than sorted among them.
+    // The catalog's own order, with 自定义 at the bottom: it is the absence of a
+    // vendor, so it belongs after them rather than ranked among them.
     const offered = offeredInOrder();
     expect(rows).toHaveLength(offered.length);
     expect(offered.map((id) => rows.indexOf(screen.getByRole('option', { name: vendorOptionName(id) }))))

--- a/ui/src/components/settings/models/AddApiKeyDialog.tsx
+++ b/ui/src/components/settings/models/AddApiKeyDialog.tsx
@@ -127,15 +127,17 @@ const ProtocolSegments: React.FC<{
 };
 
 /**
- * The 服务商 field's rows: the shipped catalog A–Z by label, then the one entry
- * that is not a vendor at all, each carrying its mark.
+ * The 服务商 field's rows: the shipped catalog in the order the file ships, then
+ * the one entry that is not a vendor at all, each carrying its mark.
  *
- * A–Z because the file's order is the backend's business — whatever it means
- * there, on screen it reads as arbitrary, and a name is what a user scans for.
- * The comparison is base-sensitivity English so case and accents do not split
- * the alphabet. 自定义 sorts nowhere: it is the absence of a vendor, so it sits
- * at the end of the vendors rather than inside them, while staying the value the
- * field opens on.
+ * File order because that order is a curated ranking, not an accident of how the
+ * rows were appended: the vendors most users are here to add sit at the top, and
+ * a name is only what you scan for once the list is long enough to have lost you.
+ * Re-sorting here would put the ranking in a second place and make the catalog's
+ * own order unobservable — so this reads the file verbatim, and moving a vendor
+ * up the list is an edit to `vibe/data/api_key_vendors.json` and to nothing else.
+ * 自定义 ranks nowhere: it is the absence of a vendor, so it sits after all of
+ * them rather than inside them, while staying the value the field opens on.
  *
  * The mark is why the field is no longer a `<select>`. A vendor is recognised by
  * its logo long before its name is read, and an `<option>` holds text only — so
@@ -148,9 +150,7 @@ const ProtocolSegments: React.FC<{
 const useVendorOptions = (): ComboboxOption[] => {
   const { t } = useTranslation();
   return React.useMemo(() => ([
-    ...API_KEY_VENDOR_PRESETS
-      .map((preset) => ({ value: preset.id, label: preset.label }))
-      .sort((one, other) => one.label.localeCompare(other.label, 'en', { sensitivity: 'base' })),
+    ...API_KEY_VENDOR_PRESETS.map((preset) => ({ value: preset.id, label: preset.label })),
     { value: CUSTOM_VENDOR, label: t('settings.models.addKey.field.vendor.custom') },
   ].map((option) => ({ ...option, icon: <VendorGlyph vendor={option.value} /> }))), [t]);
 };

--- a/ui/src/components/settings/models/vendorMarks.ts
+++ b/ui/src/components/settings/models/vendorMarks.ts
@@ -85,6 +85,13 @@ export const VENDOR_MARKS: Record<string, VendorMark | undefined> = {
     path: 'M17.143 3.429v3.428h-3.429v3.429h-3.428V6.857H6.857V3.43H3.43v13.714H0v3.428h10.286v-3.428H6.857v-3.429h3.429v3.429h3.429v-3.429h3.428v3.429h-3.428v3.428H24v-3.428h-3.43V3.429z',
     ink: [0, 3.43, 24, 17.14],
   },
+  // The four-pointed spark, whose tips ARE the corners of the box it was
+  // authored in — so its recorded ink is the whole 24 units, and the rule scales
+  // it down to the same 19 of ink every other mark shows.
+  gemini: {
+    path: 'M11.04 19.32Q12 21.51 12 24q0-2.49.93-4.68.96-2.19 2.58-3.81t3.81-2.55Q21.51 12 24 12q-2.49 0-4.68-.93a12.3 12.3 0 0 1-3.81-2.58 12.3 12.3 0 0 1-2.58-3.81Q12 2.49 12 0q0 2.49-.96 4.68-.93 2.19-2.55 3.81a12.3 12.3 0 0 1-3.81 2.58Q2.49 12 0 12q2.49 0 4.68.96 2.19.93 3.81 2.55t2.55 3.81',
+    ink: [0, 0, 24, 24],
+  },
   openai: OPENAI_MARK,
   anthropic: ANTHROPIC_MARK,
 };

--- a/vibe/data/api_key_vendors.json
+++ b/vibe/data/api_key_vendors.json
@@ -1,5 +1,29 @@
 [
   {
+    "id": "openai",
+    "label": "OpenAI",
+    "official_base_url": "https://api.openai.com/v1",
+    "protocol": "openai_responses"
+  },
+  {
+    "id": "anthropic",
+    "label": "Anthropic",
+    "official_base_url": "https://api.anthropic.com",
+    "protocol": "anthropic"
+  },
+  {
+    "id": "xai",
+    "label": "xAI",
+    "official_base_url": "https://api.x.ai/v1",
+    "protocol": "openai_chat"
+  },
+  {
+    "id": "gemini",
+    "label": "Gemini",
+    "official_base_url": "https://generativelanguage.googleapis.com/v1beta/openai",
+    "protocol": "openai_chat"
+  },
+  {
     "id": "deepseek",
     "label": "DeepSeek",
     "official_base_url": "https://api.deepseek.com",
@@ -18,33 +42,15 @@
     "protocol": "openai_chat"
   },
   {
-    "id": "zhipuai",
-    "label": "Zhipu AI",
-    "official_base_url": "https://open.bigmodel.cn/api/paas/v4",
-    "protocol": "openai_chat"
-  },
-  {
-    "id": "openai",
-    "label": "OpenAI",
-    "official_base_url": "https://api.openai.com/v1",
-    "protocol": "openai_responses"
-  },
-  {
-    "id": "anthropic",
-    "label": "Anthropic",
-    "official_base_url": "https://api.anthropic.com",
-    "protocol": "anthropic"
-  },
-  {
     "id": "openrouter",
     "label": "OpenRouter",
     "official_base_url": "https://openrouter.ai/api/v1",
     "protocol": "openai_chat"
   },
   {
-    "id": "groq",
-    "label": "Groq",
-    "official_base_url": "https://api.groq.com/openai/v1",
+    "id": "zhipuai",
+    "label": "Zhipu AI",
+    "official_base_url": "https://open.bigmodel.cn/api/paas/v4",
     "protocol": "openai_chat"
   },
   {
@@ -54,9 +60,9 @@
     "protocol": "openai_chat"
   },
   {
-    "id": "xai",
-    "label": "xAI",
-    "official_base_url": "https://api.x.ai/v1",
+    "id": "groq",
+    "label": "Groq",
+    "official_base_url": "https://api.groq.com/openai/v1",
     "protocol": "openai_chat"
   },
   {


### PR DESCRIPTION
## What changes

The 服务商 picker sorted the shipped catalog A–Z on screen, which made the order
of `vibe/data/api_key_vendors.json` unobservable: whatever the file said, the
menu re-derived its own list. This makes the file the single order authority and
ranks it for the people using it, and adds Gemini as a catalog row.

- **Curated order.** `vibe/data/api_key_vendors.json` is reordered to
  `openai, anthropic, xai, gemini, deepseek, qwen, kimi, openrouter, zhipuai,
  mistral, groq, together, fireworks`. The dialog renders that order verbatim —
  the `localeCompare` sort is gone, and the docblock that argued for A–Z is
  rewritten to say why file order is the ranking. 自定义 · 兼容端点 still sits
  last and is still the value the field opens on. Labels are untouched (xAI
  stays "xAI").
- **Gemini preset.** One new row: id `gemini`, label `Gemini`, protocol pinned to
  `openai_chat`, official base URL
  `https://generativelanguage.googleapis.com/v1beta/openai` — Google's
  OpenAI-compatible root. Its monochrome mark (the four-pointed spark, Simple
  Icons `googlegemini`) joins `vendorMarks.ts` on the same optical grid as
  #1857.
- **The order test becomes a property.** `menu order == catalog file order, then
  custom`, read from the imported JSON. The ranking itself is asserted nowhere,
  so moving a vendor stays a one-file edit; what the test catches is the menu
  re-deriving an order of its own.

## Composed-URL proof

The one thing that could have gone wrong: `upstream_api_url(root, request_path)`
composes the probe address, and Google's root already carries a path while every
taxonomy request path starts at the origin (`/v1/chat/completions`). Reading
`vibe/model_hub_runtime/client.py`: when the normalized root has any path, the
request path's `/v1` prefix is dropped before appending. So the pathed root is
carried verbatim and the endpoint is appended once.

Run against the real function, every shipped row, in file order:

| vendor | protocol | composed probe URL |
| --- | --- | --- |
| openai | openai_responses | `https://api.openai.com/v1/responses` |
| anthropic | anthropic | `https://api.anthropic.com/v1/messages` |
| xai | openai_chat | `https://api.x.ai/v1/chat/completions` |
| **gemini** | **openai_chat** | **`https://generativelanguage.googleapis.com/v1beta/openai/chat/completions`** |
| deepseek | openai_chat | `https://api.deepseek.com/v1/chat/completions` |
| qwen | openai_chat | `https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions` |
| kimi | openai_chat | `https://api.moonshot.cn/v1/chat/completions` |
| openrouter | openai_chat | `https://openrouter.ai/api/v1/chat/completions` |
| zhipuai | openai_chat | `https://open.bigmodel.cn/api/paas/v4/chat/completions` |
| mistral | openai_chat | `https://api.mistral.ai/v1/chat/completions` |
| groq | openai_chat | `https://api.groq.com/openai/v1/chat/completions` |
| together | openai_chat | `https://api.together.xyz/v1/chat/completions` |
| fireworks | openai_chat | `https://api.fireworks.ai/inference/v1/chat/completions` |

That is exactly the required address, and no existing row moved. The models
listing composes the same way:
`upstream_api_url(gemini_root, "/v1/models")` →
`https://generativelanguage.googleapis.com/v1beta/openai/models`.

**No engine change was needed**, so none is in this PR.

The stored base string is the no-trailing-slash form.
`normalize_model_hub_base_url` maps `.../v1beta/openai/` and `.../v1beta/openai`
to the same value, so composition is identical either way; storing the
already-normalized form keeps the raw JSON the UI reads byte-identical to the
value the Python loader produces.

### The proof is now a test, not a one-off run

`test_catalog_official_base_url_composes_one_probe_endpoint` is parametrized over
every catalog row and holds three properties on the composed URL: the root is
carried verbatim, the endpoint's resource is reached, and exactly one version
segment survives. Mutation-checked — reverting the `/v1` handling in
`upstream_api_url` to a plain append fails 11 of the 13 rows (the two that still
pass are the origin-only roots, where that mutation is a no-op).

### Live keyless probe (orchestrator, avibe-test VM)

The brief asked for a keyless `curl` to the composed URL as live evidence. The
implementation lane could not reach the host from its machine: DNS resolved
(`generativelanguage.googleapis.com` → `172.217.116.4`), a control request in the
same shell succeeded (`https://api.github.com/zen` → 200), and the target timed
out at connect (`curl: (28)`, `http_code 000`). Fetching it through the agent's
own fetch tool was refused by domain verification. That lane did not claim a
probe it did not get.

The orchestrator then ran the probe from the cloud avibe-test VM (deployment
egress, not the lane machine):

1. **Composed URL is live.** `POST https://generativelanguage.googleapis.com/v1beta/openai/chat/completions`
   (keyless, `Bearer fake`) → HTTP **400**, JSON
   `[{"error":{"code":400,"message":"Please pass a valid API key","status":"INVALID_ARGUMENT"}}]`.
   The endpoint parses the request; composition is correct; no engine change is
   needed. This matches the function-level table above.
2. **The path is permissive.** Even
   `https://generativelanguage.googleapis.com/v1beta/openai/v1/chat/completions`
   answers 400 (no 404), so a doubled `/v1` would still land on a live resource.
   Composition risk on this vendor is nil either way.

Google's own documented request posts to the same composed URL
([OpenAI compatibility, Gemini API docs](https://ai.google.dev/gemini-api/docs/openai),
[Gemini is now accessible from the OpenAI Library](https://developers.googleblog.com/en/gemini-is-now-accessible-from-the-openai-library/)).

## Evidence

- **Live probe** — orchestrator-run from the cloud avibe-test VM, as above: the
  composed URL returns 400 JSON (not 404); a doubled-`/v1` variant also returns
  400. Not re-run from this lane.
- **Backend, catalog-seeded** — `pytest tests/test_model_hub_runtime.py -k "vendor
  or catalog"` 47 passed; `pytest tests/test_model_hub_api.py
  tests/test_model_hub_l3.py -k "vendor or catalog"` 111 passed. These
  parametrize over every row, so the `gemini` row passes admission, label,
  protocol-pin, official-URL and engine-config properties on the same terms as
  the twelve that shipped before it.
- **Authority closure** — `scripts/check_model_hub_authorities.py` clean.
- **UI** — `vitest run src/components/settings/models` 80 files / 1202 tests
  passed (includes the rewritten order test, the vendor catalog properties, and
  the glyph properties). `npm run build` and `npm run lint` clean. `ruff check`
  clean on the changed test file.
- **Glyph geometry** — the new ink `[0, 0, 24, 24]` is a real `getBBox()`
  measurement in Chromium, the method `vendorMarks.ts` documents. The same run
  re-measured all seven inks already recorded there and reproduced every one,
  so the number is from a validated measurement rather than an eyeballed guess.
  The Gemini spark's four tips are the corners of its authoring box, so the rule
  scales it to the same 19-unit ink height as every other mark. `vendorGlyph`'s
  properties (drawn at all, one shape, centred, never two choices drawing the
  same art) are held over the catalog, so the new row is covered without a test
  edit — and the letter-fallback count in that file's comment is still five
  (xai, zhipuai, groq, together, fireworks).
- **e2e** — no change needed, and that is a property of how those specs are
  written, not luck. `ui/e2e/support/vendors.ts` reads the same tracked file, and
  `b-add-api-key.spec.ts` B1 picks `CATALOG_VENDORS[0]` **by its label** and
  points the address at the mock. The reorder changes which row B1 exercises
  (deepseek → openai, so `openai_responses` instead of `openai_chat`); the mock
  serves all three interfaces and B0 covers each one separately, so the case
  still proves what it was written to prove. No spec assumed A–Z.

## Known by design

- **The picker's order is not sorted, and that is the point.** A reviewer
  reaching for "the list should be alphabetical" is reaching for the behavior
  this PR removes. The ranking is owner-ratified and lives in
  `vibe/data/api_key_vendors.json`; the dialog and its test both read it.
- **Gemini's OpenAI-compatible endpoint returns HTTP 400, not 401, for a missing
  or invalid key**, and wraps the error in a JSON **array**
  (`[{"error":{"code":400,"message":"Please pass a valid API key","status":"INVALID_ARGUMENT"}}]`).
  Under the catalog-pin ladder (2xx / 400 / 404 / 422 → accepted), a wrong
  Gemini key therefore passes 检测 as authenticated and then fails discovery —
  the user lands in ⑤「已识别、清单拿不到」 instead of ③「鉴权失败」. Data
  integrity is safe (discovery fails; only 仍要添加 could persist an
  empty-inventory source), but the copy is imprecise for Gemini specifically.
  Recorded, not patched. A vendor-scoped auth-status hint (`gemini`: 400 +
  `INVALID_ARGUMENT` ⇒ rejected) is a possible follow-up, not this PR.
- **`docs/plans/model-hub-vendor-preset-protocol.md` still says "Gemini native is
  deferred (not in the three-protocol vocabulary)" and its first-wave table has
  no `gemini` row.** Both remain accurate as written: this PR adds Gemini through
  its OpenAI-compatible endpoint pinned to `openai_chat`, not a fourth native
  protocol, and that document is the first-wave design record — the shipped JSON
  is the live authority, as that document itself states. I did not rewrite a
  landed plan to describe later work; flagging it instead.
- **`docs/plans/model-hub-ui-spec.md` §服务商 says "自定义 · 兼容端点 first, then
  one option per shipped catalog row in file order".** This PR restores the
  second clause. The first clause went stale at #1857, which moved 自定义 to the
  end while keeping it the default; the brief for this change re-ratifies that
  placement. Reported, not edited.
- **`vendorMeta.ts` carries a second, five-vendor `OFFICIAL_BASE_URLS` map** used
  only by `officialVendorForEndpoint` / `isCustomEndpoint` (the 兼容端点 badge).
  It does not know `gemini` — nor deepseek, qwen, openrouter, groq, mistral,
  together or fireworks, so the new row inherits exactly the behavior 7 of the 12
  existing rows already have. Not a regression from this change, and collapsing
  that duplicate into the catalog is a separate change with its own display
  consequences. Reported, not fixed.

## Scope

`vibe/data/api_key_vendors.json`, four files under
`ui/src/components/settings/models/`, and one added test in
`tests/test_model_hub_runtime.py`. No engine semantics touched, no dependency
added, no i18n key added (the row's label comes from the catalog).
