### PR TITLE
fix(ui): render emphasis at CJK punctuation boundaries

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -50,6 +50,7 @@
         "react-router-dom": "^7.17.0",
         "react-zoom-pan-pinch": "^4.0.3",
         "remark-breaks": "^4.0.0",
+        "remark-cjk-friendly": "^2.3.1",
         "remark-gfm": "^4.0.1",
         "shiki": "^4.2.0",
         "tailwind-merge": "^3.4.0",
@@ -4648,6 +4649,18 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-nonce": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
@@ -5883,6 +5896,28 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-to-markdown-cjk-friendly": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown-cjk-friendly/-/mdast-util-to-markdown-cjk-friendly-1.0.0.tgz",
+      "integrity": "sha512-BoaAm8mlJ+LAYz0Qs532Y3ciTuQYgBUPZcSFbvC/ZKmEMAKgulw84YvQK1gI34t/vL2euSfuaWlqczkTBgamkw==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-to-markdown": "^2.1.2",
+        "micromark-extension-cjk-friendly-util": "3.0.1",
+        "micromark-util-symbol": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/mdast": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/mdast": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/mdast-util-to-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
@@ -5970,6 +6005,50 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-cjk-friendly": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-cjk-friendly/-/micromark-extension-cjk-friendly-2.0.1.tgz",
+      "integrity": "sha512-OkzoYVTL1ChbvQ8Cc1ayTIz7paFQz8iS9oIYmewncweUSwmWR+hkJF9spJ1lxB90XldJl26A1F4IkPOKS3bDXw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.1.0",
+        "micromark-extension-cjk-friendly-util": "3.0.1",
+        "micromark-util-chunked": "^2.0.1",
+        "micromark-util-resolve-all": "^2.0.1",
+        "micromark-util-symbol": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "micromark": "^4.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "micromark-util-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/micromark-extension-cjk-friendly-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-cjk-friendly-util/-/micromark-extension-cjk-friendly-util-3.0.1.tgz",
+      "integrity": "sha512-GcbXqTTHOsiZHyF753oIddP/J2eH8j9zpyQPhkof6B2JNxfEJabnQqxbCgzJNuNes0Y2jTNJ3LiYPSXr6eJA8w==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.4.0",
+        "micromark-util-character": "^2.1.1",
+        "micromark-util-symbol": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "micromark-util-types": {
+          "optional": true
+        }
       }
     },
     "node_modules/micromark-extension-gfm": {
@@ -7178,6 +7257,28 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-cjk-friendly": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/remark-cjk-friendly/-/remark-cjk-friendly-2.3.1.tgz",
+      "integrity": "sha512-f+pKZRxCRwNEGFBKNRAZAqU91GIK1SAo3ZyFHWRUgC9zcxRR0BXKd6YwqgSsxtW0rNpUDtONj7H5nje2WL3fcA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-to-markdown-cjk-friendly": "1.0.0",
+        "micromark-extension-cjk-friendly": "2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/mdast": "^4.0.0",
+        "unified": "^11.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/mdast": {
+          "optional": true
+        }
       }
     },
     "node_modules/remark-gfm": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -68,6 +68,7 @@
     "react-router-dom": "^7.17.0",
     "react-zoom-pan-pinch": "^4.0.3",
     "remark-breaks": "^4.0.0",
+    "remark-cjk-friendly": "^2.3.1",
     "remark-gfm": "^4.0.1",
     "shiki": "^4.2.0",
     "tailwind-merge": "^3.4.0",

