### PR TITLE
fix(model-hub): avoid route-removal prompts on inventory gains

### DIFF
--- a/core/handlers/model_hub/service.py
+++ b/core/handlers/model_hub/service.py
@@ -3424,7 +3424,19 @@ class ModelHubService:
     ) -> tuple[list[dict], list[dict]]:
         invalidated = self._invalidated_route_hops(updated, source_id)
         self._prune_invalidated_route_hops(updated, invalidated)
-        would_remove_hops = self._removed_effective_hops(previous, updated)
+        # Inventory evidence narrows speculative candidates without deleting routes.
+        # Keep explicit invalidations and newly introduced supply gaps guarded below.
+        would_remove_hops = [
+            item for item in self._removed_effective_hops(previous, updated)
+            if not (
+                effective_model_route(
+                    previous, cast(BackendName, item["backend"]), item["menu_model"],
+                ).route_origin == "passthrough"
+                and effective_model_route(
+                    updated, cast(BackendName, item["backend"]), item["menu_model"],
+                ).route_origin == "automatic"
+            )
+        ]
         would_remove_hops.extend(item for item in invalidated if item not in would_remove_hops)
         would_interrupt = self._introduced_interruptions(previous, updated)
         self._require_guard_plan(

--- a/docs/plans/model-hub-contracts/api.md
+++ b/docs/plans/model-hub-contracts/api.md
@@ -602,6 +602,13 @@ state. It counts only runnable exact hops in that model's effective Route chain,
 eligible inventory or the backend Source order by itself. A pair with no runnable hop
 appears once in `would_interrupt` or `interrupted`.
 
+Inventory updates that refine an inherited `passthrough` plan into `automatic`
+matching do not report displaced speculative candidates as `would_remove_hops` or
+`removed_hops`, in either Hub or Direct mode. They leave saved route intent unchanged.
+Explicit manual-hop invalidations, lost inventory matches, and newly introduced
+protected-supply gaps still use the exact-plan guard. This exception does not apply
+to Source deletion, default-membership changes, or Restore.
+
 Every guarded Source/inventory mutation uses the §4.5 envelope matrix and the complete
 `guard-refusal.schema.json` shape. The first refusal is:
 

--- a/docs/plans/model-hub.md
+++ b/docs/plans/model-hub.md
@@ -1176,8 +1176,16 @@ under one commit lock. Inventory disappearance can change an automatic matching 
 it never invalidates an explicit API-key manual invocation by itself. Subscription
 model-membership admission remains unchanged. Explicit retirement
 excludes the exact pair, while manual inventory deletion removes matching evidence
-without deleting explicit API-key hops; subscription admission remains unchanged. Refusals report complete effective removals and protected
-supply loss in the existing arrays. Forced success must match both echoed arrays and
+without deleting explicit API-key hops; subscription admission remains unchanged.
+When inventory evidence changes an inherited plan from `passthrough` to `automatic`,
+displaced speculative candidates are not destructive removals and are excluded from
+`would_remove_hops` / `removed_hops`. This applies equally to active Hub plans and
+dormant Direct plans: learning a model list does not delete saved route intent.
+Explicit manual-hop invalidations, disappearance of existing inventory matches, and
+new protected-supply loss remain guarded. Other mutation guards, including Source
+deletion, default membership and Restore, continue to compare all effective removals.
+Refusals report complete destructive removals and protected supply loss in the
+existing arrays. Forced success must match both echoed arrays and
 preserves surviving nonempty manual intent; Source deletion removes its actual references.
 Every final-hop removal, including catalog reconciliation, uses the same normalized
 planner. Normal saves persist the canonical sparse map; pure reads/preview never write.

--- a/tests/scenarios/model_hub/catalog.yaml
+++ b/tests/scenarios/model_hub/catalog.yaml
@@ -167,6 +167,9 @@ scenarios:
     kind: persistence
     layer: scenario
     test: tests/scenarios/model_hub/test_model_hub_configured_route_scenarios.py::test_mh_routing_003_manual_intent_survives_refresh_default_reorder_and_reload
+    partial_evidence:
+      covers: Inventory gains refine inherited candidates without destructive confirmations or saved-intent changes in Hub and Direct modes
+      test: tests/scenarios/model_hub/test_model_hub_configured_route_scenarios.py::test_mh_routing_003_refresh_refines_inherited_candidates_without_removing_saved_routes
   - id: MH-ROUTING-004
     name: Restore and undo previews are inert and committed restore deletes the override idempotently
     status: covered

--- a/tests/scenarios/model_hub/test_model_hub_configured_route_scenarios.py
+++ b/tests/scenarios/model_hub/test_model_hub_configured_route_scenarios.py
@@ -137,6 +137,48 @@ def test_mh_routing_003_manual_intent_survives_refresh_default_reorder_and_reloa
 
 
 @pytest.mark.parametrize("backend", ["claude", "codex", "opencode"])
+@pytest.mark.parametrize("mode", ["hub", "direct"])
+@pytest.mark.parametrize("inventory", [[], ["unrelated-inventory-model"]], ids=["empty", "incomplete"])
+@pytest.mark.parametrize("intent", ["manual", "absent", "legacy-empty"])
+def test_mh_routing_003_refresh_refines_inherited_candidates_without_removing_saved_routes(
+    tmp_path, backend, mode, inventory, intent,
+):
+    """MH-ROUTING-003: gaining inventory evidence is not a destructive route mutation."""
+    first = source("src_refreshfirst", ["other-provider-model"])
+    second = source("src_refreshsecond", inventory, vendor="openai", protocol="openai_responses")
+    manual = {"manual": [(first.id, "vendor/unlisted-original")], "absent": None, "legacy-empty": []}[intent]
+    config, model = _routing_config(backend, [first, second], manual=manual)
+    config.agents[backend].mode = mode
+    config = round_trip(config)
+    before = config.to_payload()
+    store = MemoryModelHubStore(config)
+    adapter = ModelHubScenarioAdapter(refresh_models=(*inventory, model))
+    service = service_for(tmp_path, store, adapter)
+
+    result = asyncio.run(service.refresh_source(second.id))
+
+    assert result["removed_hops"] == result["interrupted"] == []
+    persisted = round_trip(store.load()).to_payload()
+    assert persisted["agents"] == before["agents"]
+    assert persisted["sources"][0] == before["sources"][0]
+    assert [item["id"] for item in persisted["sources"][1]["models"]] == [*inventory, model]
+    assert len(store.saved_payloads) == 1
+    reloaded = service_for(tmp_path / "reload", MemoryModelHubStore(round_trip(store.load())), adapter)
+    resolution = resolve_model_hub_turn(reloaded.store.load(), backend, model, now=reloaded.now())
+    if mode == "direct":
+        assert resolution.channel == "direct"
+        assert resolution.route_origin is None
+        assert resolution.source_model_ids == ()
+    else:
+        assert resolution.route_origin == ("manual" if intent == "manual" else "automatic")
+        assert list(resolution.source_model_ids) == (
+            manual if intent == "manual" else [(second.id, model)]
+        )
+    assert adapter.observation_calls == adapter.invocations == []
+    assert adapter.discovery_calls == [(second.vendor, second.protocol, second.base_url, second.credential_ref)]
+
+
+@pytest.mark.parametrize("backend", ["claude", "codex", "opencode"])
 @pytest.mark.parametrize("operation", ["delete", "empty-put"])
 def test_mh_routing_004_preview_cancel_undo_are_inert_and_restore_deletes_only_override(tmp_path, backend, monkeypatch, operation):
     """MH-ROUTING-004: draft restore is read-only; committed restore removes the override idempotently."""

--- a/tests/test_model_hub_api.py
+++ b/tests/test_model_hub_api.py
@@ -5646,6 +5646,45 @@ def test_model_hub_routes_reject_non_object_json_with_error_envelope(
         assert body["error"] == error
 
 
+@pytest.mark.parametrize("mode", ["hub", "direct"])
+def test_refresh_empty_inventory_returns_success_without_route_removal_confirmation(monkeypatch, tmp_path, mode):
+    service, store, adapter = _service(tmp_path)
+    for vendor, protocol in (("anthropic", "anthropic"), ("openai", "openai_responses")):
+        store.config.sources.append(ModelHubSourceConfig(
+            id=f"src_{vendor}01", kind="api_key", vendor=vendor, display_name=vendor,
+            protocol=protocol, supply_channel="hub", billing="metered",
+            state=ModelHubSourceStateConfig(status="standby"),
+            models=[ModelHubModelConfig(id="claude-opus-4-6", provenance="discovered")] if vendor == "anthropic" else [],
+            credential_ref=f"cred_{vendor}01",
+        ))
+    for agent in store.config.agents.values():
+        agent.sources.order = [source.id for source in store.config.sources]
+        agent.routes = {}
+    store.config.agents["codex"].mode = mode
+    models = [model.id for model in store.config.agents["codex"].models]
+
+    async def discover(*_args):
+        return tuple(DiscoveredModel(id=model) for model in models)
+
+    adapter.discover_models = discover
+    before = store.config.to_payload()
+    monkeypatch.setattr(ui_server, "_model_hub_service", lambda: service)
+    client = app.test_client()
+    base_url = "http://127.0.0.1:15131"
+    response = client.post(
+        "/api/models/sources/src_openai01/refresh", json={},
+        headers=csrf_headers(client, base_url), base_url=base_url,
+    )
+    assert response.status_code == 200
+    body = response.get_json()
+    _assert_envelope(body, ok=True)
+    assert body["removed_hops"] == body["interrupted"] == []
+    assert [model["id"] for model in body["source"]["models"]] == models
+    after = store.config.to_payload()
+    assert after["agents"] == before["agents"]
+    assert after["sources"][0] == before["sources"][0]
+
+
 def test_discovered_source_model_delete_persists_retirement_tombstone(
     monkeypatch,
     tmp_path,

--- a/tests/test_model_hub_routing_modes.py
+++ b/tests/test_model_hub_routing_modes.py
@@ -471,13 +471,15 @@ def test_legacy_empty_key_keeps_derived_catalog_but_invalid_nonmenu_key_is_not_r
 
 
 @pytest.mark.parametrize("backend", ["claude", "codex", "opencode"])
+@pytest.mark.parametrize("mode", ["hub", "direct"])
 @pytest.mark.parametrize("operation", ["retire_discovered", "remove_subscription_manual", "refresh_subscription"])
-def test_final_inventory_hop_removal_uses_inherited_guard_plan(tmp_path, backend, operation):
+def test_final_inventory_hop_removal_uses_inherited_guard_plan(tmp_path, backend, mode, operation):
     default = _source("src_default01", (MODEL,))
     manual = _source("src_manual001", ("mapped",), kind="api_key" if operation == "retire_discovered" else "subscription")
     if operation == "remove_subscription_manual":
         manual.models[0].provenance = "manual"
     config = _loaded_catalog_config(backend, MODEL, default)
+    config.agents[backend].mode = mode
     config.sources.append(manual)
     config.agents[backend].routes[MODEL] = ModelHubRouteConfig(hops=(ModelHubRouteHopConfig(manual.id, "mapped"),))
     service, store, adapter = _service(tmp_path, config)
@@ -502,8 +504,10 @@ def test_final_inventory_hop_removal_uses_inherited_guard_plan(tmp_path, backend
     ))
     assert result["interrupted"] == []
     assert store.config.agents[backend].routes == {}
-    assert service.agent_chain(backend, MODEL)["current"] == {"source_id": default.id, "model_id": MODEL}
-    assert service._bindings(store.config)[0].route_model_ids == (MODEL,)
+    assert _pairs(effective_model_route(store.config, backend, MODEL)) == [(default.id, MODEL)]
+    if mode == "hub":
+        assert service.agent_chain(backend, MODEL)["current"] == {"source_id": default.id, "model_id": MODEL}
+        assert service._bindings(store.config)[0].route_model_ids == (MODEL,)
 
 
 @pytest.mark.parametrize("backend", ["claude", "codex", "opencode"])
@@ -598,12 +602,8 @@ def test_empty_intent_follows_refresh_defaults_and_health_without_reseeding(tmp_
     service, store, adapter = _service(tmp_path, config)
     assert service.agent_chain(backend, MODEL)["route_origin"] == "passthrough"
     adapter.discovered = (MODEL,)
-    with pytest.raises(ModelHubError) as refusal:
-        asyncio.run(service.refresh_source(second.id))
-    asyncio.run(service.refresh_source(second.id, force=True,
-        confirmed_remove_hops=refusal.value.data["would_remove_hops"],
-        confirmed_interruptions=refusal.value.data["would_interrupt"],
-    ))
+    refreshed = asyncio.run(service.refresh_source(second.id))
+    assert refreshed["removed_hops"] == refreshed["interrupted"] == []
     assert service.agent_chain(backend, MODEL)["route_origin"] == "automatic"
     bindings = service._bindings(store.config)
     store.config.sources[1].state = ModelHubSourceStateConfig(status="error", detail_key="models.source.error.unclassified")
@@ -615,6 +615,60 @@ def test_empty_intent_follows_refresh_defaults_and_health_without_reseeding(tmp_
     asyncio.run(service.set_agent_sources(backend, {"order": [first.id], "force": True, **defaults.value.data}))
     assert service.agent_chain(backend, MODEL)["route_origin"] == "passthrough"
     assert store.config.agents[backend].routes == {}
+
+
+@pytest.mark.parametrize("backend", ["claude", "codex", "opencode"])
+def test_inventory_refinement_still_guards_new_supply_loss(tmp_path, backend):
+    fallback = _source("src_fallback1", ())
+    known = _source("src_known0001", (), status="error")
+    known.state.detail_key = "models.source.error.unclassified"
+    config = _loaded_catalog_config(backend, MODEL, fallback, known)
+    service, store, adapter = _service(tmp_path, config)
+    updated = copy.deepcopy(config)
+    updated.sources[1].models = [ModelHubModelConfig(id=MODEL, provenance="discovered")]
+    before = config.to_payload()
+    with pytest.raises(ModelHubError) as refusal:
+        service._guard_inventory_mutation(
+            config, updated, known.id, force=False,
+            confirmed_remove_hops=None, confirmed_interruptions=None,
+        )
+    assert refusal.value.code == "source_last_supplier"
+    assert refusal.value.data == {
+        "would_remove_hops": [],
+        "would_interrupt": [{"backend": backend, "model_id": MODEL, "agents": []}],
+    }
+    assert store.config.to_payload() == before
+    assert adapter.synced == []
+
+
+@pytest.mark.parametrize("backend", ["claude", "codex", "opencode"])
+@pytest.mark.parametrize("mode", ["hub", "direct"])
+def test_refresh_preserves_guard_for_disappearing_inventory_matches(tmp_path, backend, mode):
+    first = _source("src_refresh01", (MODEL,))
+    second = _source("src_refresh02", (MODEL,))
+    config = _loaded_catalog_config(backend, MODEL, first, second)
+    config.agents[backend].mode = mode
+    service, store, adapter = _service(tmp_path, config)
+    adapter.discovered = ()
+    before = config.to_payload()
+    with pytest.raises(ModelHubError) as refusal:
+        asyncio.run(service.refresh_source(second.id))
+    assert refusal.value.code == "source_model_in_route_chain"
+    assert refusal.value.data == {
+        "would_remove_hops": [{
+            "backend": backend, "menu_model": MODEL, "source_id": second.id,
+            "model_id": MODEL, "position": 2,
+        }],
+        "would_interrupt": [],
+    }
+    assert store.config.to_payload() == before
+    assert adapter.synced == []
+    result = asyncio.run(service.refresh_source(second.id, force=True,
+        confirmed_remove_hops=refusal.value.data["would_remove_hops"],
+        confirmed_interruptions=refusal.value.data["would_interrupt"],
+    ))
+    assert result["removed_hops"] == refusal.value.data["would_remove_hops"]
+    assert result["interrupted"] == []
 
 
 @pytest.mark.parametrize("backend", ["claude", "codex"])


### PR DESCRIPTION
## Summary

Fix the false destructive confirmation when refreshing a provider with an empty or incomplete model inventory. Discovering a matching model changes an inherited plan from speculative API-key passthrough to inventory-backed matching; it does not delete the user's saved routes.

The inventory guard now excludes that specific candidate refinement from its removal arrays while preserving explicit-hop invalidations, actual inventory-match removals, and newly introduced supply gaps. Routing, provider detection, credential validation, and UI behavior are otherwise unchanged.

## Reproduction

Two API-key providers are in the default source order: one lists Claude models and the new OpenAI-compatible provider has an empty inventory. There are no saved manual routes; Codex is in Direct mode. Refreshing the OpenAI provider discovers the Codex catalog. Previously the guard reported the displaced Claude-provider speculative candidates as route deletions and returned HTTP 409. It now returns HTTP 200 with empty `removed_hops` and `interrupted`, persists the inventory, and leaves all backend configuration and the other provider unchanged.

## Evidence

- Unit: reproduced the false refusal before the fix; cover all three backends, retained destructive inventory/manual-hop guards, exact confirmation echo, and real supply-loss protection.
- API: the actual refresh endpoint returns the ordinary success envelope for the initially empty provider in both Hub and Direct modes, with no configuration changes outside its inventory/health metadata.
- Scenario: extend `MH-ROUTING-003` with empty/incomplete inventory, manual/absent/legacy-empty intent, all three backends, both modes, and persistence/reload checks; register the evidence in the scenario catalog.
- Local validation: full Model Hub unit/API/scenario suite passed (2039 passed, 1 existing expected failure); Ruff at the CI-pinned 0.4.9, whitespace checks, and Model Hub authority closure passed.
- Residual manual check: browser acceptance against an installed build is deferred. The running local Avibe, its configuration, and its processes were not updated or restarted; no live credential probes were made for this fix.

## Known By Design

- Automatic matching still excludes speculative alternatives once inventory evidence exists; this PR changes only whether that evidence refinement counts as a destructive mutation.
- Explicit route invalidation, disappearance of an existing matching hop, and newly introduced protected supply loss still require the unchanged exact-plan confirmation.
- Source deletion, default source membership edits, and Restore retain their existing full effective-removal guards, including protection of dormant saved intent.
- Provider authentication/detection is explicitly outside this PR's scope.

## CI Dependency

The initial head passed Codex review but exposed an existing baseline CI blocker: `migration-release-guard` could not seed `skill_usage_daily` in the released `gh-v3.0.15rc6` schema (`ck_skill_usage_day`). Dependency #1933 was independently merged into `master` as `a58644528deb8365876915904d11fb89df48db11`; this branch now incorporates that landed base normally. The PR diff against `master` contains no seeder or schema changes.

The installer job's transient HTTP 504 cleared on the single targeted retry. After base integration, 1292 focused API, routing, scenario and migration-release-guard tests passed locally, including the released-history repair; authority closure and whitespace checks passed. Fresh exact-head Codex review and all 17 expected CI jobs are required for the integration head `27b4119d90694911a0c791c545bbe49cd539a7f5`; the earlier pass is not reused.

Based on `master` with #1920 already merged. No deployment or running-local update is included.
