### PR TITLE
fix(workbench): limit project grab cursors to existing icons

### DIFF
--- a/ui/e2e/project-order/order.spec.ts
+++ b/ui/e2e/project-order/order.spec.ts
@@ -10,6 +10,56 @@ test.beforeEach(async ({ page }) => {
   await expect(rows(page)).toHaveCount(8);
 });
 
+test('only the folder and disclosure icons advertise dragging; the title remains a click target', async ({ page, isMobile }, testInfo) => {
+  const first = header(page, 0);
+  const title = first.getByText('Avibe', { exact: true });
+  const icons = first.locator('.project-drag-icon');
+  for (const expanded of [false, true]) {
+    if (expanded) await title.click();
+    await expect(first).toHaveCSS('cursor', 'pointer');
+    await title.hover();
+    await expect(title).toHaveCSS('cursor', 'pointer');
+    await expect(icons).toHaveCount(2);
+    for (const icon of await icons.all()) {
+      await icon.hover();
+      await expect(icon).toHaveCSS('cursor', 'grab');
+    }
+    for (const label of await first.locator('span').all()) {
+      await expect(label).toHaveCSS('cursor', 'pointer');
+    }
+  }
+  await expect(rows(page).first().getByText('Conversation 1', { exact: true })).toBeVisible();
+  await icons.first().click();
+  await expect(rows(page).first().getByText('Conversation 1', { exact: true })).not.toBeVisible();
+  await icons.nth(1).click();
+  await expect(rows(page).first().getByText('Conversation 1', { exact: true })).toBeVisible();
+  await title.hover();
+  await page.screenshot({ path: testInfo.outputPath('project-cursor-targets.png'), scale: 'css' });
+  if (!isMobile) {
+    await first.focus();
+    await page.keyboard.press('Space', { delay: 80 });
+    await expect(first).toHaveCSS('cursor', 'grabbing');
+    await expect(title).toHaveCSS('cursor', 'grabbing');
+    for (const icon of await icons.all()) await expect(icon).toHaveCSS('cursor', 'grabbing');
+    await page.keyboard.press('Escape');
+    await expect(title).toHaveCSS('cursor', 'pointer');
+  }
+});
+
+test('a project that cannot be reordered keeps click cursors on its icons', async ({ page }) => {
+  await page.evaluate(() => localStorage.setItem('project-order-fixture', JSON.stringify(['project-0'])));
+  await page.reload();
+  await expect(rows(page)).toHaveCount(1);
+  const first = header(page, 0);
+  await expect(first).not.toHaveAttribute('aria-describedby');
+  await expect(first).toHaveCSS('cursor', 'pointer');
+  for (const icon of await first.locator('.project-drag-icon').all()) {
+    await expect(icon).toHaveCSS('cursor', 'pointer');
+  }
+  await first.getByText('Avibe', { exact: true }).click();
+  await expect(rows(page).first().getByText('Conversation 1', { exact: true })).toBeVisible();
+});
+
 test('header click expands; a direct drag animates neighbors and persists across reload', async ({ page, isMobile }, testInfo) => {
   await header(page, 0).click();
   await expect(rows(page).first().getByText('Conversation 1', { exact: true })).toBeVisible();

--- a/ui/src/components/workbench/ProjectsPage.tsx
+++ b/ui/src/components/workbench/ProjectsPage.tsx
@@ -170,7 +170,7 @@ const MobileProjectRow: React.FC<{
           onClick={onToggle}
           className="project-drag-header flex min-w-0 flex-1 items-center gap-2.5 px-4 py-3.5 text-left"
         >
-          {open ? <FolderOpen className="size-4 shrink-0 text-cyan-ink" /> : <Folder className="size-4 shrink-0 text-muted" />}
+          {open ? <FolderOpen className="project-drag-icon size-4 shrink-0 text-cyan-ink" /> : <Folder className="project-drag-icon size-4 shrink-0 text-muted" />}
           <span className="min-w-0 flex-1 truncate text-sm font-semibold">{project.display_name}</span>
           {state.sessions !== null && !state.error && (
             <Badge variant="secondary" className="font-mono text-[10px]">
@@ -178,7 +178,7 @@ const MobileProjectRow: React.FC<{
               {state.cursor ? '+' : ''}
             </Badge>
           )}
-          {open ? <ChevronDown className="size-4 shrink-0 text-muted" /> : <ChevronRight className="size-4 shrink-0 text-muted" />}
+          {open ? <ChevronDown className="project-drag-icon size-4 shrink-0 text-muted" /> : <ChevronRight className="project-drag-icon size-4 shrink-0 text-muted" />}
         </button>
         {(canChat || canManageProjects) && <Popover open={menuOpen} onOpenChange={setMenuOpen}>
           <PopoverTrigger asChild>

--- a/ui/src/components/workbench/WorkbenchSidebar.tsx
+++ b/ui/src/components/workbench/WorkbenchSidebar.tsx
@@ -491,11 +491,11 @@ const ProjectRow: React.FC<{
             onClick={onToggle}
             className="project-drag-header flex min-w-0 flex-1 items-center gap-1.5 text-left"
           >
-            <Chevron className="size-3 shrink-0 text-muted" />
+            <Chevron className="project-drag-icon size-3 shrink-0 text-muted" />
             {expanded ? (
-              <FolderOpen className="size-3.5 shrink-0 text-muted" />
+              <FolderOpen className="project-drag-icon size-3.5 shrink-0 text-muted" />
             ) : (
-              <Folder className="size-3.5 shrink-0 text-muted" />
+              <Folder className="project-drag-icon size-3.5 shrink-0 text-muted" />
             )}
             <span className="flex-1 truncate text-[12px] font-medium text-foreground">
               {project.display_name}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -892,12 +892,14 @@ pre,
 
 /* The project header remains a scroll/tap target until a touch hold activates. */
 .project-drag-header {
+  cursor: pointer;
   touch-action: manipulation;
   -webkit-touch-callout: none;
   user-select: none;
 }
-.project-drag-header[aria-describedby] { cursor: grab; }
-.project-drag-header[aria-pressed="true"] { cursor: grabbing; }
+.project-drag-header[aria-describedby] .project-drag-icon { cursor: grab; }
+.project-drag-header[aria-pressed="true"],
+.project-drag-header[aria-pressed="true"] .project-drag-icon { cursor: grabbing; }
 .project-drag-preview { animation: project-pickup 140ms ease-out; }
 @keyframes project-pickup {
   from { opacity: 0.75; transform: scale(0.98); }


### PR DESCRIPTION
## Capability

Restore the ordinary click pointer over project titles and header whitespace.
Only the existing folder and expand/collapse icons advertise dragging with a
grab cursor. Both desktop and mobile project navigation use the same policy.

## Scope

- CSS and icon classes only; no new toolbar, handle, dependency, or visible copy.
- Click/tap expansion, whole-header drag activation, touch hold, keyboard
  movement, and drag animations remain unchanged.
- During an active drag, the header and its icons show the grabbing cursor.
- When sorting is disabled, icons retain the normal click pointer.

## Evidence

- 52 focused UI/provider/bootstrap tests pass.
- 16 desktop/mobile-emulated Chromium browser cases pass; two touch-only cases
  intentionally skip desktop. Added computed-cursor assertions for title,
  whitespace, both icon variants, badges, active dragging, and disabled sorting.
- Existing animation, persistence, cross-page invalidation, keyboard, touch
  scrolling/cancellation, and reduced-motion browser scenarios still pass.
- Desktop/mobile screenshots inspected; layout is unchanged.
- UI lint baseline, production build, and diff checks pass.
- Scenario IDs: regression coverage lives in ui/e2e/project-order/order.spec.ts;
  no separate scenario catalog entry describes this cursor-only refinement.

## Dependencies And Residuals

Follow-up to merged #1930; based on the latest master, with no unmerged dependency.
Physical iOS and installed-environment local Incus verification remain deferred.
No deployment or restart of the running Avibe service is included.

## Known By Design

The whole header remains draggable as requested originally; this change narrows
the idle cursor hint, not the gesture hit area. Documentation and persistence
semantics are unchanged.