--- a/ui/src/components/ui/markdown.test.tsx
+++ b/ui/src/components/ui/markdown.test.tsx
@@ -1,0 +1,81 @@
+/* @vitest-environment jsdom */
+
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { Markdown } from './markdown';
+
+afterEach(cleanup);
+
+describe('Markdown emphasis', () => {
+  it.each([
+    ['', 'p'],
+    ['1. ', 'ol > li'],
+    ['- ', 'ul > li'],
+    ['> ', 'blockquote > p'],
+    ['### ', 'h3'],
+  ])('renders CJK punctuation boundaries inside %j blocks', (prefix, selector) => {
+    const bold = 'A 不再出现在后续请求里，线程 ID 和聊天记录不变。';
+    const continuation = '源码允许冷恢复时优先采用传入的基础指令。';
+    const { container } = render(
+      <Markdown content={`${prefix}**${bold}**${continuation}`} />,
+    );
+    const block = container.querySelector(selector);
+
+    expect(block?.querySelector('strong')?.textContent).toBe(bold);
+    expect(block?.textContent).toBe(bold + continuation);
+  });
+
+  it.each([false, true])('keeps adjacent CJK emphasis with softBreaks=%s', (softBreaks) => {
+    const { container } = render(
+      <Markdown
+        content={'前文**「重点」**后文**结论。**继续\n下一行'}
+        softBreaks={softBreaks}
+        interactive={false}
+      />,
+    );
+
+    expect(Array.from(container.querySelectorAll('strong'), (node) => node.textContent))
+      .toEqual(['「重点」', '结论。']);
+    expect(container.querySelectorAll('br')).toHaveLength(softBreaks ? 1 : 0);
+  });
+
+  it('preserves inline structure inside CJK strong emphasis', () => {
+    const { container } = render(
+      <Markdown content={'1. **保留 `Codex` 和[链接](https://example.com)。**后文'} />,
+    );
+    const strong = container.querySelector('li > strong');
+
+    expect(strong?.textContent).toBe('保留 Codex 和链接。');
+    expect(strong?.querySelector('code')?.textContent).toBe('Codex');
+    expect(strong?.querySelector('a')?.getAttribute('href')).toBe('https://example.com');
+    expect(container.querySelector('li')?.textContent).toBe('保留 Codex 和链接。后文');
+  });
+
+  it.each([
+    ['`**中文。**后文`', 'code', '**中文。**后文'],
+    ['```md\n**中文。**后文\n```', 'pre > code', '**中文。**后文\n'],
+    ['    **中文。**后文', 'pre > code', '**中文。**后文\n'],
+    [String.raw`\*\*中文。\*\*后文`, 'p', '**中文。**后文'],
+    ['&#42;&#42;中文。&#42;&#42;后文', 'p', '**中文。**后文'],
+    ['**中文。', 'p', '**中文。'],
+    ['**中文。 **后文', 'p', '**中文。 **后文'],
+  ])('preserves literal markers in %j', (content, selector, expected) => {
+    const { container } = render(<Markdown content={content} interactive={false} />);
+
+    expect(container.querySelector('strong')).toBeNull();
+    expect(container.querySelector(selector)?.textContent).toBe(expected);
+  });
+
+  it('preserves standard emphasis and GFM rendering', () => {
+    const { container } = render(
+      <Markdown content={'- [x] **Bold** and *italic* and ~~deleted~~\n\n| A | B |\n| - | - |\n| one | two |'} />,
+    );
+
+    expect(container.querySelector('strong')?.textContent).toBe('Bold');
+    expect(container.querySelector('em')?.textContent).toBe('italic');
+    expect(container.querySelector('del')?.textContent).toBe('deleted');
+    expect(container.querySelector<HTMLInputElement>('input')?.checked).toBe(true);
+    expect(container.querySelectorAll('td')).toHaveLength(2);
+  });
+});

--- a/ui/src/components/ui/markdown.tsx
+++ b/ui/src/components/ui/markdown.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import ReactMarkdown, { type Components, defaultUrlTransform } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkBreaks from 'remark-breaks';
+import remarkCjkFriendly from 'remark-cjk-friendly/parseOnly';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { Check, Copy } from 'lucide-react';
@@ -212,7 +213,10 @@ export const Markdown: React.FC<{
   // never reaches here to begin with — this is defence in depth + correctness for
   // the editor-preview caller that lacks that wrapper.)
   const remarkPlugins = React.useMemo(
-    () => (softBreaks ? [remarkGfm, remarkBreaks] : [remarkGfm]),
+    // CJK punctuation can touch emphasis markers without spaces between words.
+    () => (softBreaks
+      ? [remarkGfm, remarkCjkFriendly, remarkBreaks]
+      : [remarkGfm, remarkCjkFriendly]),
     [softBreaks],
   );
   const components = React.useMemo<Components>(


### PR DESCRIPTION
Chinese emphasis next to punctuation currently appears as literal stars in both paragraphs and lists: `**不变。**源码` never produces a strong element under the default CommonMark boundary rules.

Enable `remark-cjk-friendly/parseOnly` in the shared Markdown renderer so CJK punctuation boundaries render correctly across chat and previews, including existing messages, without rewriting their source. The new dependency and its transitive packages are recorded in the lockfile; existing dependency versions remain unchanged.

Validation:
- The new renderer tests reproduce eight failing CJK cases before the change and pass afterward.
- 62 focused tests pass across Markdown, file preview, and archived chat rendering. They cover paragraph/list/quote/heading containers, adjacent emphasis, soft breaks, nested links/code, literal code/escapes, and existing GFM behavior.
- Changed-file ESLint and the production UI build pass.
- Isolated browser rendering at mobile and desktop sizes checks the screenshot text, actual bold elements, and horizontal overflow.
- Residual integration: installed-app and iOS Safari verification in local Incus is deferred; the active workstation service was not changed.

Scenario catalog: no existing scenario covers Web Markdown emphasis parsing. No cross-PR dependencies.

Known by design: this extends CJK emphasis boundaries only. Whitespace-invalid markers remain literal; GFM strikethrough keeps its current parser.
