### PR TITLE
fix(ci): seed constrained schemas in migration release guard

### DIFF
--- a/scripts/migration_release_guard.py
+++ b/scripts/migration_release_guard.py
@@ -65,7 +65,7 @@ import string
 import subprocess
 import sys
 import tempfile
-from collections import defaultdict
+from collections import defaultdict, deque
 from collections.abc import Iterable
 from dataclasses import dataclass
 from decimal import Decimal
@@ -803,6 +803,7 @@ CHECK_FAILURE = re.compile(r"CHECK constraint failed: (\w+)")
 SEED_ATTEMPTS = 60
 # Shape proposals are witnesses, not an invitation to allocate arbitrary declared widths.
 SEED_TEXT_LIMIT = 4096
+SEED_GLOB_STATES = 16384
 SQLITE_INT_MIN = -(2**63)
 SQLITE_INT_MAX = 2**63 - 1
 
@@ -970,41 +971,99 @@ def json_proposals(
 
 def glob_witness(
     connection: sqlite3.Connection,
-    pattern: str,
+    patterns: tuple[str, ...],
     *,
     width: int | None = None,
     alphabet: str = string.printable,
 ) -> str | None:
-    """Offer one finite witness, using SQLite itself to interpret character classes."""
-    parts: list[str | None] = []
-    for token in re.findall(r"\[[^]]+\]|.", pattern, re.DOTALL):
-        if token == "*":
-            parts.append(None)
-            continue
-        if token == "?" or token.startswith("["):
-            accepted = next(
-                (char for char in alphabet if connection.execute("select ? glob ?", (char, token)).fetchone()[0]),
-                None,
-            )
-            if accepted is None:
-                return None
-            parts.append(accepted)
-        else:
-            parts.append(token)
-    minimum = sum(part is not None for part in parts)
-    size = minimum if width is None else width
-    if not minimum <= size <= SEED_TEXT_LIMIT or (size > minimum and (None not in parts or not alphabet)):
+    """Search the intersection of finite GLOB automata, with SQLite as the oracle.
+
+    A state retains every possible token position after the current prefix. Stars
+    both consume characters and admit an empty transition to the next token.
+    """
+    if (width is not None and not 0 <= width <= SEED_TEXT_LIMIT) or sum(map(len, patterns)) > SEED_TEXT_LIMIT:
         return None
-    padding = size - minimum
-    expanded = []
-    for part in parts:
-        if part is None:
-            expanded.append(alphabet[:1] * padding)
-            padding = 0
-        else:
-            expanded.append(part)
-    witness = "".join(expanded)
-    return witness if connection.execute("select ? glob ?", (witness, pattern)).fetchone()[0] else None
+    machines: list[list[str]] = []
+    for pattern in patterns:
+        tokens = []
+        index = 0
+        while index < len(pattern):
+            end = index + 1
+            if pattern[index] == "[":
+                if pattern[end:end + 1] == "^":
+                    end += 1
+                # SQLite admits ']' as the first member, including after '^'.
+                if pattern[end:end + 1] == "]":
+                    end += 1
+                closing = pattern.find("]", end)
+                if closing < 0:
+                    return None
+                end = closing + 1
+            tokens.append(pattern[index:end])
+            index = end
+        machines.append(tokens)
+    alphabet = "".join(dict.fromkeys(alphabet.replace("\x00", "")))
+    members = {
+        token: frozenset(
+            char for char in alphabet
+            if connection.execute("select ? glob ?", (char, token)).fetchone()[0]
+        )
+        for token in sorted({token for tokens in machines for token in tokens if token != "*"})
+    }
+    # Equivalent characters have identical transitions in every pattern.
+    representatives: dict[tuple[bool, ...], str] = {}
+    for char in alphabet:
+        representatives.setdefault(tuple(char in accepted for accepted in members.values()), char)
+
+    def closure(tokens: list[str], positions: Iterable[int]) -> frozenset[int]:
+        result = set(positions)
+        for position in tuple(result):
+            while position < len(tokens) and tokens[position] == "*":
+                position += 1
+                if position in result:
+                    break
+                result.add(position)
+        return frozenset(result)
+
+    initial = tuple(closure(tokens, [0]) for tokens in machines)
+    start = (initial, 0)
+    parents = {start: None}
+    queue = deque([(start, 0)])
+    while queue:
+        key, depth = queue.popleft()
+        states, _ = key
+        if (width is None or depth == width) and all(
+            len(tokens) in state for tokens, state in zip(machines, states)
+        ):
+            parts = []
+            cursor = key
+            while parents[cursor] is not None:
+                cursor, char = parents[cursor]
+                parts.append(char)
+            witness = "".join(reversed(parts))
+            if all(connection.execute("select ? glob ?", (witness, pattern)).fetchone()[0] for pattern in patterns):
+                return witness
+        if depth >= (SEED_TEXT_LIMIT if width is None else width):
+            continue
+        for char in representatives.values():
+            next_states = tuple(
+                closure(tokens, (
+                    position if tokens[position] == "*" else position + 1
+                    for position in state if position < len(tokens)
+                    and (tokens[position] == "*" or char in members[tokens[position]])
+                ))
+                for tokens, state in zip(machines, states)
+            )
+            if not all(next_states):
+                continue
+            next_key = (next_states, depth + 1 if width is not None else 0)
+            if next_key in parents:
+                continue
+            if len(parents) >= SEED_GLOB_STATES:
+                return None
+            parents[next_key] = (key, char)
+            queue.append((next_key, depth + 1))
+    return None
 
 
 def shape_proposals(
@@ -1014,6 +1073,8 @@ def shape_proposals(
     values: dict[str, object],
     *,
     text_constraints: str | None = None,
+    omitted: Iterable[tuple[str, str, str | None]] = (),
+    unavailable: Iterable[str] = (),
 ) -> list[tuple[str, object]]:
     """Derive bounded text-shape and numeric candidates from the rejected CHECK.
 
@@ -1035,7 +1096,16 @@ def shape_proposals(
         shapes,
         re.IGNORECASE,
     )
+    positive: dict[str, list[str]] = defaultdict(list)
     alphabets = {name: string.printable for name in text}
+    for name, negated, quoted in globs:
+        name = names.get(identifier_key(name), name)
+        if name in text:
+            pattern = quoted.replace("''", "'")
+            alphabets[name] += pattern
+            if not negated:
+                positive[name].append(pattern)
+    alphabets = {name: "".join(dict.fromkeys(alphabet)) for name, alphabet in alphabets.items()}
     # Restrict the alphabet before generating a witness so later CHECK order cannot
     # erase a required width or introduce characters forbidden by another CHECK.
     for name, negated, quoted in globs:
@@ -1052,14 +1122,10 @@ def shape_proposals(
             alphabets[name] = allowed
             if allowed:
                 text[name] = "".join(char if char in allowed else allowed[0] for char in text[name])
-    for name, negated, quoted in globs:
-        name = names.get(identifier_key(name), name)
-        if negated or name not in text:
+    for name, patterns in positive.items():
+        if all(connection.execute("select ? glob ?", (text[name], pattern)).fetchone()[0] for pattern in patterns):
             continue
-        pattern = quoted.replace("''", "'")
-        if connection.execute("select ? glob ?", (text[name], pattern)).fetchone()[0]:
-            continue
-        witness = glob_witness(connection, pattern, width=widths.get(name), alphabet=alphabets[name])
+        witness = glob_witness(connection, tuple(patterns), width=widths.get(name), alphabet=alphabets[name])
         if witness is not None:
             text[name] = witness
     for name, start, width, other in SUBSTRING_REQUIREMENT.findall(shapes):
@@ -1081,6 +1147,11 @@ def shape_proposals(
         f'cast(? as {declared}) as "{name}"' if declared else f'? as "{name}"'
         for name, declared in required
     )
+    for name, declared, default in omitted:
+        term = f"({default})" if default is not None else "NULL"
+        if declared:
+            term = f"cast({term} as {declared})"
+        projection += f', {term} as "{name}"'
     numeric = [
         name for name, declared in required
         if "INT" in declared.upper() and re.search(rf"\b{re.escape(identifier_key(name))}\b", identifier_key(expression))
@@ -1089,21 +1160,33 @@ def shape_proposals(
         value for bound in sorted(bounds) for value in (bound, bound + 1, bound - 1)
         if SQLITE_INT_MIN <= value <= SQLITE_INT_MAX
     ))
-    # A CHECK may require multiple columns to move together. Keep the evaluation
-    # bounded, but evaluate whole assignments rather than rejecting partial moves.
+    fallback = [(name, candidate) for candidate in candidates for name in numeric if candidate != values[name]]
+    if any(re.search(rf"\b{re.escape(identifier_key(name))}\b", identifier_key(expression)) for name in unavailable):
+        return [*proposals, *fallback]
+    # Reserve half the budget for whole-row boundary assignments before a large
+    # single-column search or Cartesian prefix can starve coordinated moves.
     domains = [list(dict.fromkeys([values[name], *candidates])) for name in numeric]
     single_changes = (
         tuple(candidate if name == changed else values[name] for name in numeric)
         for changed in numeric for candidate in candidates if candidate != values[changed]
     )
-    assignments = itertools.chain(single_changes, itertools.product(*domains)) if numeric else ()
+    assignments = itertools.chain(
+        itertools.islice(single_changes, SEED_ATTEMPTS // 2),
+        (tuple(candidate for _ in numeric) for candidate in candidates),
+        single_changes,
+        itertools.product(*domains),
+    ) if numeric else ()
     for assignment in itertools.islice(assignments, SEED_ATTEMPTS):
         changes = dict(zip(numeric, assignment))
         parameters = [changes.get(column, values[column]) for column, _ in required]
         try:
-            accepted = connection.execute(f"select ({expression}) from (select {projection})", parameters).fetchone()[0]
+            accepted = connection.execute(
+                f"select coalesce(cast(({expression}) as numeric), 1) != 0 from (select {projection})", parameters
+            ).fetchone()[0]
         except sqlite3.OperationalError:
-            # Omitted/defaulted columns still leave the actual INSERT authoritative.
+            # Generated columns or unsupported context cannot reject a candidate.
+            # Offer the bounded values to the real INSERT, which supplies that context.
+            proposals.extend(fallback)
             break
         if accepted:
             proposals.extend((name, value) for name, value in changes.items() if value != values[name])
@@ -1391,6 +1474,17 @@ def insert_seed_row(
         for name in re.findall(r'\bconstraint\s+"?(\w+)"?\s+check\s*\(', ddl, re.IGNORECASE)
     ]
     text_constraints = "\n".join(constraints)
+    omitted = []
+    unavailable = []
+    for info in connection.execute(f'pragma table_xinfo("{table}")'):
+        if str(info[1]) in values:
+            continue
+        if info[6] or (info[5] and str(info[2]).upper() == "INTEGER" and info[4] is None):
+            # Generated columns and implicit primary keys depend on the INSERT.
+            # In particular, a missing double-quoted name may silently become text.
+            unavailable.append(str(info[1]))
+        else:
+            omitted.append((str(info[1]), str(info[2]), info[4]))
     prefix_sources = {identifier_key(other) for _, _, _, other in SUBSTRING_REQUIREMENT.findall(text_constraints)}
     proposed: set[tuple[str, object]] = set()
     objection = ""
@@ -1409,7 +1503,10 @@ def insert_seed_row(
             untried = [
                 pair
                 for pair in [
-                    *shape_proposals(connection, expression, required, values, text_constraints=text_constraints),
+                    *shape_proposals(
+                        connection, expression, required, values,
+                        text_constraints=text_constraints, omitted=omitted, unavailable=unavailable,
+                    ),
                     *check_proposals(expression, names),
                     *json_proposals(connection, expression, names),
                 ]

--- a/scripts/migration_release_guard.py
+++ b/scripts/migration_release_guard.py
@@ -67,6 +67,7 @@ import tempfile
 from collections import defaultdict
 from collections.abc import Iterable
 from dataclasses import dataclass
+from decimal import Decimal
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -801,6 +802,8 @@ CHECK_FAILURE = re.compile(r"CHECK constraint failed: (\w+)")
 SEED_ATTEMPTS = 60
 # Shape proposals are witnesses, not an invitation to allocate arbitrary declared widths.
 SEED_TEXT_LIMIT = 4096
+SQLITE_INT_MIN = -(2**63)
+SQLITE_INT_MAX = 2**63 - 1
 
 # Where `varied` records a row's step inside a JSON document. Nothing reads it back; it is
 # there so the document differs while staying a document, and it is namespaced so it cannot
@@ -814,6 +817,10 @@ JSON_VARIED_MEMBER = "__seed_step__"
 JSON_REQUIREMENT = re.compile(
     r"json_(extract|type)\s*\(\s*\"?(\w+)\"?\s*,\s*'([^']*)'\s*\)\s*(?:==|=|is)\s*"
     r"('[^']*'|-?[0-9]+(?:\.[0-9]+)?)",
+    re.IGNORECASE,
+)
+SUBSTRING_REQUIREMENT = re.compile(
+    r'\bsubstr\s*\(\s*"?(\w+)"?\s*,\s*(\d+)\s*,\s*(\d+)\s*\)\s*=\s*"?(\w+)"?',
     re.IGNORECASE,
 )
 
@@ -887,6 +894,20 @@ def check_expression(ddl: str, name: str) -> str:
     return ""
 
 
+def identifier_key(value: str) -> str:
+    """SQLite folds ASCII identifier case, not Unicode or JSON member names."""
+    return value.translate(str.maketrans(string.ascii_uppercase, string.ascii_lowercase))
+
+
+def bounded_integer(literal: str, lower: int, upper: int) -> int | None:
+    """Reject oversized decimal tokens before Python parsing or SQLite binding."""
+    digits = literal.lstrip("-").lstrip("0") or "0"
+    if len(digits) > len(str(max(abs(lower), abs(upper)))):
+        return None
+    value = int(digits) * (-1 if literal.startswith("-") else 1)
+    return value if lower <= value <= upper else None
+
+
 def check_proposals(expression: str, columns: Iterable[str]) -> list[tuple[str, str]]:
     """``(column, value)`` pairs ``expression`` itself suggests, for the columns it names.
 
@@ -900,7 +921,8 @@ def check_proposals(expression: str, columns: Iterable[str]) -> list[tuple[str, 
     than producing a row the schema would have refused.
     """
     literals = re.findall(r"'([^']*)'", expression)
-    named = [column for column in columns if re.search(rf"\b{re.escape(column)}\b", expression)]
+    folded = identifier_key(expression)
+    named = [column for column in columns if re.search(rf"\b{re.escape(identifier_key(column))}\b", folded)]
     return [(column, literal) for column in named for literal in literals]
 
 
@@ -914,10 +936,11 @@ def json_proposals(
     one column are folded into a single document, because a constraint requiring two paths
     is not satisfied by a document carrying either one.
     """
-    wanted = set(columns)
+    wanted = {identifier_key(column): column for column in columns}
     required: dict[str, list[tuple[str, str, object]]] = {}
     for function, column, path, literal in JSON_REQUIREMENT.findall(expression):
-        if column not in wanted:
+        column = wanted.get(identifier_key(column))
+        if column is None:
             continue
         if function.lower() == "type":
             named = literal.strip("'").lower()
@@ -931,7 +954,7 @@ def json_proposals(
         elif literal.startswith("'"):
             required.setdefault(column, []).append((path, "?", literal[1:-1]))
         else:
-            required.setdefault(column, []).append((path, "?", float(literal) if "." in literal else int(literal)))
+            required.setdefault(column, []).append((path, "json(?)", str(Decimal(literal))))
 
     proposals = []
     for column, clauses in required.items():
@@ -969,21 +992,28 @@ def shape_proposals(
     expression: str,
     required: list[tuple[str, str]],
     values: dict[str, object],
+    *,
+    text_constraints: str | None = None,
 ) -> list[tuple[str, object]]:
     """Derive bounded text-shape and numeric candidates from the rejected CHECK.
 
     This extends the literal/JSON proposals, not the seeder's coverage claim. Unsupported
     expressions still fail visibly; every proposed value must survive a real insert.
     """
+    names = {identifier_key(name): name for name in values}
     text = {name: value for name, value in values.items() if isinstance(value, str)}
-    for name, width in re.findall(r'\blength\s*\(\s*"?(\w+)"?\s*\)\s*=\s*(\d+)', expression, re.IGNORECASE):
-        if name in text and int(width) <= SEED_TEXT_LIMIT:
-            text[name] = text[name][: int(width)].ljust(int(width), "0")
+    shapes = text_constraints if text_constraints is not None else expression
+    for name, width in re.findall(r'\blength\s*\(\s*"?(\w+)"?\s*\)\s*=\s*(\d+)', shapes, re.IGNORECASE):
+        name = names.get(identifier_key(name), name)
+        size = bounded_integer(width, 0, SEED_TEXT_LIMIT)
+        if name in text and size is not None:
+            text[name] = text[name][:size].ljust(size, "0")
     for name, negated, quoted in re.findall(
         r"\b\"?(\w+)\"?\s+(not\s+)?glob\s*'((?:[^']|'')*)'",
-        expression,
+        shapes,
         re.IGNORECASE,
     ):
+        name = names.get(identifier_key(name), name)
         if name not in text:
             continue
         pattern = quoted.replace("''", "'")
@@ -999,25 +1029,30 @@ def shape_proposals(
             ]
             if allowed:
                 text[name] = "".join(char if char in allowed else allowed[0] for char in text[name])
-    for name, start, width, other in re.findall(
-        r'\bsubstr\s*\(\s*"?(\w+)"?\s*,\s*(\d+)\s*,\s*(\d+)\s*\)\s*=\s*"?(\w+)"?',
-        expression,
-        re.IGNORECASE,
-    ):
-        if name in text and isinstance(values.get(other), str) and 0 < int(start) <= SEED_TEXT_LIMIT:
-            offset, size = int(start) - 1, int(width)
+    for name, start, width, other in SUBSTRING_REQUIREMENT.findall(shapes):
+        name, other = names.get(identifier_key(name), name), names.get(identifier_key(other), other)
+        position = bounded_integer(start, 1, SEED_TEXT_LIMIT)
+        size = bounded_integer(width, 0, SEED_TEXT_LIMIT)
+        if name in text and isinstance(values.get(other), str) and position is not None and size is not None:
+            offset = position - 1
             source = text.get(other, str(values[other]))
             if len(source) == size:
                 text[name] = text[name][:offset].ljust(offset, "0") + source + text[name][offset + size :]
     proposals: list[tuple[str, object]] = [(name, value) for name, value in text.items() if value != values[name]]
-    bounds = {int(value) for value in re.findall(r"(?<![\w.])-?\d+(?![\w.])", expression)}
+    bounds = {
+        bound
+        for token in re.findall(r"(?<![\w.])-?[0-9]+(?![\w.])", expression)
+        if (bound := bounded_integer(token, SQLITE_INT_MIN, SQLITE_INT_MAX)) is not None
+    }
     projection = ", ".join(
         f'cast(? as {declared}) as "{name}"' if declared else f'? as "{name}"'
         for name, declared in required
     )
     for name, declared in required:
-        if "INT" in declared.upper() and re.search(rf"\b{re.escape(name)}\b", expression):
+        if "INT" in declared.upper() and re.search(rf"\b{re.escape(identifier_key(name))}\b", identifier_key(expression)):
             for candidate in dict.fromkeys(value for bound in sorted(bounds) for value in (bound, bound + 1, bound - 1)):
+                if not SQLITE_INT_MIN <= candidate <= SQLITE_INT_MAX:
+                    continue
                 parameters = [candidate if column == name else values[column] for column, _ in required]
                 try:
                     accepted = connection.execute(f"select ({expression}) from (select {projection})", parameters).fetchone()[0]
@@ -1196,7 +1231,7 @@ def varied(value: object, step: int) -> object:
     if isinstance(value, bool):
         return not value
     if isinstance(value, int):
-        return value + step
+        return (value + step - SQLITE_INT_MIN) % (SQLITE_INT_MAX - SQLITE_INT_MIN + 1) + SQLITE_INT_MIN
     if isinstance(value, float):
         return value + float(step)
     if isinstance(value, bytes):
@@ -1303,6 +1338,14 @@ def insert_seed_row(
     placeholders = ", ".join("?" for _ in required)
     statement = f'insert into "{table}" ({columns}) values ({placeholders})'
     names = [column for column, _ in required]
+    # Related columns may be constrained by a later CHECK. Derive their text shapes
+    # together so declaration order does not decide whether a prefix can be offered.
+    constraints = [
+        check_expression(ddl, name)
+        for name in re.findall(r'\bconstraint\s+"?(\w+)"?\s+check\s*\(', ddl, re.IGNORECASE)
+    ]
+    text_constraints = "\n".join(constraints)
+    prefix_sources = {identifier_key(other) for _, _, _, other in SUBSTRING_REQUIREMENT.findall(text_constraints)}
     proposed: set[tuple[str, object]] = set()
     objection = ""
     for _ in range(SEED_ATTEMPTS):
@@ -1320,12 +1363,21 @@ def insert_seed_row(
             untried = [
                 pair
                 for pair in [
-                    *shape_proposals(connection, expression, required, values),
+                    *shape_proposals(connection, expression, required, values, text_constraints=text_constraints),
                     *check_proposals(expression, names),
                     *json_proposals(connection, expression, names),
                 ]
                 if pair not in proposed and values[pair[0]] != pair[1]
             ]
+            if not untried:
+                # Follow only prefix-source dependencies into other CHECKs. Unrelated
+                # literals must not overwrite columns that already satisfy their checks.
+                untried = [
+                    pair
+                    for related in constraints
+                    for pair in [*check_proposals(related, names), *json_proposals(connection, related, names)]
+                    if identifier_key(pair[0]) in prefix_sources and pair not in proposed and values[pair[0]] != pair[1]
+                ]
             if not untried:
                 return objection, True
             column, literal = untried[0]

--- a/scripts/migration_release_guard.py
+++ b/scripts/migration_release_guard.py
@@ -57,6 +57,7 @@ from __future__ import annotations
 import argparse
 import ast
 import hashlib
+import itertools
 import json
 import re
 import sqlite3
@@ -967,15 +968,22 @@ def json_proposals(
     return proposals
 
 
-def glob_witness(connection: sqlite3.Connection, pattern: str) -> str | None:
+def glob_witness(
+    connection: sqlite3.Connection,
+    pattern: str,
+    *,
+    width: int | None = None,
+    alphabet: str = string.printable,
+) -> str | None:
     """Offer one finite witness, using SQLite itself to interpret character classes."""
-    parts = []
+    parts: list[str | None] = []
     for token in re.findall(r"\[[^]]+\]|.", pattern, re.DOTALL):
         if token == "*":
+            parts.append(None)
             continue
         if token == "?" or token.startswith("["):
             accepted = next(
-                (char for char in string.printable if connection.execute("select ? glob ?", (char, token)).fetchone()[0]),
+                (char for char in alphabet if connection.execute("select ? glob ?", (char, token)).fetchone()[0]),
                 None,
             )
             if accepted is None:
@@ -983,7 +991,19 @@ def glob_witness(connection: sqlite3.Connection, pattern: str) -> str | None:
             parts.append(accepted)
         else:
             parts.append(token)
-    witness = "".join(parts)
+    minimum = sum(part is not None for part in parts)
+    size = minimum if width is None else width
+    if not minimum <= size <= SEED_TEXT_LIMIT or (size > minimum and (None not in parts or not alphabet)):
+        return None
+    padding = size - minimum
+    expanded = []
+    for part in parts:
+        if part is None:
+            expanded.append(alphabet[:1] * padding)
+            padding = 0
+        else:
+            expanded.append(part)
+    witness = "".join(expanded)
     return witness if connection.execute("select ? glob ?", (witness, pattern)).fetchone()[0] else None
 
 
@@ -1002,33 +1022,46 @@ def shape_proposals(
     """
     names = {identifier_key(name): name for name in values}
     text = {name: value for name, value in values.items() if isinstance(value, str)}
+    widths = {}
     shapes = text_constraints if text_constraints is not None else expression
     for name, width in re.findall(r'\blength\s*\(\s*"?(\w+)"?\s*\)\s*=\s*(\d+)', shapes, re.IGNORECASE):
         name = names.get(identifier_key(name), name)
         size = bounded_integer(width, 0, SEED_TEXT_LIMIT)
         if name in text and size is not None:
+            widths[name] = size
             text[name] = text[name][:size].ljust(size, "0")
-    for name, negated, quoted in re.findall(
+    globs = re.findall(
         r"\b\"?(\w+)\"?\s+(not\s+)?glob\s*'((?:[^']|'')*)'",
         shapes,
         re.IGNORECASE,
-    ):
+    )
+    alphabets = {name: string.printable for name in text}
+    # Restrict the alphabet before generating a witness so later CHECK order cannot
+    # erase a required width or introduce characters forbidden by another CHECK.
+    for name, negated, quoted in globs:
         name = names.get(identifier_key(name), name)
         if name not in text:
             continue
         pattern = quoted.replace("''", "'")
-        if not negated:
-            witness = glob_witness(connection, pattern)
-            if witness is not None:
-                text[name] = witness
-        elif pattern.startswith("*[^") and pattern.endswith("]*"):
-            allowed = [
+        if negated and pattern.startswith("*[^") and pattern.endswith("]*"):
+            allowed = "".join(
                 char
-                for char in string.printable
+                for char in alphabets[name]
                 if not connection.execute("select ? glob ?", (char, pattern)).fetchone()[0]
-            ]
+            )
+            alphabets[name] = allowed
             if allowed:
                 text[name] = "".join(char if char in allowed else allowed[0] for char in text[name])
+    for name, negated, quoted in globs:
+        name = names.get(identifier_key(name), name)
+        if negated or name not in text:
+            continue
+        pattern = quoted.replace("''", "'")
+        if connection.execute("select ? glob ?", (text[name], pattern)).fetchone()[0]:
+            continue
+        witness = glob_witness(connection, pattern, width=widths.get(name), alphabet=alphabets[name])
+        if witness is not None:
+            text[name] = witness
     for name, start, width, other in SUBSTRING_REQUIREMENT.findall(shapes):
         name, other = names.get(identifier_key(name), name), names.get(identifier_key(other), other)
         position = bounded_integer(start, 1, SEED_TEXT_LIMIT)
@@ -1048,20 +1081,33 @@ def shape_proposals(
         f'cast(? as {declared}) as "{name}"' if declared else f'? as "{name}"'
         for name, declared in required
     )
-    for name, declared in required:
-        if "INT" in declared.upper() and re.search(rf"\b{re.escape(identifier_key(name))}\b", identifier_key(expression)):
-            for candidate in dict.fromkeys(value for bound in sorted(bounds) for value in (bound, bound + 1, bound - 1)):
-                if not SQLITE_INT_MIN <= candidate <= SQLITE_INT_MAX:
-                    continue
-                parameters = [candidate if column == name else values[column] for column, _ in required]
-                try:
-                    accepted = connection.execute(f"select ({expression}) from (select {projection})", parameters).fetchone()[0]
-                except sqlite3.OperationalError:
-                    # An omitted/defaulted column may prevent evaluating the standalone CHECK.
-                    # Leave that case to the existing insert path and its visible refusal.
-                    continue
-                if accepted:
-                    proposals.append((name, candidate))
+    numeric = [
+        name for name, declared in required
+        if "INT" in declared.upper() and re.search(rf"\b{re.escape(identifier_key(name))}\b", identifier_key(expression))
+    ]
+    candidates = list(dict.fromkeys(
+        value for bound in sorted(bounds) for value in (bound, bound + 1, bound - 1)
+        if SQLITE_INT_MIN <= value <= SQLITE_INT_MAX
+    ))
+    # A CHECK may require multiple columns to move together. Keep the evaluation
+    # bounded, but evaluate whole assignments rather than rejecting partial moves.
+    domains = [list(dict.fromkeys([values[name], *candidates])) for name in numeric]
+    single_changes = (
+        tuple(candidate if name == changed else values[name] for name in numeric)
+        for changed in numeric for candidate in candidates if candidate != values[changed]
+    )
+    assignments = itertools.chain(single_changes, itertools.product(*domains)) if numeric else ()
+    for assignment in itertools.islice(assignments, SEED_ATTEMPTS):
+        changes = dict(zip(numeric, assignment))
+        parameters = [changes.get(column, values[column]) for column, _ in required]
+        try:
+            accepted = connection.execute(f"select ({expression}) from (select {projection})", parameters).fetchone()[0]
+        except sqlite3.OperationalError:
+            # Omitted/defaulted columns still leave the actual INSERT authoritative.
+            break
+        if accepted:
+            proposals.extend((name, value) for name, value in changes.items() if value != values[name])
+            break
     return proposals
 
 

--- a/scripts/migration_release_guard.py
+++ b/scripts/migration_release_guard.py
@@ -60,6 +60,7 @@ import hashlib
 import json
 import re
 import sqlite3
+import string
 import subprocess
 import sys
 import tempfile
@@ -798,6 +799,8 @@ CHECK_FAILURE = re.compile(r"CHECK constraint failed: (\w+)")
 # that a table whose constraints cannot be satisfied this way is given up on rather than
 # searched for. Reached only on the tables that refuse the first row at all.
 SEED_ATTEMPTS = 60
+# Shape proposals are witnesses, not an invitation to allocate arbitrary declared widths.
+SEED_TEXT_LIMIT = 4096
 
 # Where `varied` records a row's step inside a JSON document. Nothing reads it back; it is
 # there so the document differs while staying a document, and it is namespaced so it cannot
@@ -938,6 +941,92 @@ def json_proposals(
             document = f"json_set({document}, ?, {term})"
             parameters.extend([path, value])
         proposals.append((column, str(connection.execute(f"select {document}", parameters).fetchone()[0])))
+    return proposals
+
+
+def glob_witness(connection: sqlite3.Connection, pattern: str) -> str | None:
+    """Offer one finite witness, using SQLite itself to interpret character classes."""
+    parts = []
+    for token in re.findall(r"\[[^]]+\]|.", pattern, re.DOTALL):
+        if token == "*":
+            continue
+        if token == "?" or token.startswith("["):
+            accepted = next(
+                (char for char in string.printable if connection.execute("select ? glob ?", (char, token)).fetchone()[0]),
+                None,
+            )
+            if accepted is None:
+                return None
+            parts.append(accepted)
+        else:
+            parts.append(token)
+    witness = "".join(parts)
+    return witness if connection.execute("select ? glob ?", (witness, pattern)).fetchone()[0] else None
+
+
+def shape_proposals(
+    connection: sqlite3.Connection,
+    expression: str,
+    required: list[tuple[str, str]],
+    values: dict[str, object],
+) -> list[tuple[str, object]]:
+    """Derive bounded text-shape and numeric candidates from the rejected CHECK.
+
+    This extends the literal/JSON proposals, not the seeder's coverage claim. Unsupported
+    expressions still fail visibly; every proposed value must survive a real insert.
+    """
+    text = {name: value for name, value in values.items() if isinstance(value, str)}
+    for name, width in re.findall(r'\blength\s*\(\s*"?(\w+)"?\s*\)\s*=\s*(\d+)', expression, re.IGNORECASE):
+        if name in text and int(width) <= SEED_TEXT_LIMIT:
+            text[name] = text[name][: int(width)].ljust(int(width), "0")
+    for name, negated, quoted in re.findall(
+        r"\b\"?(\w+)\"?\s+(not\s+)?glob\s*'((?:[^']|'')*)'",
+        expression,
+        re.IGNORECASE,
+    ):
+        if name not in text:
+            continue
+        pattern = quoted.replace("''", "'")
+        if not negated:
+            witness = glob_witness(connection, pattern)
+            if witness is not None:
+                text[name] = witness
+        elif pattern.startswith("*[^") and pattern.endswith("]*"):
+            allowed = [
+                char
+                for char in string.printable
+                if not connection.execute("select ? glob ?", (char, pattern)).fetchone()[0]
+            ]
+            if allowed:
+                text[name] = "".join(char if char in allowed else allowed[0] for char in text[name])
+    for name, start, width, other in re.findall(
+        r'\bsubstr\s*\(\s*"?(\w+)"?\s*,\s*(\d+)\s*,\s*(\d+)\s*\)\s*=\s*"?(\w+)"?',
+        expression,
+        re.IGNORECASE,
+    ):
+        if name in text and isinstance(values.get(other), str) and 0 < int(start) <= SEED_TEXT_LIMIT:
+            offset, size = int(start) - 1, int(width)
+            source = text.get(other, str(values[other]))
+            if len(source) == size:
+                text[name] = text[name][:offset].ljust(offset, "0") + source + text[name][offset + size :]
+    proposals: list[tuple[str, object]] = [(name, value) for name, value in text.items() if value != values[name]]
+    bounds = {int(value) for value in re.findall(r"(?<![\w.])-?\d+(?![\w.])", expression)}
+    projection = ", ".join(
+        f'cast(? as {declared}) as "{name}"' if declared else f'? as "{name}"'
+        for name, declared in required
+    )
+    for name, declared in required:
+        if "INT" in declared.upper() and re.search(rf"\b{re.escape(name)}\b", expression):
+            for candidate in dict.fromkeys(value for bound in sorted(bounds) for value in (bound, bound + 1, bound - 1)):
+                parameters = [candidate if column == name else values[column] for column, _ in required]
+                try:
+                    accepted = connection.execute(f"select ({expression}) from (select {projection})", parameters).fetchone()[0]
+                except sqlite3.OperationalError:
+                    # An omitted/defaulted column may prevent evaluating the standalone CHECK.
+                    # Leave that case to the existing insert path and its visible refusal.
+                    continue
+                if accepted:
+                    proposals.append((name, candidate))
     return proposals
 
 
@@ -1214,7 +1303,7 @@ def insert_seed_row(
     placeholders = ", ".join("?" for _ in required)
     statement = f'insert into "{table}" ({columns}) values ({placeholders})'
     names = [column for column, _ in required]
-    proposed: set[tuple[str, str]] = set()
+    proposed: set[tuple[str, object]] = set()
     objection = ""
     for _ in range(SEED_ATTEMPTS):
         try:
@@ -1231,10 +1320,11 @@ def insert_seed_row(
             untried = [
                 pair
                 for pair in [
+                    *shape_proposals(connection, expression, required, values),
                     *check_proposals(expression, names),
                     *json_proposals(connection, expression, names),
                 ]
-                if pair not in proposed
+                if pair not in proposed and values[pair[0]] != pair[1]
             ]
             if not untried:
                 return objection, True

--- a/tests/test_migration_release_guard.py
+++ b/tests/test_migration_release_guard.py
@@ -1024,6 +1024,71 @@ def test_numeric_candidates_use_the_column_affinity():
         assert ("n", -1) not in proposals
 
 
+@pytest.mark.parametrize("pattern,width", [("[A-Z]*", 4), ("*[A-Z]", 4), ("[A-Z]*[A-Z]", 4), ("*[A-Z]*", 4), ("[A-Z]???", 4), ("[A-Z][A-Z][A-Z][A-Z]", 4), ("*", 0), ("*", guard.SEED_TEXT_LIMIT)])
+@pytest.mark.parametrize("order", list(itertools.permutations(range(3))))
+@pytest.mark.parametrize("separate", [False, True])
+@pytest.mark.parametrize("alphabet", ["A-Z", "0-9A-Z"])
+def test_text_shape_composition_preserves_every_requirement(tmp_path, pattern, width, order, separate, alphabet):
+    requirements = [f"length(code) = {width}", f"code glob '{pattern}'", f"code not glob '*[^{alphabet}]*'"]
+    expressions = [requirements[index] for index in order]
+    if not separate:
+        expressions = [" and ".join(expressions)]
+    checks = ", ".join(f"constraint ck_{index} check ({expression})" for index, expression in enumerate(expressions))
+    db_path = tmp_path / "vibe.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table shaped (id integer primary key, code text not null, {checks})")
+
+    short, _ = guard.seed_representative_rows(db_path)
+
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("select count(*) from shaped").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize(
+    "columns,clauses",
+    [
+        (columns, clauses)
+        for names in [("low", "high"), ("low", "middle", "high")]
+        for columns in itertools.permutations(names)
+        for clauses in itertools.permutations(["low > 0", *(f"{right} >= {left}" for left, right in itertools.pairwise(names))])
+    ],
+)
+def test_numeric_repairs_coordinate_columns_without_order_dependence(tmp_path, columns, clauses):
+    db_path = tmp_path / "vibe.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        declared = ", ".join(f'"{name}" integer not null' for name in columns)
+        connection.execute(f"create table shaped (id integer primary key, {declared}, constraint ck_counts check ({' and '.join(clauses)}))")
+
+    short, _ = guard.seed_representative_rows(db_path)
+
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("select count(*) from shaped").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+def test_joint_numeric_evaluation_has_a_finite_budget():
+    required = [(f"n{index}", "INTEGER") for index in range(6)]
+    values = {name: 0 for name, _ in required}
+    expression = " and ".join(f"{name} > 0" for name in values) + " and n5 < 0"
+    statements = []
+    with sqlite3.connect(":memory:") as connection:
+        connection.set_trace_callback(statements.append)
+        assert guard.shape_proposals(connection, expression, required, values) == []
+    assert len(statements) == guard.SEED_ATTEMPTS
+
+
+@pytest.mark.parametrize("changed", range(6))
+def test_joint_numeric_search_preserves_single_column_repairs(changed):
+    required = [(f"n{index}", "INTEGER") for index in range(6)]
+    values = {name: 0 for name, _ in required}
+    expression = " and ".join(f"{name} >= 0" for name in values) + f" and n{changed} > 0"
+    with sqlite3.connect(":memory:") as connection:
+        assert guard.shape_proposals(connection, expression, required, values) == [(f"n{changed}", 1)]
+
+
 @pytest.mark.parametrize("reverse", [False, True])
 def test_prefix_sources_can_be_derived_from_json_checks(tmp_path, reverse):
     db_path = tmp_path / "vibe.sqlite"

--- a/tests/test_migration_release_guard.py
+++ b/tests/test_migration_release_guard.py
@@ -14,6 +14,7 @@ properties through the CLI with the full history fetched.
 from __future__ import annotations
 
 import inspect
+import itertools
 import json
 import sqlite3
 from pathlib import Path
@@ -990,25 +991,23 @@ def test_current_schema_gets_valid_rows_in_every_table(tmp_path):
 
 
 @pytest.mark.parametrize("minimum", [0, 4])
-def test_shape_repairs_follow_constraints_not_column_names(tmp_path, minimum):
+@pytest.mark.parametrize("order", list(itertools.permutations(range(4))))
+@pytest.mark.parametrize("mixed_case", [False, True])
+@pytest.mark.parametrize("source_check", ["a glob 'R-[A-C][0-9]'", "a in ('R-A0')"])
+def test_shape_repairs_follow_constraints_not_column_names(tmp_path, minimum, order, mixed_case, source_check):
     db_path = tmp_path / "vibe.sqlite"
+    columns = "id integer primary key, a text not null, b text not null, c text not null, d integer not null, e integer not null"
+    if mixed_case:
+        columns = columns.upper()
+    checks = (
+        f"constraint ck_a check ({source_check})",
+        "constraint ck_b check (length(b) = 12 and b not glob '*[^0-9a-f]*')",
+        "constraint ck_c check (length(c) = 9 and substr(c, 1, 4) = a)",
+        f"constraint ck_counts check (typeof(d) = 'integer' and d >= 0 "
+        f"and typeof(e) = 'integer' and e >= 0 and d + e > {minimum} and (d = 0 or c = ''))",
+    )
     with sqlite3.connect(db_path) as connection:
-        connection.execute(f"""
-            create table shaped (
-                id integer primary key,
-                a text not null,
-                b text not null,
-                c text not null,
-                d integer not null,
-                e integer not null,
-                constraint ck_a check (a glob 'R-[A-C][0-9]'),
-                constraint ck_b check (length(b) = 12 and b not glob '*[^0-9a-f]*'),
-                constraint ck_c check (length(c) = 9 and substr(c, 1, 4) = a),
-                constraint ck_counts check (typeof(d) = 'integer' and d >= 0
-                    and typeof(e) = 'integer' and e >= 0 and d + e > {minimum}
-                    and (d = 0 or c = ''))
-            )
-        """)
+        connection.execute(f"create table shaped ({columns}, {', '.join(checks[index] for index in order)})")
 
     short, _ = guard.seed_representative_rows(db_path)
 
@@ -1025,12 +1024,83 @@ def test_numeric_candidates_use_the_column_affinity():
         assert ("n", -1) not in proposals
 
 
-def test_unsupported_shapes_remain_a_visible_seed_failure(tmp_path):
+@pytest.mark.parametrize("reverse", [False, True])
+def test_prefix_sources_can_be_derived_from_json_checks(tmp_path, reverse):
+    db_path = tmp_path / "vibe.sqlite"
+    checks = [
+        "constraint ck_source check (json_valid(a) = 1 and json_extract(a, '$.version') = 1)",
+        "constraint ck_prefix check (length(b) = 20 and substr(b, 1, 13) = a)",
+    ]
+    if reverse:
+        checks.reverse()
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table shaped (id integer primary key, a text not null, b text not null, {', '.join(checks)})")
+
+    short, _ = guard.seed_representative_rows(db_path)
+
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("select count(*) from shaped").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize(
+    "comparison",
+    ["> 9223372036854775807", "< -9223372036854775808", "> " + "9" * 5000],
+    ids=["above-int64", "below-int64", "arbitrary-precision-literal"],
+)
+def test_unbindable_numeric_boundaries_are_reported_not_raised(tmp_path, comparison):
+    db_path = tmp_path / "vibe.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table extreme (id integer primary key, n integer not null, constraint ck_n check (n {comparison}))")
+
+    short, _ = guard.seed_representative_rows(db_path)
+
+    assert "ck_n" in short["extreme"]
+
+
+@pytest.mark.parametrize("value", [-(2**63), 2**63 - 1])
+def test_integer_variations_remain_sqlite_bindable(value):
+    with sqlite3.connect(":memory:") as connection:
+        variants = [guard.varied(value, step) for step in range(1, guard.SEED_ATTEMPTS + 1)]
+        assert len(set(variants)) == len(variants)
+        assert value not in variants
+        for varied in variants:
+            assert connection.execute("select ?", (varied,)).fetchone()[0] == varied
+
+
+def test_literal_and_json_repairs_use_sqlite_identifier_case_rules(tmp_path):
+    db_path = tmp_path / "vibe.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute("""
+            create table named (id integer primary key, Kind text not null, Payload text not null,
+                constraint ck_kind check (kIND in ('ready')),
+                constraint ck_payload check (json_valid(PAYLOAD) = 1 and json_extract(payload, '$.CaseSensitive') = 1))
+        """)
+
+    short, _ = guard.seed_representative_rows(db_path)
+
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("select count(*) from named where Kind = 'ready' and json_extract(Payload, '$.CaseSensitive') = 1").fetchone()[0] >= guard.SEED_ROWS
+
+
+def test_identifier_folding_matches_sqlite_without_changing_unicode():
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute('create table names ("A" text, "\u00c4" text, "\u00e4" text)')
+        connection.execute('insert into names values (\'ascii\', \'upper\', \'lower\')')
+        assert connection.execute('select a, "\u00c4", "\u00e4" from names').fetchone() == ("ascii", "upper", "lower")
+    assert guard.identifier_key("A") == guard.identifier_key("a")
+    assert guard.identifier_key("\u00c4") != guard.identifier_key("\u00e4")
+
+
+@pytest.mark.parametrize("width", [str(guard.SEED_TEXT_LIMIT + 1), "9" * 5000], ids=["width-limit", "huge-width"])
+def test_unsupported_shapes_remain_a_visible_seed_failure(tmp_path, width):
     db_path = tmp_path / "vibe.sqlite"
     with sqlite3.connect(db_path) as connection:
         connection.execute(f"""
             create table oversized (id integer primary key, value text not null,
-                constraint ck_width check (length(value) = {guard.SEED_TEXT_LIMIT + 1}))
+                constraint ck_width check (length(value) = {width}))
         """)
 
     short, _ = guard.seed_representative_rows(db_path)
@@ -1038,6 +1108,31 @@ def test_unsupported_shapes_remain_a_visible_seed_failure(tmp_path):
     assert "ck_width" in short["oversized"]
     with sqlite3.connect(db_path) as connection:
         assert connection.execute("select count(*) from oversized").fetchone()[0] == 0
+
+
+def test_bounded_numeric_tokens_ignore_leading_zeroes():
+    assert guard.bounded_integer("0" * 5000 + "12", 0, 4096) == 12
+    assert guard.bounded_integer("-" + "0" * 5000 + "12", -4096, 0) == -12
+    with sqlite3.connect(":memory:") as connection:
+        assert guard.shape_proposals(connection, "substr(a, " + "9" * 5000 + ", 1) = b", [("a", "TEXT"), ("b", "TEXT")], {"a": "x", "b": "y"}) == []
+
+
+@pytest.mark.parametrize("literal", ["9223372036854775808", "0001", "1.0", "-0001.5"])
+def test_json_numeric_candidates_are_parsed_by_sqlite_without_integer_binding(tmp_path, literal):
+    db_path = tmp_path / "vibe.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"""
+            create table shaped (id integer primary key, payload text not null,
+                constraint ck_payload check (json_valid(payload) = 1 and json_extract(payload, '$.large') = {literal}
+                    and typeof(json_extract(payload, '$.large')) = typeof({literal})))
+        """)
+
+    short, _ = guard.seed_representative_rows(db_path)
+
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("select count(*) from shaped").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
 
 
 @requires_release_history

--- a/tests/test_migration_release_guard.py
+++ b/tests/test_migration_release_guard.py
@@ -966,6 +966,80 @@ def test_a_repeat_the_rows_do_not_carry_is_a_violation_however_it_got_there():
         connection.close()
 
 
+def test_current_schema_gets_valid_rows_in_every_table(tmp_path):
+    """New constrained tables must be seedable even before their first release tag exists."""
+    db_path = tmp_path / "vibe.sqlite"
+    guard.run_migrations(db_path)
+
+    short, _ = guard.seed_representative_rows(db_path)
+
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        tables = {
+            name
+            for (name,) in connection.execute(
+                "select name from sqlite_master where type = 'table' and name not like 'sqlite_%'"
+            )
+            if name != guard.ALEMBIC_BOOKKEEPING_TABLE
+        }
+        assert tables == guard.HEAD_TABLES
+        for table in tables:
+            assert connection.execute(f'select count(*) from "{table}"').fetchone()[0] >= guard.SEED_ROWS, table
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+        assert connection.execute("pragma foreign_key_check").fetchall() == []
+
+
+@pytest.mark.parametrize("minimum", [0, 4])
+def test_shape_repairs_follow_constraints_not_column_names(tmp_path, minimum):
+    db_path = tmp_path / "vibe.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"""
+            create table shaped (
+                id integer primary key,
+                a text not null,
+                b text not null,
+                c text not null,
+                d integer not null,
+                e integer not null,
+                constraint ck_a check (a glob 'R-[A-C][0-9]'),
+                constraint ck_b check (length(b) = 12 and b not glob '*[^0-9a-f]*'),
+                constraint ck_c check (length(c) = 9 and substr(c, 1, 4) = a),
+                constraint ck_counts check (typeof(d) = 'integer' and d >= 0
+                    and typeof(e) = 'integer' and e >= 0 and d + e > {minimum}
+                    and (d = 0 or c = ''))
+            )
+        """)
+
+    short, _ = guard.seed_representative_rows(db_path)
+
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("select count(*) from shaped").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+def test_numeric_candidates_use_the_column_affinity():
+    with sqlite3.connect(":memory:") as connection:
+        proposals = guard.shape_proposals(connection, "n > '0'", [("n", "INTEGER")], {"n": 0})
+        assert ("n", 1) in proposals
+        assert ("n", -1) not in proposals
+
+
+def test_unsupported_shapes_remain_a_visible_seed_failure(tmp_path):
+    db_path = tmp_path / "vibe.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"""
+            create table oversized (id integer primary key, value text not null,
+                constraint ck_width check (length(value) = {guard.SEED_TEXT_LIMIT + 1}))
+        """)
+
+    short, _ = guard.seed_representative_rows(db_path)
+
+    assert "ck_width" in short["oversized"]
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("select count(*) from oversized").fetchone()[0] == 0
+
+
 @requires_release_history
 def test_the_upgrade_property_runs_over_a_database_that_carries_rows(monkeypatch):
     """The seeding is only worth anything if the upgrade under test is the thing it precedes.

--- a/tests/test_migration_release_guard.py
+++ b/tests/test_migration_release_guard.py
@@ -1089,6 +1089,128 @@ def test_joint_numeric_search_preserves_single_column_repairs(changed):
         assert guard.shape_proposals(connection, expression, required, values) == [(f"n{changed}", 1)]
 
 
+@pytest.mark.parametrize("order", list(itertools.permutations(range(3))))
+@pytest.mark.parametrize("separate", [False, True])
+@pytest.mark.parametrize("patterns", [("A*", "*Z"), ("[A-C]*", "*[Y-Z]"), ("*A*", "*Z*"), ("\u00e9*", "*]")])
+def test_positive_globs_are_composed_in_every_check_order(tmp_path, order, separate, patterns):
+    requirements = ["length(code) = 4", *(f"code glob '{pattern}'" for pattern in patterns)]
+    expressions = [requirements[index] for index in order]
+    if not separate:
+        expressions = [" and ".join(expressions)]
+    checks = ", ".join(f"constraint ck_{index} check ({expression})" for index, expression in enumerate(expressions))
+    db_path = tmp_path / "vibe.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table shaped (id integer primary key, code text not null, {checks})")
+
+    short, _ = guard.seed_representative_rows(db_path)
+
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("select count(*) from shaped").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("pattern", ["[]]", "[^]]", "[]-]", "[-]", "[[]", "[]a]", "[a-]", "[\u00e9]", "?[]]*"])
+def test_glob_classes_follow_sqlite_token_semantics(tmp_path, pattern):
+    db_path = tmp_path / "vibe.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table shaped (id integer primary key, code text not null, constraint ck_code check (code glob '{pattern}'))")
+
+    short, _ = guard.seed_representative_rows(db_path)
+
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("select count(*) from shaped").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+def test_glob_intersection_matches_sqlite_over_a_finite_domain():
+    alphabet = "ab[]-"
+    patterns = ("*", "a*", "*b", "?a", "[ab]", "[]]", "[^]]", "[[]", "[-a]", "a**b", "[a-]", "[", "[]", "[^]")
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute("create table domain (value text, width integer)")
+        connection.executemany("insert into domain values (?, ?)", [
+            ("".join(chars), width) for width in range(4) for chars in itertools.product(alphabet, repeat=width)
+        ])
+        for left, right, width in itertools.product(patterns, patterns, range(4)):
+            expected = connection.execute(
+                "select value from domain where width = ? and value glob ? and value glob ? limit 1",
+                (width, left, right),
+            ).fetchone()
+            witness = guard.glob_witness(connection, (left, right), width=width, alphabet=alphabet)
+            assert (witness is None) == (expected is None), (left, right, width, witness)
+            if witness is not None:
+                assert len(witness) == width
+                assert connection.execute("select ? glob ? and ? glob ?", (witness, left, witness, right)).fetchone()[0]
+
+
+def test_glob_search_has_explicit_width_pattern_and_state_limits(monkeypatch):
+    with sqlite3.connect(":memory:") as connection:
+        assert guard.glob_witness(connection, ("*",), width=guard.SEED_TEXT_LIMIT + 1) is None
+        assert guard.glob_witness(connection, ("a" * (guard.SEED_TEXT_LIMIT + 1),)) is None
+        monkeypatch.setattr(guard, "SEED_GLOB_STATES", 3)
+        assert guard.glob_witness(connection, ("????",)) is None
+
+
+@pytest.mark.parametrize("patterns", [("A*", "B*"), ("[]", "*"), ("[", "*")])
+def test_unsatisfiable_glob_intersections_remain_visible_failures(tmp_path, patterns):
+    db_path = tmp_path / "vibe.sqlite"
+    expression = " and ".join(f"code glob '{pattern}'" for pattern in patterns)
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table shaped (code text not null, constraint ck_code check ({expression}))")
+    short, _ = guard.seed_representative_rows(db_path)
+    assert "ck_code" in short["shaped"]
+
+
+@pytest.mark.parametrize("count", [5, 6, 16])
+@pytest.mark.parametrize("bound", [0, 7, -7])
+@pytest.mark.parametrize("reverse", [False, True])
+def test_joint_boundary_repairs_are_not_starved_by_cartesian_prefix(tmp_path, count, bound, reverse):
+    names = [f"n{index}" for index in range(count)]
+    clauses = [f"{name} > {bound}" if bound >= 0 else f"{name} < {bound}" for name in names]
+    if reverse:
+        names.reverse()
+    columns = ", ".join(f"{name} integer not null" for name in names)
+    db_path = tmp_path / "vibe.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table shaped (id integer primary key, {columns}, constraint ck_counts check ({' and '.join(clauses)}))")
+
+    short, _ = guard.seed_representative_rows(db_path)
+
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("select count(*) from shaped").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize(
+    "column,check,expected",
+    [
+        ("tag TEXT", "tag is null", None),
+        ("tag TEXT DEFAULT 'ready'", "tag = 'ready'", "ready"),
+        ("tag TEXT DEFAULT (upper('ready'))", "tag = 'READY'", "READY"),
+        ("tag INTEGER DEFAULT 7", "tag = 7", 7),
+        ("tag INTEGER DEFAULT NULL", "tag is null", None),
+        ("tag INTEGER", "tag = 7", None),
+        ("tag TEXT GENERATED ALWAYS AS (case when n > 0 then 'ready' end)", "tag = 'ready'", "ready"),
+        ("tag TEXT GENERATED ALWAYS AS (case when n > 0 then 'ready' end)", "\"tag\" = 'ready'", "ready"),
+        ("tag INTEGER PRIMARY KEY", "\"tag\" > 0", 1),
+    ],
+)
+@pytest.mark.parametrize("reverse", [False, True])
+def test_numeric_check_context_includes_omitted_columns(column, check, expected, reverse):
+    columns = ["n INTEGER NOT NULL", column]
+    if reverse:
+        columns.reverse()
+    ddl = f"create table shaped ({', '.join(columns)}, constraint ck_n check (n > 0 and {check}))"
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute(ddl)
+        objection, settled = guard.insert_seed_row(connection, "shaped", ddl, [("n", "INTEGER")], {"n": 0})
+        assert (objection, settled) == ("", True)
+        assert connection.execute("select n, tag from shaped").fetchall() == [(1, expected)]
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
 @pytest.mark.parametrize("reverse", [False, True])
 def test_prefix_sources_can_be_derived_from_json_checks(tmp_path, reverse):
     db_path = tmp_path / "vibe.sqlite"


### PR DESCRIPTION
## Summary

## Owner-Directed Early Merge

At 2026-09-08 10:37:30 CST the owner explicitly requested merging the current CI-green head first to unblock dependent PRs, then opening a separate PR for the remaining five findings. This overrides the normal clean-review/zero-unresolved gate for this merge only. Merge target: b2bb3b339778c78badc236b4582402830f4cd70f. Its 17 expected CI checks pass, but Codex has NOT passed this head and the five current threads remain unresolved. They will be linked from the follow-up PR, not marked fixed here. Uncommitted follow-up reproduction tests are excluded from this merge. No deployment or merge of another PR is authorized.

## Capability

Repair migration-release-guard fixture generation for CHECK-constrained text and counters. Publishing gh-v3.0.15rc6 exposed the existing seeder's inability to populate skill_usage_daily, blocking the otherwise unrelated cursor PR #1932.

- Extend the existing bounded candidate mechanism with SQLite-validated intersections of positive GLOB patterns, fixed-width/alphabet repairs, substring relationships, and integer boundary candidates.
- Evaluate integer candidates against the complete rejected CHECK with declared column types and omitted default/NULL context. Single-column attempts use at most half the budget before whole-row boundary assignments; the remaining search includes the Cartesian product. Generated columns, implicit primary keys, and unsupported projection context defer bounded proposals to the real INSERT.
- Verify that the current, potentially unreleased schema can populate every table and passes SQLite integrity and foreign-key checks. This catches fixture gaps before a release tag makes them part of historical upgrade coverage.

## Scope And Dependencies

- Only scripts/migration_release_guard.py and tests/test_migration_release_guard.py change.
- Independent branch from master at 6bad0ca137ca9a72678511a094d366aa7e48af36; no dependency on an unmerged PR.
- Repairs the baseline CI blocker observed in #1932 and #1934, not their feature changes. After this fix is merged with separate authorization, those PRs can incorporate the updated baseline normally and obtain fresh exact-head CI/review evidence. No duplicate fix or unmerged repair is incorporated into either consumer.
- No migration revision, production schema, database constraint, workflow gate, dependency, or user-facing documentation changes.
- No application scenario IDs change; this is the migration verification harness.

## Evidence

- Red/green reproduction: both the current-schema invariant and neutral-column constrained fixture failed before the fix.
- 787 tests passed across test_migration_release_guard.py, test_skill_observability_migration.py, test_sqlite_state_migration.py, test_dev_state_migration_guard.py, and test_migration_lock.py after the third review fixes (no skips).
- Includes the complete tagged-release upgrade check, including the previously failing gh-v3.0.15rc6 graph; no tests skipped.
- Consuming tests permute every declaration order for the four related CHECKs, across mixed identifier case, GLOB/literal prefix sources, and zero/nonzero numeric bounds; JSON prefix sources cover both declaration orders. Boundary tests cover signed-64-bit limits, oversized decimal tokens, leading zeroes, JSON numeric types, bounded variation, and SQLite's ASCII-only identifier folding. Every current table still carries at least two valid rows; impossible-schema and repetition/refusal tests remain intact.
- Second-head composition tests cover every order of length, positive GLOB, and forbidden-character requirements, together and in separate CHECKs; wildcard positions, zero/maximum widths, and different alphabets are included. Numeric tests permute all column/clause orders for two- and three-column dependencies, preserve single-column repairs at every position, and verify the total evaluation budget through SQLite's trace callback.
- Third-head tests cover positive-pattern intersections across every CHECK order, closing-bracket classes, Unicode literals, and a differential oracle against SQLite for every pair of 14 patterns at widths 0-3 over a finite alphabet (784 comparisons). They verify explicit state/width/pattern limits and visible failures, joint boundary assignments for 5/6/16 columns, omitted NULL/default expressions, SQLite CHECK NULL acceptance, quoted generated columns, and implicit primary-key context. All four reviewed failures were reproduced before the fix.
- Ruff and git diff --check passed. Existing SQLAlchemy expression-index reflection warnings remain.
- Local Incus regression is unavailable and was not run. No production database or remote regression environment was used. UI/browser verification is unchanged and belongs to #1932.

## Known By Design

- This remains a bounded, schema-derived fixture generator, not a general constraint solver or a per-table/per-release fixture registry. SQLite validates every actual INSERT.
- Text-width proposals and the combined positive-pattern length are bounded at 4096 characters. GLOB intersection search stores at most 16384 joint states. Character-class witnesses use a finite printable alphabet augmented with characters present in the patterns, then restricted by supported forbidden-character requirements. SQLite decides token membership and final pattern validity. Unsupported constraints remain visible seed failures; no release or table is skipped to turn the gate green.
- Integer candidates and their variations stay within SQLite's signed-64-bit binding range. Constraints that require values outside that finite candidate domain remain explicit seed failures, not exceptions or claimed coverage. Numeric tokens are bounded before Python integer parsing; SQLite handles JSON numeric values without Python arbitrary-precision binding.
- Numeric evaluation examines at most 60 assignments per proposal call, counting single-column attempts, prioritized whole-row boundaries, and the joint product together. Single-column search cannot consume more than the first 30 slots before joint boundaries run. Large heterogeneous domains can remain explicit seed failures; no exhaustive constraint-solving claim is made. Every final row still has to pass a real INSERT within the unchanged 60-attempt insertion budget.
- GLOB witnesses satisfy every positive pattern for a column simultaneously while retaining required widths and the permitted finite alphabet. Existing matching text is retained. Incompatible widths/patterns, exhausted search budgets, and unsupported combinations remain visible failures rather than being truncated into claimed valid rows.
- Omitted ordinary columns use their declared default expression or NULL in numeric evaluation; NULL CHECK results are accepted as SQLite accepts them. Generated columns and implicit primary keys are not falsely projected as NULL or a quoted string. Their referenced context, or a projection SQLite cannot evaluate, defers bounded numeric proposals to the real INSERT without claiming those proposals were prevalidated.
- Related text CHECKs are considered together. When a prefix source needs a literal or JSON candidate from a different CHECK, only that source dependency is followed; unrelated literals cannot overwrite already-satisfied columns. This remains the existing bounded candidate mechanism, not a general constraint search.
- Existing refusal reporting, attempt limits, minimum row coverage, reference resolution, and read-back repetition checks remain in place. No guard is waived or weakened.
- Submission and review only; merging or deployment requires separate authorization.

## Review Inventory And Scope Decision

Findings-bearing head count: four. Head `41c067bd39b03ada6826209225c2845be8bc3701` received three findings; head `ffbf2aa360f5fd9329ea750df9ec4010df8e79d7` received two; head `aef3f40ca15f8e9e255ca813ffd96546bb1e9ff3` received four; head `b2bb3b339778c78badc236b4582402830f4cd70f` received five. All fourteen paginated threads, all bot reviews/verdicts, and every exact-head lint run/job/check were inspected before further edits. The fourth head's 17 checks passed, but its terminal review has findings. It is the first findings-bearing head following the conservatively tracked GLOB candidate-model rewrite; historical classes are not reset.

| Root cause | Review thread | Scope decision |
| --- | --- | --- |
| Cross-CHECK dependency order | [3950623523](https://github.com/avibe-bot/avibe/pull/1933#discussion_r3950623523) | Derive text shapes across related CHECKs and follow existing literal/JSON proposals only for prefix-source dependencies; assert all CHECK permutations. |
| Numeric parsing and SQLite binding bounds | [3950623531](https://github.com/avibe-bot/avibe/pull/1933#discussion_r3950623531) | Bound decimal parsing, integer proposals, and variations at their shared entry points; let SQLite interpret JSON numbers; retain visible refusal outside the supported domain. |
| SQLite identifier case resolution | [3950623536](https://github.com/avibe-bot/avibe/pull/1933#discussion_r3950623536) | Use one ASCII-only identifier key across shape, literal, JSON, and numeric proposals while preserving actual column spellings, literal values, and JSON path case. |
| Constraint composition: GLOB and required length | [3950911804](https://github.com/avibe-bot/avibe/pull/1933#discussion_r3950911804) | Generate a width-aware GLOB witness, including wildcard expansion, rather than discarding an already-derived width. |
| Constraint composition: coordinated numeric values | [3950911813](https://github.com/avibe-bot/avibe/pull/1933#discussion_r3950911813) | Evaluate a bounded product of numeric candidates as joint assignments; retain the winning assignment's changes instead of requiring each individual change to satisfy the entire CHECK. |
| Constraint composition: positive GLOB intersection | [3951083001](https://github.com/avibe-bot/avibe/pull/1933#discussion_r3951083001) | Replace sequential per-pattern overwrites with one bounded intersection search over all patterns for the column. |
| Constraint composition: numeric search fairness | [3951083012](https://github.com/avibe-bot/avibe/pull/1933#discussion_r3951083012) | Prioritize joint boundary assignments before Cartesian enumeration; do not simply raise the budget. |
| Candidate validation context | [3951083023](https://github.com/avibe-bot/avibe/pull/1933#discussion_r3951083023) | Include omitted default/NULL columns and SQLite CHECK NULL semantics; unsupported synthetic context must defer boundary proposals to the real INSERT. |
| SQLite GLOB token semantics | [3951083027](https://github.com/avibe-bot/avibe/pull/1933#discussion_r3951083027) | Recognize a leading closing bracket inside character classes, while SQLite still decides character membership and final validity. |
| Candidate validation context: insertion affinity | [3953808110](https://github.com/avibe-bot/avibe/pull/1933#discussion_r3953808110) | Replace CAST projections with an ephemeral typed candidate table so SQLite performs insertion affinity and defaults; no target constraint is disabled. |
| Constraint composition: heterogeneous numeric domains | [3953808117](https://github.com/avibe-bot/avibe/pull/1933#discussion_r3953808117) | Rank each column's bounded domain using its literal predicates before joint enumeration; remove the singles/uniform budget split. |
| Equivalent predicate normalization | [3953808120](https://github.com/avibe-bot/avibe/pull/1933#discussion_r3953808120) | Normalize substring equality operand order and equivalent equality spellings once for both dependency discovery and candidate construction. |
| Numeric producer/consumer type classification | [3953808127](https://github.com/avibe-bot/avibe/pull/1933#discussion_r3953808127) | Share SQLite affinity classification across representative values and numeric candidates; cover declared numeric types and precedence. |
| Constraint composition: negative GLOB languages | [3953808133](https://github.com/avibe-bot/avibe/pull/1933#discussion_r3953808133) | Carry negative-pattern states in the existing joint automaton and require their rejection; remove the special-case forbidden-alphabet transform. |

### Second-Head Circuit-Breaker Diagnosis

The two latest findings repeat the broader constraint-composition class already exposed by first-head cross-CHECK dependency ordering. This triggers the repeated-class breaker; implementation paused for orchestrator diagnosis rather than treating the comments as unrelated new classes. Both examples were reproduced against SQLite before editing: the seeder refused each table while explicit valid rows passed integrity checks.

The cause is local candidate composition: text transformations overwrite an earlier requirement, while numeric filtering assumes only one column may need to change. The existing schema-derived, bounded candidate model can express both cases. The smallest complete scope is width-aware GLOB generation plus bounded joint numeric evaluation within the existing shape-proposal owner. Width/character constraints and numeric column/clause permutations will be consuming tests. Unsupported domains must still fail visibly; this is not a completeness claim for arbitrary SQL constraints.

Orchestrator decision: continue in the same two files, retain the actual INSERT as authority, preserve the 60 INSERT-attempt limit and minimum-row/refusal invariants, and cap joint numeric evaluation separately at the existing attempt budget. No application architecture, data model, migrations, workflow, dependencies, or production state changes are warranted. This is a localized candidate-algorithm correction, not an application architecture or data-model rewrite.

### Third-Head Circuit-Breaker Diagnosis

The third head repeats constraint composition again, so the breaker paused implementation before another edit or push. All four fresh examples were reproduced: the existing generator refused them, while explicit witnesses passed real SQLite INSERTs and integrity checks. The two new classes are incomplete synthetic row context and SQLite character-class tokenization, not storage migration failures.

The earlier assumption that ordered text transformations sufficiently compose requirements is disproved. The text candidate owner will instead intersect the GLOB languages with a bounded joint-state search. SQLite remains responsible for token membership and final validity; the implementation only traverses finite states. Fixed widths and the finite alphabet stay explicit, and a state cap keeps resource use bounded. This replaces the old witness construction rather than adding a second fallback implementation.

The numeric domain is still a bounded heuristic, not an SMT solver. Preserve the 60-evaluation cap, but prioritize whole-row boundary assignments so five or more identical positive predicates do not depend on a Cartesian index exponential in the column count. Include omitted columns using their actual declared default expressions or NULL. If a synthetic projection cannot represent a referenced column, offer safe boundary proposals to the authoritative INSERT instead of treating the missing context as an exhausted domain.

Decision: continue within the same two harness files, without dependencies, migrations, schema/workflow changes, skipped coverage, or production operations. This replaces the GLOB candidate algorithm; conservatively track it as a candidate-model rewrite for subsequent review-loop gating. Further composition repeats still require renewed orchestrator diagnosis, irrespective of green tests. The general finite-search limitation remains documented, not silently presented as schema unsatisfiability.

### Fourth-Head Circuit-Breaker Diagnosis

The fourth review repeats both constraint composition and candidate validation context. The breaker paused edits/pushes again. All five examples were reproduced against the unchanged reviewed head: the seeder refused each and a direct valid SQLite INSERT passed integrity checks. The remaining two classes are equivalent predicate normalization and inconsistent numeric type classification. Existing diff ownership and consuming tests were inspected independently; test/CI success does not settle these defects.

The default failure shows that CAST is not an insertion-affinity emulator, as documented by [SQLite's affinity rules](https://www.sqlite.org/datatype3.html#type_affinity). Replace that projection with one ephemeral typed candidate table on the fixture connection, populated through real INSERTs with the declared defaults, then evaluate the rejected CHECK there. The helper owns creation/cleanup and never disables constraints or alters the source table; the final INSERT into the unchanged schema remains authoritative. Generated or otherwise unrepresentable context retains explicit bounded fallback, not fabricated NULL values.

Uniform numeric tuples were an insufficient priority model, not evidence that the budget should grow. Replace the singles/uniform allocation with predicate-ranked per-column finite domains, then validate joint assignments with the same total 60-CHECK-evaluation cap. Ranking is only a proposal heuristic, not a truth evaluator for arbitrary SQL. The shared affinity classifier must follow SQLite precedence so BOOLEAN/NUMERIC and other numeric declarations receive the same candidate capability. Substring dependency extraction and construction will consume one normalized equality representation rather than separate regex interpretations.

The joint GLOB state model already expresses negative patterns: retain their states, accept only when none matches, and prune dead states only for positive requirements. Replace the special forbidden-character mutation with that one positive/negative owner. Differential tests will cover every polarity combination, malformed negative classes, fixed widths, and explicit resource bounds, alongside consuming table tests.

Scope decision: continue within the same two files. These are reversible corrections at the existing candidate owner; no application/schema/migration/workflow/dependency or production changes are needed. No release/table/constraint is skipped, and insertion attempts, minimum-row coverage, reference restoration, and refusal/repetition evidence stay unchanged. The typed evaluator and ranked numeric strategy are conservatively tracked as a further candidate-model rewrite. Preserve all four reviewed-head counts; any further repeated class requires renewed diagnosis before editing.
