### PR TITLE
fix(show-pages): always inject page guidance

### DIFF
--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -1275,7 +1275,6 @@ def _reset_recoverable_config_section(
         "include_time_info",
         "include_user_info",
         "reply_enhancements",
-        "show_pages_prompt",
         "setup_completed",
     }:
         payload[section] = {
@@ -1283,7 +1282,6 @@ def _reset_recoverable_config_section(
             "include_time_info": True,
             "include_user_info": True,
             "reply_enhancements": True,
-            "show_pages_prompt": True,
             "setup_completed": False,
         }[section]
         return True
@@ -3861,7 +3859,6 @@ class V2Config:
     include_time_info: bool = True  # Prepend current local time to agent messages
     include_user_info: bool = True  # Prepend user identity to agent messages
     reply_enhancements: bool = True  # Enable quick-reply buttons
-    show_pages_prompt: bool = True  # Inject Show Pages capability guidance into agent prompts
     language: str = "en"  # Global language setting (see vibe/i18n)
     # Progress UX for editing platforms (Slack/Discord):
     #   "off" (default) no process bubble, "concise" one self-updating bubble,
@@ -4310,7 +4307,6 @@ class V2Config:
         include_user_info = _declared_bool("include_user_info", True)
         include_time_info = _declared_bool("include_time_info", True)
         reply_enhancements = _declared_bool("reply_enhancements", True)
-        show_pages_prompt = _declared_bool("show_pages_prompt", True)
 
         language = normalize_language(payload.get("language"), default="en")
 
@@ -4367,7 +4363,6 @@ class V2Config:
             include_time_info=include_time_info,
             include_user_info=include_user_info,
             reply_enhancements=reply_enhancements,
-            show_pages_prompt=show_pages_prompt,
             language=language,
             agent_progress_style=agent_progress_style,
             agent_status_heartbeat_ms=agent_status_heartbeat_ms,
@@ -4475,7 +4470,6 @@ class V2Config:
             "include_time_info": self.include_time_info,
             "include_user_info": self.include_user_info,
             "reply_enhancements": self.reply_enhancements,
-            "show_pages_prompt": self.show_pages_prompt,
             "language": self.language,
             "agent_progress_style": self.agent_progress_style,
             "agent_status_heartbeat_ms": self.agent_status_heartbeat_ms,

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -1764,7 +1764,6 @@ class SessionHandler(BaseHandler):
         system_prompt_injection = await asyncio.to_thread(
             build_system_prompt_injection,
             include_quick_replies=quick_replies_on and platform != "wechat",
-            include_show_pages=getattr(self.config, "show_pages_prompt", True),
             memory_enabled=bool(getattr(getattr(self.config, "memory", None), "enabled", False)),
             context=context,
             fallback_platform=platform,

--- a/core/system_prompt_injection.py
+++ b/core/system_prompt_injection.py
@@ -192,7 +192,6 @@ def _context_block(
 def build_system_prompt_blocks(
     *,
     include_quick_replies: bool = True,
-    include_show_pages: bool = True,
     include_codex_generated_images: bool = False,
     include_context_guidance: bool = True,
     memory_enabled: bool = False,
@@ -214,8 +213,6 @@ def build_system_prompt_blocks(
             project_base=skills_project_base,
             claude_cli_path=skills_claude_cli_path,
         )
-        if not include_show_pages:
-            skills = [skill for skill in skills if skill.name != "use-show-pages"]
 
     advertisable_skills = [] if skills is None else [skill for skill in skills if not skill.disable_model_invocation]
     vault_skill_available = any(
@@ -234,8 +231,7 @@ def build_system_prompt_blocks(
     blocks.append(render_prompt_block("base-capabilities-body"))
     if include_codex_generated_images:
         blocks.append(_codex_generated_images_block())
-    if include_show_pages and context is not None:
-        blocks.append(render_prompt_block("show-pages-prompt"))
+    blocks.append(render_prompt_block("show-pages-prompt"))
     if include_quick_replies:
         blocks.append(render_prompt_block("quick-replies-prompt"))
     if vault_skill_available:

--- a/docs/plans/show-page.md
+++ b/docs/plans/show-page.md
@@ -229,9 +229,10 @@ The prompt should mention useful reference libraries without limiting the
 agent: native HTML/CSS/JavaScript, Excalidraw-style static SVG/PNG diagrams,
 React Flow, Mermaid, Markmap, Chart.js, and Cytoscape.js.
 
-The Web UI setting `show_pages_prompt` controls this prompt section only. It
-does not disable `vibe show`, the local workspace, private serving, or public
-sharing.
+Show Page guidance is always included in the shared system prompt for every
+agent backend. There is no configuration toggle or Web UI setting for it;
+legacy configurations containing `show_pages_prompt` are accepted and the
+retired field is ignored and omitted on the next save.
 
 ## State Model
 

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -2523,7 +2523,6 @@ class CodexAgent(BaseAgent):
                 build_system_prompt_injection,
                 include_quick_replies=getattr(self.controller.config, "reply_enhancements", True)
                 and platform != "wechat",
-                include_show_pages=getattr(self.controller.config, "show_pages_prompt", True),
                 include_codex_generated_images=True,
                 memory_enabled=bool(
                     getattr(getattr(self.controller.config, "memory", None), "enabled", False)

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -1559,7 +1559,6 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                 build_system_prompt_injection,
                 include_quick_replies=getattr(self.controller.config, "reply_enhancements", True)
                 and platform != "wechat",
-                include_show_pages=getattr(self.controller.config, "show_pages_prompt", True),
                 memory_enabled=bool(
                     getattr(getattr(self.controller.config, "memory", None), "enabled", False)
                 ),

--- a/tests/test_agent_steering.py
+++ b/tests/test_agent_steering.py
@@ -1052,7 +1052,6 @@ async def test_opencode_coordinator_error_aborts_through_steering_owner(
         config=SimpleNamespace(
             platform="avibe",
             reply_enhancements=False,
-            show_pages_prompt=False,
             remote_access=None,
             language="en",
             opencode=SimpleNamespace(
@@ -1232,7 +1231,6 @@ async def test_opencode_definitive_start_rejection_reconciles_before_poll_cleanu
         config=SimpleNamespace(
             platform="avibe",
             reply_enhancements=False,
-            show_pages_prompt=False,
             remote_access=None,
             language="en",
             opencode=SimpleNamespace(
@@ -1364,7 +1362,6 @@ async def test_opencode_ambiguous_start_failure_preserves_recovery_poll(
         config=SimpleNamespace(
             platform="avibe",
             reply_enhancements=False,
-            show_pages_prompt=False,
             remote_access=None,
             language="en",
             opencode=SimpleNamespace(

--- a/tests/test_api_save_config_merge.py
+++ b/tests/test_api_save_config_merge.py
@@ -97,7 +97,6 @@ def _full_config_payload() -> dict:
         "include_time_info": True,
         "include_user_info": True,
         "reply_enhancements": True,
-        "show_pages_prompt": True,
         "language": "en",
     }
 
@@ -561,18 +560,19 @@ def test_config_payload_default_instance_name_ignores_malformed_remote_url(monke
     assert payload["ui"]["default_instance_name"] == "macbook"
 
 
-def test_save_config_preserves_show_pages_prompt_toggle(monkeypatch, tmp_path, sqlite_schema_db_factory):
+@pytest.mark.parametrize("legacy_value", [False, True])
+def test_save_config_discards_retired_show_pages_prompt(monkeypatch, tmp_path, sqlite_schema_db_factory, legacy_value):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     sqlite_schema_db_factory(tmp_path / "state" / "vibe.sqlite")
 
-    created = api.save_config(_full_config_payload())
-    assert created.show_pages_prompt is True
+    api.save_config(_full_config_payload())
 
-    updated = api.save_config({"show_pages_prompt": False})
+    updated = api.save_config({"show_pages_prompt": legacy_value})
     payload = api.config_to_payload(updated)
 
-    assert updated.show_pages_prompt is False
-    assert payload["show_pages_prompt"] is False
+    assert not hasattr(updated, "show_pages_prompt")
+    assert "show_pages_prompt" not in payload
+    assert "show_pages_prompt" not in json.loads((tmp_path / "config" / "config.json").read_text())
 
 
 def test_save_config_preserves_status_bubble_settings_on_partial_save(monkeypatch, tmp_path, sqlite_schema_db_factory):
@@ -662,13 +662,18 @@ def test_show_page_api_timeout_rejects_values_that_do_not_name_a_deadline(value)
         V2Config.from_payload(payload)
 
 
-def test_config_load_defaults_missing_show_pages_prompt_to_enabled():
+@pytest.mark.parametrize("legacy_fields", [{}, {"show_pages_prompt": False}, {"show_pages_prompt": True}])
+def test_config_load_ignores_retired_show_pages_prompt(tmp_path, legacy_fields):
     payload = _full_config_payload()
-    payload.pop("show_pages_prompt")
+    payload.update(legacy_fields)
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(payload), encoding="utf-8")
 
-    created = V2Config.from_payload(payload)
+    created = V2Config.load(config_path)
 
-    assert created.show_pages_prompt is True
+    assert created.load_warnings == ()
+    assert not hasattr(created, "show_pages_prompt")
+    assert api.config_to_payload(created) == api.config_to_payload(V2Config.from_payload(_full_config_payload()))
 
 
 def test_config_load_preserves_pre_upgrade_audio_asr_false_as_opt_out():
@@ -1438,9 +1443,7 @@ def _settings_write_paths() -> list[tuple[str, ...]]:
             paths += [("audio_asr", sub) for sub in sorted(api._EDITOR_AUDIO_ASR_WRITE_FIELDS)]
         else:
             paths.append((key,))
-    # ``show_pages_prompt`` is Owner-only, so it is absent from the Editor
-    # allowlist while sharing the same validation block.
-    return [*paths, ("show_pages_prompt",)]
+    return paths
 
 
 def _nested_patch(path: tuple[str, ...], value: object) -> dict:
@@ -1574,6 +1577,9 @@ def test_wrong_typed_settings_on_disk_degrade_instead_of_failing_the_load(tmp_pa
                     path[0]
                 ]
             ), label
+        assert {key: value for key, value in recovered.items() if key != path[0]} == {
+            key: value for key, value in healthy.items() if key != path[0]
+        }, label
 
     # A number that names no setting reaches the file by a route none of the
     # shapes above take. ``json`` reads a hand-edited ``1e309`` and the
@@ -1610,16 +1616,12 @@ def test_wrong_typed_settings_on_disk_degrade_instead_of_failing_the_load(tmp_pa
             config = V2Config.load(config_path)
 
             assert any(path[0] in warning for warning in config.load_warnings), (label, number)
-            assert (
-                api.config_to_payload(config, include_secrets=True, include_internal=True)
-                == like_any_other
-            ), (label, number)
-        # Everything outside the corrupted section survives. Without this the
-        # test would pass just as well for a recovery that threw the whole file
-        # away, which for a scalar looks identical to repairing that scalar.
-        assert {key: value for key, value in recovered.items() if key != path[0]} == {
-            key: value for key, value in healthy.items() if key != path[0]
-        }, label
+            recovered = api.config_to_payload(config, include_secrets=True, include_internal=True)
+            assert recovered == like_any_other, (label, number)
+            # Every recovery preserves all sections outside the corrupted one.
+            assert {key: value for key, value in recovered.items() if key != path[0]} == {
+                key: value for key, value in healthy.items() if key != path[0]
+            }, (label, number)
 
 
 def test_unreadable_optional_feature_fields_never_load_the_feature_back_on(tmp_path, monkeypatch):
@@ -1843,7 +1845,6 @@ def test_editor_config_write_payload_keeps_messaging_fields_only():
         {"ui": {"setup_host": "0.0.0.0"}},
         {"ui": {"instance_name": "renamed"}},
         {"ui": {"default_instance_name": "owned"}},
-        {"show_pages_prompt": False},
     ],
 )
 def test_editor_config_write_payload_rejects_owner_fields(payload):

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -629,7 +629,7 @@ def test_session_handler_preserves_passed_agent_system_prompt(monkeypatch, tmp_p
     assert "Use the release-reviewer Vibe Agent policy." in prompt
 
 
-def test_session_handler_omits_show_pages_prompt_when_disabled(
+def test_session_handler_includes_show_pages_despite_legacy_opt_out(
     monkeypatch, tmp_path: Path
 ) -> None:
     captured: dict[str, Any] = {}
@@ -656,7 +656,8 @@ def test_session_handler_omits_show_pages_prompt_when_disabled(
     assert captured["connected"] is True
     assert "# Avibe" in prompt
     assert "Current session id: `sesk8m4q2p7x`" in prompt
-    assert "## Show Pages" not in prompt
+    assert "## Show Pages" in prompt
+    assert "load the `use-show-pages` Skill" in prompt
     assert "vibe show path" not in prompt
 
 

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -1969,7 +1969,7 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
             developer_instructions,
         )
 
-    async def test_start_thread_omits_show_pages_prompt_when_disabled(self):
+    async def test_start_thread_includes_show_pages_despite_legacy_opt_out(self):
         agent = object.__new__(CodexAgent)
         agent.controller = SimpleNamespace(
             config=SimpleNamespace(platform="slack", reply_enhancements=True, show_pages_prompt=False)
@@ -2003,7 +2003,8 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("# Avibe", developer_instructions)
         self.assertIn("## Quick-reply buttons", developer_instructions)
         self.assertIn("Current session id: `sesk8m4q2p7x`", developer_instructions)
-        self.assertNotIn("## Show Pages", developer_instructions)
+        self.assertIn("## Show Pages", developer_instructions)
+        self.assertIn("load the `use-show-pages` Skill", developer_instructions)
         self.assertNotIn("vibe show path", developer_instructions)
 
     async def test_resume_thread_refreshes_developer_instructions_without_appending(self):

--- a/tests/test_multi_platform_runtime.py
+++ b/tests/test_multi_platform_runtime.py
@@ -956,7 +956,6 @@ def test_opencode_prompt_disables_question_tool_for_all_platforms(monkeypatch):
                 {
                     "platform": "avibe",
                     "reply_enhancements": True,
-                    "show_pages_prompt": True,
                     "remote_access": None,
                     "language": "en",
                     "memory": type("MemoryConfig", (), {"enabled": True})(),
@@ -1360,7 +1359,6 @@ def test_opencode_fork_prompt_marks_target_session_id_authoritative():
                 {
                     "platform": "avibe",
                     "reply_enhancements": True,
-                    "show_pages_prompt": True,
                     "remote_access": None,
                     "language": "en",
                     "opencode": type(
@@ -1558,7 +1556,6 @@ def test_opencode_process_message_removes_active_poll_when_question_tool_aborts(
                 {
                     "platform": "slack",
                     "reply_enhancements": True,
-                    "show_pages_prompt": True,
                     "remote_access": None,
                     "language": "en",
                 },

--- a/tests/test_prompt_render_export.py
+++ b/tests/test_prompt_render_export.py
@@ -138,7 +138,6 @@ def test_working_principles_remain_without_session_skills_or_optional_capabiliti
         "backend": backend,
         "options": {
             "include_quick_replies": False,
-            "include_show_pages": False,
             "include_codex_generated_images": False,
             "include_context_guidance": False,
         },
@@ -148,7 +147,7 @@ def test_working_principles_remain_without_session_skills_or_optional_capabiliti
     if backend == "codex":
         blocks = blocks[1:-1]
     assert [block["id"] for block in blocks] == [
-        "base-capabilities-intro", "agent-working-principles", "base-capabilities-body",
+        "base-capabilities-intro", "agent-working-principles", "base-capabilities-body", "show-pages-prompt",
     ]
     assert blocks[1]["text"] == prompt_text("agent-working-principles")
     assert rendered == render_prompt_context(request)
@@ -287,7 +286,7 @@ def test_debug_cli_rejects_invalid_context_without_partial_json(tmp_path, capsys
     ({"context": {"user_id": "u", "channel_id": "c", "unknown": 1}}, "options.context.unknown", "unknownField"),
     ({"context": {"user_id": "u"}}, "options.context.channel_id", "invalidField"),
     ({"memory_enabled": "false"}, "options.memory_enabled", "invalidField"),
-    ({"include_show_pages": []}, "options.include_show_pages", "invalidField"),
+    ({"include_show_pages": False}, "options.include_show_pages", "unknownField"),
     ({"enabled_agents": 123}, "options.enabled_agents", "invalidField"),
     ({"unknown": True}, "options.unknown", "unknownField"),
 ])

--- a/tests/test_reply_enhancer_platform.py
+++ b/tests/test_reply_enhancer_platform.py
@@ -229,7 +229,7 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("load the `use-avibe-harness` Skill", prompt)
         self.assertNotIn("No enabled Agents", prompt)
 
-    def test_prompt_can_exclude_show_pages(self):
+    def test_show_pages_remain_when_quick_replies_are_disabled(self):
         context = MessageContext(
             user_id="U1",
             channel_id="C1",
@@ -242,13 +242,13 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
             patch("core.managed_skills.resolve_skills", return_value=_resolved_core_skills()),
         ):
             prompt = build_system_prompt_injection(
-                include_show_pages=False,
                 include_quick_replies=False,
                 context=context,
                 skills_cwd=Path("/tmp/project"),
             )
 
-        self.assertNotIn("## Show Pages", prompt)
+        self.assertIn("## Show Pages", prompt)
+        self.assertNotIn("## Quick-reply buttons", prompt)
         self.assertIn("## Harness", prompt)
         self.assertNotIn("## Scheduled tasks, watches, and hooks", prompt)
         self.assertIn("Current session id: `sesk8m4q2p7x`", prompt)
@@ -1980,7 +1980,7 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("injects the current Cloud-availability guidance", skill)
         self.assertNotIn("Avibe Cloud is not connected", skill)
 
-    def test_disabled_show_pages_are_not_advertised_through_the_skill_catalog(self):
+    def test_show_pages_guidance_and_skill_catalog_are_advertised_together(self):
         context = MessageContext(
             user_id="U1",
             channel_id="C1",
@@ -2007,14 +2007,13 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
             patch("core.managed_skills.resolve_skills", return_value=skills),
         ):
             prompt = build_system_prompt_injection(
-                include_show_pages=False,
                 include_quick_replies=False,
                 context=context,
                 skills_cwd=Path("/tmp/project"),
             )
 
-        self.assertNotIn("load the `use-show-pages` Skill", prompt)
-        self.assertNotIn("- use-show-pages:", prompt)
+        self.assertIn("load the `use-show-pages` Skill", prompt)
+        self.assertIn("- use-show-pages:", prompt)
         self.assertIn("- use-avibe-vault:", prompt)
 
     def test_required_skill_routes_remain_when_catalog_entries_are_manual_only(self):

--- a/ui/src/components/settings/SettingsMessagingPage.test.tsx
+++ b/ui/src/components/settings/SettingsMessagingPage.test.tsx
@@ -43,7 +43,6 @@ const baseConfig = {
   include_time_info: true,
   include_user_info: false,
   reply_enhancements: true,
-  show_pages_prompt: true,
   agent_progress_style: 'off',
   audio_asr: { enabled: true, echo_transcript: true, enabled_configured: true },
   remote_access: { vibe_cloud: { paired: true } },
@@ -164,7 +163,7 @@ describe('SettingsMessagingPage locality gating', () => {
 
     expect(await screen.findByText('dashboard.errorRetryLimit')).toBeTruthy();
     expect(screen.getByText('dashboard.opencodeActiveTurnTimeout')).toBeTruthy();
-    expect(screen.getByText('dashboard.showPagesPrompt')).toBeTruthy();
+    expect(screen.queryByText('dashboard.showPagesPrompt')).toBeNull();
   });
 
   it('keeps owner-only runtime messaging controls hidden from an Editor', async () => {

--- a/ui/src/components/settings/SettingsMessagingPage.tsx
+++ b/ui/src/components/settings/SettingsMessagingPage.tsx
@@ -476,26 +476,6 @@ export const SettingsMessagingPage: React.FC = () => {
             />
           }
         />
-        {canShowProtectedMessagingControl('show_pages_prompt') && (
-          <SettingsRow
-            title={t('dashboard.showPagesPrompt')}
-            description={t('dashboard.showPagesPromptHint')}
-            control={
-              <ToggleSwitch
-                enabled={config.show_pages_prompt !== false}
-                onClick={() =>
-                  void persist(
-                    {
-                      ...config,
-                      show_pages_prompt: !(config.show_pages_prompt !== false),
-                    },
-                    { show_pages_prompt: !(config.show_pages_prompt !== false) },
-                  )
-                }
-              />
-            }
-          />
-        )}
         {/* ``slack.*`` is outside the Editor write allowlist, so this control
             is only offered to roles that may manage the instance — a remote
             Owner included, which is why it carries its own field patch. */}

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -3222,8 +3222,6 @@
     "includeUserInfoHint": "Prepend [username<user_id>] to messages sent to agents",
     "replyEnhancements": "Quick-reply Buttons",
     "replyEnhancementsHint": "Allow agents to add clickable quick-reply buttons at the end of result messages",
-    "showPagesPrompt": "Show Page Guidance",
-    "showPagesPromptHint": "Tell agents when and how to use visual Show Pages. The vibe show CLI remains available when this is off.",
     "agentProgressStyle": "Progress display (Slack/Discord/Lark)",
     "agentProgressStyleHint": "How agent progress is shown: off, a single concise status bubble that becomes the result, or the verbose process log.",
     "agentProgressStyleConcise": "Concise",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -3222,8 +3222,6 @@
     "includeUserInfoHint": "在发给 Agent 的消息前添加 [用户名<用户ID>]",
     "replyEnhancements": "快捷回复按钮",
     "replyEnhancementsHint": "允许 Agent 在结果消息末尾添加可点击的快捷回复按钮",
-    "showPagesPrompt": "Show Page 引导",
-    "showPagesPromptHint": "提示 Agent 何时以及如何使用可视化 Show Page。关闭后 vibe show CLI 仍然可用。",
     "agentProgressStyle": "进度显示（Slack/Discord/飞书）",
     "agentProgressStyleHint": "Agent 进度的呈现方式：关闭 / 精简状态条(最终变成结果) / 详细过程日志。",
     "agentProgressStyleConcise": "精简",

--- a/ui/src/lib/adminNavigation.test.ts
+++ b/ui/src/lib/adminNavigation.test.ts
@@ -70,7 +70,6 @@ describe('isLocalOnlyMessagingField', () => {
   it('keeps machine-global controls owner-only without gating Replies', () => {
     expect(isLocalOnlyMessagingField('agents.opencode.error_retry_limit')).toBe(true);
     expect(isLocalOnlyMessagingField('agents.opencode.active_turn_timeout_seconds')).toBe(true);
-    expect(isLocalOnlyMessagingField('show_pages_prompt')).toBe(true);
     expect(isLocalOnlyMessagingField('reply_enhancements')).toBe(false);
   });
 });

--- a/ui/src/lib/adminNavigation.ts
+++ b/ui/src/lib/adminNavigation.ts
@@ -38,7 +38,6 @@ export const OWNER_ONLY_ROUTES = [
 const LOCAL_ONLY_MESSAGING_FIELDS = new Set([
   'agents.opencode.error_retry_limit',
   'agents.opencode.active_turn_timeout_seconds',
-  'show_pages_prompt',
 ]);
 
 export const isOwnerOnlyPath = (pathname: string): boolean =>

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -1514,7 +1514,6 @@ def config_to_payload(
         "include_time_info": config.include_time_info,
         "include_user_info": config.include_user_info,
         "reply_enhancements": config.reply_enhancements,
-        "show_pages_prompt": config.show_pages_prompt,
         "agent_progress_style": config.agent_progress_style,
         "agent_status_heartbeat_ms": config.agent_status_heartbeat_ms,
         "agent_status_no_output_ms": config.agent_status_no_output_ms,


### PR DESCRIPTION
Show Page guidance is now always included in the shared system prompt used by Claude, Codex, and OpenCode. Remove the Settings toggle, translations, config field, and Skill catalog filtering so an old `show_pages_prompt: false` no longer suppresses guidance. Existing configuration files remain loadable; the retired field is ignored and omitted on save.

Prompt Studio exports follow the same unconditional composition. Update the existing config-recovery test to compare each current recovery result instead of retaining a result from the previous loop.

Validation:
- Unit/contract: 853 Python tests and 74 subtests passed across prompt composition/export, backend integration, config loading/saving, and steering. The config suite was rerun after correcting its stale-result assertion (100 passed).
- UI: 22 focused Settings/navigation tests passed; production build passed.
- Static checks: Ruff on every changed Python file and `git diff --check` passed.
- Scenario IDs: no catalog scenario covers this prompt preference.
- Residual manual verification: local Incus conversation/Settings acceptance is deferred to integration. The active local service has not been restarted or upgraded.

Dependencies: none.
