### PR TITLE
fix(ci): preserve SQLite seed candidate semantics

### DIFF
--- a/scripts/migration_release_guard.py
+++ b/scripts/migration_release_guard.py
@@ -1032,12 +1032,15 @@ def check_proposals(
         for match in sql_matches(pattern, expression):
             parts[match.start():match.end()] = " " * (match.end() - match.start())
     expression = "".join(parts)
-    literals = [match.group()[1:-1].replace("''", "'") for match in SQL_OPAQUE.finditer(expression) if match.group().startswith("'")]
+    if not any(match.group().startswith("'") for match in SQL_OPAQUE.finditer(expression)):
+        return []
     mentioned = sql_identifiers(expression)
     named = [column for column in columns if identifier_key(column) in mentioned]
     names = {identifier_key(column): column for column in named}
+    context_columns = tuple(context_columns)
+    terms = list(conjunctive_terms(expression, (*columns, *context_columns)))
     preferred = []
-    for term in conjunctive_terms(expression, (*columns, *context_columns)):
+    for term in terms:
         for reverse in (False, True):
             operands = (SQL_STRING, SQL_IDENTIFIER) if reverse else (SQL_IDENTIFIER, SQL_STRING)
             match = re.fullmatch(rf'\s*({operands[0]}){EQUALITY}({operands[1]})\s*', term, SQL_FLAGS)
@@ -1046,8 +1049,16 @@ def check_proposals(
                 column = names.get(identifier_key(unquote_identifier(token)))
                 if column is not None:
                     preferred.append((column, literal[1:-1].replace("''", "'")))
-    # An explicit binding should not first be broadcast into unrelated columns.
-    return list(dict.fromkeys([*preferred, *((column, literal) for column in named for literal in literals)]))
+    # Reuse the semantic owners' connectivity: a literal may help a functional
+    # dependent, but cannot repair a disconnected term's column.
+    recipients = semantic_recipients(expression, named, context_columns=context_columns)
+    scoped = []
+    for term in terms:
+        keys = sql_identifiers(term)
+        targets = set().union(*(recipients[name] for name in named if identifier_key(name) in keys))
+        literals = [match.group()[1:-1].replace("''", "'") for match in SQL_OPAQUE.finditer(term) if match.group().startswith("'")]
+        scoped.extend((name, literal) for name in named if name in targets for literal in literals)
+    return list(dict.fromkeys([*preferred, *scoped]))
 
 
 SeedAssignment = tuple[tuple[str, object], ...]
@@ -1293,6 +1304,7 @@ def conjunctive_terms(expression: str, columns: Iterable[str] = ()) -> Iterable[
         between = False
         outer_start = outer_end = None
         commas = []
+        cast_as = None
         for token in re.finditer(rf'\(|\)|,|{SQL_IDENTIFIER}', active, SQL_FLAGS):
             kind = token.group().lower()
             if kind == '(':
@@ -1310,6 +1322,8 @@ def conjunctive_terms(expression: str, columns: Iterable[str] = ()) -> Iterable[
             elif kind == ',':
                 if depth == 1 and case_depth == 0:
                     commas.append(token.start())
+            elif kind == 'as' and depth == 1 and case_depth == 0:
+                cast_as = (token.start(), token.end())
             elif kind in {"and", "or", "between"} and depth == 0 and case_depth == 0:
                 if kind == 'or':
                     cuts = []
@@ -1338,7 +1352,7 @@ def conjunctive_terms(expression: str, columns: Iterable[str] = ()) -> Iterable[
                 boolean_suffix = re.fullmatch(
                     rf'(?:{is_true}{not_false})', suffix, SQL_FLAGS,
                 )
-                whole_operand = not operand or identifier_key(unquote_identifier(operand)) in {"likely", "unlikely", "likelihood"}
+                whole_operand = not operand or identifier_key(unquote_identifier(operand)) in {"likely", "unlikely", "likelihood", "cast"}
                 if whole_operand and negations % 2 == 0 and (not suffix or (
                     not negations and ("-" not in unary.group() or boolean_suffix)
                 )):
@@ -1355,6 +1369,17 @@ def conjunctive_terms(expression: str, columns: Iterable[str] = ()) -> Iterable[
                     probability = sql_projection(term[commas[0] + 1:outer_end - 1]).strip(SQL_WHITESPACE)
                     if re.fullmatch(r'(?:0(?:\.\d*)?|1(?:\.0*)?|\.\d+)', probability, SQL_FLAGS):
                         inner = term[outer_start + 1:commas[0]]
+                elif cast_as is not None and (
+                    (prefix.lower() == "cast" and (not suffix or re.fullmatch(
+                        rf'(?:{EQUALITY}{truth}{not_false})', suffix, SQL_FLAGS
+                    )))
+                    or (not suffix and re.fullmatch(rf'{truth}{EQUALITY}cast', prefix, SQL_FLAGS))
+                ):
+                    target = sql_projection(term[cast_as[1]:outer_end - 1], literals=True, identifiers=True)
+                    if sqlite_affinity(target.strip(SQL_WHITESPACE)) in {"INTEGER", "REAL", "NUMERIC"}:
+                        # A whole numeric truth CAST exposes required predicates,
+                        # not a converted operand of an arbitrary comparison.
+                        inner = term[outer_start + 1:cast_as[0]]
             if inner is None:
                 yield term
             else:
@@ -2029,20 +2054,25 @@ def insert_seed_row(
                      *json_proposals(connection, expression, names, text_constraints=text_constraints, context_columns=context_columns),
                      *((pair,) for pair in related_proposals)],
                 ]
-                # Derived repairs precede guesses. Both guess sources remain live
-                # throughout the INSERT budget, with JSON after generic literals.
-                for offset in range(len(sources)):
-                    source = (next_source + offset) % len(sources)
-                    options = sources[source]
-                    for step in range(len(options)):
-                        index = (source_positions[source] + step) % len(options)
-                        if unseen(options[index]):
-                            untried = [options[index]]
-                            source_positions[source] = (index + 1) % len(options)
+                # Finish each source's forward pass before either wraps. Otherwise
+                # a short numeric list restarts with every new text value and
+                # consumes turns owed to the longer source's unvisited tail.
+                # A later pass still permits whole-row repairs in changed context.
+                for _ in range(2):
+                    for offset in range(len(sources)):
+                        source = (next_source + offset) % len(sources)
+                        options = sources[source]
+                        for index in range(source_positions[source], len(options)):
+                            source_positions[source] = index + 1
+                            if unseen(options[index]):
+                                untried = [options[index]]
+                                break
+                        if untried:
+                            source_progress[expression] = ((source + 1) % len(sources), source_positions)
                             break
                     if untried:
-                        source_progress[expression] = ((source + 1) % len(sources), source_positions)
                         break
+                    source_positions[:] = [0] * len(sources)
             if not untried:
                 return objection, True
             values.update(untried[0])

--- a/scripts/migration_release_guard.py
+++ b/scripts/migration_release_guard.py
@@ -823,6 +823,7 @@ EQUALITY = r'\s*(?:==|=(?!=)|\bis\b(?!\s+not\b))\s*'
 SQL_STRING = r"'(?:[^']|'')*'"
 JSON_TERM = rf"\bjson_(extract|type)\s*\(\s*({SQL_IDENTIFIER})\s*,\s*'((?:[^']|'')*)'\s*\)"
 JSON_REQUIREMENT = re.compile(JSON_TERM + EQUALITY + rf"({SQL_STRING}|-?[0-9]+(?:\.[0-9]+)?)", re.IGNORECASE)
+GLOB_REQUIREMENT = rf"({SQL_IDENTIFIER})\s+(not\s+)?glob\s*'((?:[^']|'')*)'"
 SQL_OPAQUE = re.compile(
     SQL_STRING + '|' + SQL_QUOTED_IDENTIFIER + r'|--[^\n]*|/\*[\s\S]*?(?:\*/|$)'
 )
@@ -1007,10 +1008,10 @@ def check_proposals(expression: str, columns: Iterable[str]) -> list[tuple[str, 
     whether the resulting row is admissible, so a bad proposal costs an attempt rather
     than producing a row the schema would have refused.
     """
-    # Paths and member values already belong to semantic JSON proposals; offering
-    # them to ordinary columns can overwrite an otherwise successful repair.
+    # Semantic operands already belong to their shape/JSON owners; offering them
+    # to ordinary columns can overwrite an otherwise successful repair.
     parts = list(sql_projection(expression, literals=True, identifiers=True))
-    for pattern in (JSON_REQUIREMENT, JSON_TERM):
+    for pattern in (JSON_REQUIREMENT, JSON_TERM, GLOB_REQUIREMENT):
         for match in sql_matches(pattern, expression):
             parts[match.start():match.end()] = " " * (match.end() - match.start())
     expression = "".join(parts)
@@ -1178,10 +1179,13 @@ def glob_witness(
     return None
 
 
+SeedAssignment = tuple[tuple[str, object], ...]
+
+
 @dataclass
 class ShapeProposals:
     derived: list[tuple[str, object]]
-    numeric_fallback: list[tuple[str, object]]
+    numeric_fallback: list[SeedAssignment]
 
 
 def shape_proposals(
@@ -1213,10 +1217,7 @@ def shape_proposals(
             text.setdefault(name, "x")
             widths[name] = size
             text[name] = text[name][:size].ljust(size, "0")
-    globs = (match.groups() for match in sql_matches(
-        rf"({SQL_IDENTIFIER})\s+(not\s+)?glob\s*'((?:[^']|'')*)'",
-        shapes,
-    ))
+    globs = (match.groups() for match in sql_matches(GLOB_REQUIREMENT, shapes))
     positive: dict[str, list[str]] = defaultdict(list)
     negative: dict[str, list[str]] = defaultdict(list)
     alphabets: dict[str, str] = defaultdict(lambda: string.printable)
@@ -1269,18 +1270,16 @@ def shape_proposals(
         value for bound in sorted(bounds) for value in (bound, bound + 1, bound - 1)
         if SQLITE_INT_MIN <= value <= SQLITE_INT_MAX
     ))
-    fallback = [
-        (name, candidate) for candidate in candidates for name in numeric if candidate != values[name]
-    ]
+    if not numeric or not candidates:
+        return ShapeProposals(proposals, [])
+    domains = numeric_domains(expression, numeric, values, candidates)
+    assignments = numeric_assignments(domains, tuple(values[name] for name in numeric), candidates)
+    fallback = [tuple(zip(numeric, assignment)) for assignment in itertools.islice(assignments, SEED_ATTEMPTS)]
     omitted, unavailable = tuple(omitted), tuple(unavailable)
     declared_names = {identifier_key(name) for name, _ in required} | {identifier_key(name) for name, _, _ in omitted} | {identifier_key(name) for name in unavailable}
     implicit = {"rowid", "_rowid_", "oid"} - declared_names
     if any(identifier_key(name) in mentioned for name in (*unavailable, *implicit)):
         return ShapeProposals(proposals, fallback)
-    if not numeric or not candidates:
-        return ShapeProposals(proposals, [])
-    domains = numeric_domains(expression, numeric, values, candidates)
-    assignments = numeric_assignments(domains, tuple(values[name] for name in numeric), candidates)
     # Native typed insertion models affinity, but scratch DML must never change
     # the fixture connection's changes()/last_insert_rowid()/total_changes().
     evaluation = sqlite3.connect(":memory:")
@@ -1312,8 +1311,8 @@ def shape_proposals(
             if default is not None:
                 evaluation.execute(f"explain select ({default})").fetchall()
         evaluation.execute(f"create table {table} ({', '.join(declarations)})" + (" STRICT" if strict else ""))
-        for assignment in itertools.islice(assignments, SEED_ATTEMPTS):
-            changes = dict(zip(numeric, assignment))
+        for assignment in fallback:
+            changes = dict(assignment)
             parameters = [changes.get(column, values[column]) for column, _ in required]
             evaluation.execute(f"delete from {table}")
             try:
@@ -1354,9 +1353,9 @@ def numeric_assignments(
     seen = {ranked}
     yield ranked
     local = sparse(current)
-    # Every candidate-bearing column gets its initial sparse opportunity before
-    # family mixing can dilute it. Larger domains still obey the same total cap.
-    for assignment in itertools.islice(local, len(domains)):
+    # Reserve half the budget for later local alternatives as well as the first
+    # opportunity per column. Larger domains still obey the same total cap.
+    for assignment in itertools.islice(local, max(len(domains), SEED_ATTEMPTS // 2)):
         if assignment not in seen:
             seen.add(assignment)
             yield assignment
@@ -1703,10 +1702,19 @@ def insert_seed_row(
             omitted.append((str(info[1]), str(info[2]), info[4]))
     prefix_sources = {identifier_key(other) for _, _, _, other in substring_requirements(text_constraints)}
     strict = is_strict_table(connection, table)
-    proposed: set[tuple[str, object]] = set()
+    def row_identity(row: dict[str, object]) -> tuple:
+        return tuple((name, type(row[name]), row[name]) for name in names)
+
+    proposed: set[tuple] = set()
+
+    def unseen(assignment: SeedAssignment) -> bool:
+        return row_identity({**values, **dict(assignment)}) not in proposed
+
     next_source = 0
+    source_positions = [0, 0]
     objection = ""
     for _ in range(SEED_ATTEMPTS):
+        proposed.add(row_identity(values))
         try:
             connection.execute(statement, [values[column] for column in names])
         except sqlite3.Error as exc:
@@ -1723,17 +1731,23 @@ def insert_seed_row(
                 text_constraints=text_constraints, omitted=omitted, unavailable=unavailable,
                 strict=strict,
             )
-            untried = [pair for pair in shaped.derived if pair not in proposed and values[pair[0]] != pair[1]]
+            untried = [(pair,) for pair in shaped.derived if unseen((pair,))]
             if not untried:
                 sources = [
                     shaped.numeric_fallback,
-                    [*check_proposals(expression, names), *json_proposals(connection, expression, names)],
+                    [(pair,) for pair in [*check_proposals(expression, names), *json_proposals(connection, expression, names)]],
                 ]
                 # Derived repairs precede guesses. Both guess sources remain live
                 # throughout the INSERT budget, with JSON after generic literals.
                 for offset in range(len(sources)):
                     source = (next_source + offset) % len(sources)
-                    untried = [pair for pair in sources[source] if pair not in proposed and values[pair[0]] != pair[1]]
+                    options = sources[source]
+                    for step in range(len(options)):
+                        index = (source_positions[source] + step) % len(options)
+                        if unseen(options[index]):
+                            untried = [options[index]]
+                            source_positions[source] = (index + 1) % len(options)
+                            break
                     if untried:
                         next_source = (source + 1) % len(sources)
                         break
@@ -1741,16 +1755,14 @@ def insert_seed_row(
                 # Follow only prefix-source dependencies into other CHECKs. Unrelated
                 # literals must not overwrite columns that already satisfy their checks.
                 untried = [
-                    pair
+                    (pair,)
                     for related in constraints
                     for pair in [*check_proposals(related, names), *json_proposals(connection, related, names)]
-                    if identifier_key(pair[0]) in prefix_sources and pair not in proposed and values[pair[0]] != pair[1]
+                    if identifier_key(pair[0]) in prefix_sources and unseen((pair,))
                 ]
             if not untried:
                 return objection, True
-            column, literal = untried[0]
-            proposed.add((column, literal))
-            values[column] = literal
+            values.update(untried[0])
         else:
             return "", True
     return f"{SEED_ATTEMPTS} attempts did not produce a row the schema accepts; last was {objection}", False

--- a/scripts/migration_release_guard.py
+++ b/scripts/migration_release_guard.py
@@ -886,7 +886,7 @@ def representative_value(column: str, declared_type: str) -> object:
     kind = sqlite_affinity(declared_type)
     if kind in {"INTEGER", "REAL", "NUMERIC"}:
         return 0
-    if kind == "BLOB":
+    if kind == "BLOB" and declared_type:
         return b""
     if column.endswith(("_at", "_time")):
         return "1970-01-01T00:00:00+00:00"
@@ -1179,12 +1179,7 @@ def shape_proposals(
     if not numeric or not candidates:
         return proposals
     domains = numeric_domains(expression, numeric, values, candidates)
-    products = itertools.product(*domains)
-    assignments = itertools.chain(
-        itertools.islice(products, 1),
-        (tuple(candidate for _ in numeric) for candidate in candidates),
-        products,
-    )
+    assignments = numeric_assignments(domains, tuple(values[name] for name in numeric), candidates)
     # Native typed insertion models affinity, but scratch DML must never change
     # the fixture connection's changes()/last_insert_rowid()/total_changes().
     evaluation = sqlite3.connect(":memory:")
@@ -1204,13 +1199,21 @@ def shape_proposals(
     columns = ', '.join(quote(name) for name, _ in required)
     placeholders = ', '.join('?' for _ in required)
     try:
-        context = identifier_key(expression + "\n" + "\n".join(default or "" for _, _, default in omitted))
         contextual = {
             str(row[0]) for row in evaluation.execute("pragma function_list")
             if not int(row[5]) & 0x800  # SQLITE_DETERMINISTIC
         }
-        if any(re.search(rf"\b{re.escape(name)}\b", context) for name in contextual):
-            return [*proposals, *fallback]
+        def authorize(action, _first, function, _database, _source):
+            if action == sqlite3.SQLITE_FUNCTION and function in contextual:
+                return sqlite3.SQLITE_DENY
+            return sqlite3.SQLITE_OK
+
+        evaluation.set_authorizer(authorize)
+        # INSERT compilation does not authorize DEFAULT functions. Compile them
+        # separately without execution, including SQLite's keyword-style functions.
+        for _, _, default in omitted:
+            if default is not None:
+                evaluation.execute(f"explain select ({default})").fetchall()
         evaluation.execute(f"create table {table} ({', '.join(declarations)})")
         for assignment in itertools.islice(assignments, SEED_ATTEMPTS):
             changes = dict(zip(numeric, assignment))
@@ -1229,6 +1232,41 @@ def shape_proposals(
     finally:
         evaluation.close()
     return proposals
+
+
+def numeric_assignments(
+    domains: list[list[object]], current: tuple[object, ...], candidates: list[int]
+) -> Iterable[tuple[object, ...]]:
+    """Give local repairs and joint guesses turns in the same bounded search."""
+    ranked = tuple(domain[0] for domain in domains)
+
+    def sparse(base: tuple[object, ...]) -> Iterable[tuple[object, ...]]:
+        alternatives = [
+            [value for value in dict.fromkeys([current[index], *domain]) if value != base[index]]
+            for index, domain in enumerate(domains)
+        ]
+        for rank in range(max(map(len, alternatives), default=0)):
+            for index, options in enumerate(alternatives):
+                if rank < len(options):
+                    yield (*base[:index], options[rank], *base[index + 1:])
+
+    seen = {ranked}
+    yield ranked
+    uniform = [tuple(candidate for _ in domains) for candidate in candidates]
+
+    def interleave(*families):
+        for batch in itertools.zip_longest(*families):
+            yield from (assignment for assignment in batch if assignment is not None)
+
+    anchors = dict.fromkeys([ranked, *uniform])
+    neighborhoods = interleave(*(sparse(base) for base in anchors if base != current))
+    joint = interleave(neighborhoods, iter(uniform), itertools.product(*domains))
+    # Current-row single changes keep their own turns regardless of how many
+    # joint anchors the CHECK's literals introduced.
+    for assignment in interleave(sparse(current), joint):
+        if assignment not in seen:
+            seen.add(assignment)
+            yield assignment
 
 
 def numeric_domains(

--- a/scripts/migration_release_guard.py
+++ b/scripts/migration_release_guard.py
@@ -1451,16 +1451,25 @@ def numeric_assignments(
                 if rank < len(options):
                     yield (*base[:index], options[rank], *base[index + 1:])
 
-    seen = {ranked}
-    yield ranked
+    seen = set()
+    uniform = [tuple(candidate for _ in domains) for candidate in candidates]
+    if len(domains) > SEED_ATTEMPTS // 2:
+        # A stable anchor prefix survives fallback retries rebasing the sparse
+        # row. Cap it so even a large boundary set leaves room for ranked repair.
+        for assignment in itertools.islice(uniform, SEED_ATTEMPTS // 2):
+            if assignment not in seen:
+                seen.add(assignment)
+                yield assignment
+    if ranked not in seen:
+        seen.add(ranked)
+        yield ranked
     local = sparse(current)
-    # A column-count-dependent reservation can exclude every joint candidate.
-    # Retain later local alternatives, but leave half the budget for mixed search.
-    for assignment in itertools.islice(local, SEED_ATTEMPTS // 2):
+    # Finish the first per-column wave before deeper mixed search dilutes it.
+    # Small domains keep their existing reservation for later alternatives.
+    for assignment in itertools.islice(local, max(len(domains), SEED_ATTEMPTS // 2)):
         if assignment not in seen:
             seen.add(assignment)
             yield assignment
-    uniform = [tuple(candidate for _ in domains) for candidate in candidates]
 
     def interleave(*families):
         for batch in itertools.zip_longest(*families):

--- a/scripts/migration_release_guard.py
+++ b/scripts/migration_release_guard.py
@@ -1381,6 +1381,14 @@ def conjunctive_terms(expression: str, columns: Iterable[str] = ()) -> Iterable[
             if outer_start is not None and outer_end is not None:
                 prefix = sql_projection(term[:outer_start], identifiers=True).strip(SQL_WHITESPACE)
                 suffix = sql_projection(term[outer_end:], literals=True, identifiers=True).strip(SQL_WHITESPACE)
+                if suffix[:7].lower() == "collate" and (
+                    collations := re.match(rf'(?:collate\s+(?:{SQL_IDENTIFIER}|{SQL_STRING})\s*)+', suffix, SQL_FLAGS)
+                ):
+                    # Only postfixes on this complete operand are transparent.
+                    # Keep comparison-operand collations and the original SQL
+                    # in the native probe of the complete wrapper composition.
+                    suffix = suffix[collations.end():]
+                    verify = True
                 body = (outer_start + 1, outer_end - 1)
                 # These operators wrap the whole parenthesized operand (or hint).
                 # Never strip '+' from an operand of an equality: it removes affinity.

--- a/scripts/migration_release_guard.py
+++ b/scripts/migration_release_guard.py
@@ -67,7 +67,7 @@ import sys
 import tempfile
 from collections import defaultdict, deque
 from collections.abc import Iterable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from decimal import Decimal
 from pathlib import Path
 
@@ -1186,14 +1186,60 @@ SeedAssignment = tuple[tuple[str, object], ...]
 class ShapeProposals:
     derived: list[tuple[str, object]]
     numeric_fallback: list[SeedAssignment]
+    text_fallback: list[tuple[str, object]] = field(default_factory=list)
+
+
+def conjunctive_terms(expression: str) -> Iterable[str]:
+    """Only descend through AND and grouping, never conditional boolean branches."""
+    pending = [expression]
+    while pending:
+        term = pending.pop().strip()
+        active = sql_projection(term)
+        depth = case_depth = 0
+        cuts = []
+        between = False
+        outer_end = None
+        for token in re.finditer(r'\(|\)|\b(?:and|or|between|case|end)\b', active, re.IGNORECASE):
+            kind = token.group().lower()
+            if kind == '(':
+                depth += 1
+            elif kind == ')':
+                depth -= 1
+                if depth == 0 and outer_end is None:
+                    outer_end = token.end()
+            elif kind == 'case':
+                case_depth += 1
+            elif kind == 'end':
+                case_depth -= 1
+            elif depth == 0 and case_depth == 0:
+                if kind == 'or':
+                    cuts = []
+                    break  # OR has lower precedence than AND.
+                if kind == 'between':
+                    between = True
+                elif between:
+                    between = False
+                else:
+                    cuts.append((token.start(), token.end()))
+        if cuts:
+            edges = [0, *(end for _, end in cuts)]
+            ends = [*(start for start, _ in cuts), len(term)]
+            pending.extend(reversed([term[start:end] for start, end in zip(edges, ends)]))
+        elif active.lstrip().startswith('(') and outer_end == len(active.rstrip()):
+            pending.append(term[len(active) - len(active.lstrip()) + 1:outer_end - 1])
+        else:
+            yield term
 
 
 def column_equality_groups(expression: str, columns: Iterable[str]) -> list[list[str]]:
     """Group bare column equalities without exposing opaque SQL or function calls."""
     names = {identifier_key(name): name for name in columns}
     groups = {name: [name] for name in names.values()}
-    pattern = rf'(?<![.\w$])({SQL_IDENTIFIER}){EQUALITY}({SQL_IDENTIFIER})(?![\w$]|\s*[.(])'
-    for match in sql_matches(pattern, expression):
+    pattern = rf'\s*({SQL_IDENTIFIER}){EQUALITY}({SQL_IDENTIFIER})\s*'
+    for term in conjunctive_terms(expression):
+        match = re.fullmatch(pattern, sql_projection(term, identifiers=True), re.IGNORECASE)
+        if match is None:
+            continue
         left, right = (names.get(identifier_key(unquote_identifier(token))) for token in match.groups())
         if left is not None and right is not None and groups[left] is not groups[right]:
             joined, moved = groups[left], groups[right]
@@ -1229,20 +1275,21 @@ def shape_proposals(
         name = names.get(identifier_key(unquote_identifier(name)), name)
         size = bounded_integer(width, 0, SEED_TEXT_LIMIT)
         if name in text_eligible and size is not None:
-            text.setdefault(name, "x")
             widths[name] = size
-            text[name] = text[name][:size].ljust(size, "0")
+            if isinstance(values[name], str) or connection.execute("select length(?)", (values[name],)).fetchone()[0] != size:
+                text.setdefault(name, "x")
+                text[name] = text[name][:size].ljust(size, "0")
     globs = (match.groups() for match in sql_matches(GLOB_REQUIREMENT, shapes))
     positive: dict[str, list[str]] = defaultdict(list)
     negative: dict[str, list[str]] = defaultdict(list)
     for name, negated, quoted in globs:
         name = names.get(identifier_key(unquote_identifier(name)), name)
         if name in text_eligible:
-            text.setdefault(name, "x")
             pattern = quoted.replace("''", "'")
             (negative if negated else positive)[name].append(pattern)
     groups = column_equality_groups(shapes, (name for name, _ in required if name in text_eligible))
     aliases = {name: members for members in groups for name in members}
+    witnesses = []
     for members in groups:
         patterns = tuple(dict.fromkeys(pattern for name in members for pattern in positive[name]))
         excluded = tuple(dict.fromkeys(pattern for name in members for pattern in negative[name]))
@@ -1252,6 +1299,13 @@ def shape_proposals(
         if len(sizes) > 1:
             continue  # No common text can satisfy incompatible declared widths.
         width = next(iter(sizes), None)
+        if len(members) == 1 and not isinstance(values[members[0]], str):
+            original = values[members[0]]
+            if ((width is None or connection.execute("select length(?)", (original,)).fetchone()[0] == width)
+                    and all(connection.execute("select ? glob ?", (original, pattern)).fetchone()[0] for pattern in patterns)
+                    and not any(connection.execute("select ? glob ?", (original, pattern)).fetchone()[0] for pattern in excluded)):
+                text.pop(members[0], None)
+                continue
         witness = next((text[name] for name in members if name in text
                         and (width is None or len(text[name]) == width)
                         and all(connection.execute("select ? glob ?", (text[name], pattern)).fetchone()[0] for pattern in patterns)
@@ -1261,6 +1315,7 @@ def shape_proposals(
             witness = glob_witness(connection, patterns, excluded=excluded, width=width, alphabet=alphabet)
         if witness is not None:
             text.update((name, witness) for name in members)
+            witnesses.append(witness)
     for name, start, width, other in substring_requirements(shapes):
         name, other = names.get(identifier_key(name), name), names.get(identifier_key(other), other)
         position = bounded_integer(start, 1, SEED_TEXT_LIMIT)
@@ -1275,6 +1330,10 @@ def shape_proposals(
     proposals: list[tuple[str, object]] = [(name, value) for name, value in text.items() if value != values[name]]
     active = sql_projection(expression)
     mentioned = sql_identifiers(expression)
+    # Retain computed values for functional dependents as guesses, not aliases.
+    # Raw pattern operands remain owned by the GLOB matcher.
+    text_fallback = [(name, witness) for witness in dict.fromkeys(witnesses)
+                     for name, _ in required if name in text_eligible and identifier_key(name) in mentioned]
     numeric_text = active + " " + " ".join(
         match.group()[1:-1] for match in re.finditer(SQL_STRING, sql_projection(expression, literals=True))
         if re.fullmatch(r"-?[0-9]+", match.group()[1:-1])
@@ -1295,7 +1354,7 @@ def shape_proposals(
         if SQLITE_INT_MIN <= value <= SQLITE_INT_MAX
     ))
     if not numeric or not candidates:
-        return ShapeProposals(proposals, [])
+        return ShapeProposals(proposals, [], text_fallback)
     domains = numeric_domains(expression, numeric, values, candidates)
     assignments = numeric_assignments(domains, tuple(values[name] for name in numeric), candidates)
     fallback = [tuple(zip(numeric, assignment)) for assignment in itertools.islice(assignments, SEED_ATTEMPTS)]
@@ -1303,7 +1362,7 @@ def shape_proposals(
     declared_names = {identifier_key(name) for name, _ in required} | {identifier_key(name) for name, _, _ in omitted} | {identifier_key(name) for name in unavailable}
     implicit = {"rowid", "_rowid_", "oid"} - declared_names
     if any(identifier_key(name) in mentioned for name in (*unavailable, *implicit)):
-        return ShapeProposals(proposals, fallback)
+        return ShapeProposals(proposals, fallback, text_fallback)
     # Native typed insertion models affinity, but scratch DML must never change
     # the fixture connection's changes()/last_insert_rowid()/total_changes().
     evaluation = sqlite3.connect(":memory:")
@@ -1319,22 +1378,14 @@ def shape_proposals(
     columns = ', '.join(quote_identifier(name) for name, _ in required)
     placeholders = ', '.join('?' for _ in required)
     try:
-        contextual = {
-            str(row[0]) for row in evaluation.execute("pragma function_list")
-            if not int(row[5]) & 0x800  # SQLITE_DETERMINISTIC
-        }
-        def authorize(action, _first, function, _database, _source):
-            if action == sqlite3.SQLITE_FUNCTION and function in contextual:
-                return sqlite3.SQLITE_DENY
-            return sqlite3.SQLITE_OK
-
-        evaluation.set_authorizer(authorize)
-        # INSERT compilation does not authorize DEFAULT functions. Compile them
-        # separately without execution, including SQLite's keyword-style functions.
+        evaluation.execute(f"create table {table} ({', '.join(declarations)})" + (" STRICT" if strict else ""))
+        # Let SQLite resolve overloads and enforce expression-index determinism.
+        # EXPLAIN compiles without creating an index or evaluating any expression.
+        # Defaults need their own check before scratch INSERT can execute them.
         for _, _, default in omitted:
             if default is not None:
-                evaluation.execute(f"explain select ({default})").fetchall()
-        evaluation.execute(f"create table {table} ({', '.join(declarations)})" + (" STRICT" if strict else ""))
+                evaluation.execute(f"explain create index seed_probe on {table} (+({default}\n))").fetchall()
+        evaluation.execute(f"explain create index seed_probe on {table} (+({expression}\n))").fetchall()
         for assignment in fallback:
             changes = dict(assignment)
             parameters = [changes.get(column, values[column]) for column, _ in required]
@@ -1352,10 +1403,10 @@ def shape_proposals(
                 break
     except sqlite3.OperationalError:
         # Unrepresentable context cannot reject a candidate; actual INSERT decides.
-        return ShapeProposals(proposals, fallback)
+        return ShapeProposals(proposals, fallback, text_fallback)
     finally:
         evaluation.close()
-    return ShapeProposals(proposals, [])
+    return ShapeProposals(proposals, [], text_fallback)
 
 
 def numeric_assignments(
@@ -1712,7 +1763,7 @@ def insert_seed_row(
         check_expression(ddl, unquote_identifier(match.group(1)))
         for match in sql_matches(rf'\bconstraint\s+({SQL_IDENTIFIER})\s+check\s*\(', ddl)
     ]
-    text_constraints = "\n".join(constraints)
+    text_constraints = " AND ".join(f"({constraint}\n)" for constraint in constraints)
     omitted = []
     unavailable = []
     for info in connection.execute(f'pragma table_xinfo({quote_identifier(table)})'):
@@ -1759,7 +1810,7 @@ def insert_seed_row(
             if not untried:
                 sources = [
                     shaped.numeric_fallback,
-                    [(pair,) for pair in [*check_proposals(expression, names), *json_proposals(connection, expression, names)]],
+                    [(pair,) for pair in [*check_proposals(expression, names), *shaped.text_fallback, *json_proposals(connection, expression, names)]],
                 ]
                 # Derived repairs precede guesses. Both guess sources remain live
                 # throughout the INSERT budget, with JSON after generic literals.

--- a/scripts/migration_release_guard.py
+++ b/scripts/migration_release_guard.py
@@ -1188,6 +1188,21 @@ class ShapeProposals:
     numeric_fallback: list[SeedAssignment]
 
 
+def column_equality_groups(expression: str, columns: Iterable[str]) -> list[list[str]]:
+    """Group bare column equalities without exposing opaque SQL or function calls."""
+    names = {identifier_key(name): name for name in columns}
+    groups = {name: [name] for name in names.values()}
+    pattern = rf'(?<![.\w$])({SQL_IDENTIFIER}){EQUALITY}({SQL_IDENTIFIER})(?![\w$]|\s*[.(])'
+    for match in sql_matches(pattern, expression):
+        left, right = (names.get(identifier_key(unquote_identifier(token))) for token in match.groups())
+        if left is not None and right is not None and groups[left] is not groups[right]:
+            joined, moved = groups[left], groups[right]
+            joined.extend(moved)
+            for name in moved:
+                groups[name] = joined
+    return [members for name, members in groups.items() if name == members[0]]
+
+
 def shape_proposals(
     connection: sqlite3.Connection,
     expression: str,
@@ -1220,24 +1235,32 @@ def shape_proposals(
     globs = (match.groups() for match in sql_matches(GLOB_REQUIREMENT, shapes))
     positive: dict[str, list[str]] = defaultdict(list)
     negative: dict[str, list[str]] = defaultdict(list)
-    alphabets: dict[str, str] = defaultdict(lambda: string.printable)
     for name, negated, quoted in globs:
         name = names.get(identifier_key(unquote_identifier(name)), name)
         if name in text_eligible:
             text.setdefault(name, "x")
             pattern = quoted.replace("''", "'")
-            alphabets[name] += pattern
             (negative if negated else positive)[name].append(pattern)
-    alphabets = {name: "".join(dict.fromkeys(alphabet)) for name, alphabet in alphabets.items()}
-    for name in dict.fromkeys([*positive, *negative]):
-        patterns, excluded = positive[name], negative[name]
-        if all(connection.execute("select ? glob ?", (text[name], pattern)).fetchone()[0] for pattern in patterns) and not any(
-            connection.execute("select ? glob ?", (text[name], pattern)).fetchone()[0] for pattern in excluded
-        ):
+    groups = column_equality_groups(shapes, (name for name, _ in required if name in text_eligible))
+    aliases = {name: members for members in groups for name in members}
+    for members in groups:
+        patterns = tuple(dict.fromkeys(pattern for name in members for pattern in positive[name]))
+        excluded = tuple(dict.fromkeys(pattern for name in members for pattern in negative[name]))
+        if not patterns and not excluded:
             continue
-        witness = glob_witness(connection, tuple(patterns), excluded=tuple(excluded), width=widths.get(name), alphabet=alphabets[name])
+        sizes = {widths[name] for name in members if name in widths}
+        if len(sizes) > 1:
+            continue  # No common text can satisfy incompatible declared widths.
+        width = next(iter(sizes), None)
+        witness = next((text[name] for name in members if name in text
+                        and (width is None or len(text[name]) == width)
+                        and all(connection.execute("select ? glob ?", (text[name], pattern)).fetchone()[0] for pattern in patterns)
+                        and not any(connection.execute("select ? glob ?", (text[name], pattern)).fetchone()[0] for pattern in excluded)), None)
+        if witness is None:
+            alphabet = "".join(dict.fromkeys(string.printable + "".join((*patterns, *excluded))))
+            witness = glob_witness(connection, patterns, excluded=excluded, width=width, alphabet=alphabet)
         if witness is not None:
-            text[name] = witness
+            text.update((name, witness) for name in members)
     for name, start, width, other in substring_requirements(shapes):
         name, other = names.get(identifier_key(name), name), names.get(identifier_key(other), other)
         position = bounded_integer(start, 1, SEED_TEXT_LIMIT)
@@ -1247,7 +1270,8 @@ def shape_proposals(
             offset = position - 1
             source = text.get(other, str(values[other]))
             if len(source) == size:
-                text[name] = text[name][:offset].ljust(offset, "0") + source + text[name][offset + size :]
+                repaired = text[name][:offset].ljust(offset, "0") + source + text[name][offset + size :]
+                text.update((member, repaired) for member in aliases[name])
     proposals: list[tuple[str, object]] = [(name, value) for name, value in text.items() if value != values[name]]
     active = sql_projection(expression)
     mentioned = sql_identifiers(expression)
@@ -1710,8 +1734,7 @@ def insert_seed_row(
     def unseen(assignment: SeedAssignment) -> bool:
         return row_identity({**values, **dict(assignment)}) not in proposed
 
-    next_source = 0
-    source_positions = [0, 0]
+    source_progress: dict[str, tuple[int, list[int]]] = {}
     objection = ""
     for _ in range(SEED_ATTEMPTS):
         proposed.add(row_identity(values))
@@ -1726,6 +1749,7 @@ def insert_seed_row(
             if failure is None:
                 return objection, True
             expression = check_expression(ddl, failure.group(1))
+            next_source, source_positions = source_progress.setdefault(expression, (0, [0, 0]))
             shaped = shape_proposals(
                 connection, expression, required, values,
                 text_constraints=text_constraints, omitted=omitted, unavailable=unavailable,
@@ -1749,7 +1773,7 @@ def insert_seed_row(
                             source_positions[source] = (index + 1) % len(options)
                             break
                     if untried:
-                        next_source = (source + 1) % len(sources)
+                        source_progress[expression] = ((source + 1) % len(sources), source_positions)
                         break
             if not untried:
                 # Follow only prefix-source dependencies into other CHECKs. Unrelated

--- a/scripts/migration_release_guard.py
+++ b/scripts/migration_release_guard.py
@@ -59,6 +59,7 @@ import ast
 import hashlib
 import itertools
 import json
+import operator
 import re
 import sqlite3
 import string
@@ -822,6 +823,7 @@ SQL_QUOTED_IDENTIFIER = r'"(?:[^"]|"")*"|`(?:[^`]|``)*`|\[[^\]]*\]'
 SQL_IDENTIFIER_CHARS = r'A-Za-z_0-9$\x80-\U0010ffff'
 SQL_FLAGS = re.IGNORECASE | re.ASCII
 SQL_WHITESPACE = " \t\n\r\f"
+SQL_IDENTIFIER_CASE = str.maketrans(string.ascii_uppercase, string.ascii_lowercase)
 SQL_IDENTIFIER = rf'(?:{SQL_QUOTED_IDENTIFIER}|(?<![{SQL_IDENTIFIER_CHARS}])(?!\ufeff)[A-Za-z_\x80-\U0010ffff][{SQL_IDENTIFIER_CHARS}]*)'
 # These scalar-function results have no column affinity for unary '+' to erase.
 SQL_UNARY_PLUS = r'(?:\+\s*)*'
@@ -998,7 +1000,7 @@ def check_expression(ddl: str, name: str) -> str:
 
 def identifier_key(value: str) -> str:
     """SQLite folds ASCII identifier case, not Unicode or JSON member names."""
-    return value.translate(str.maketrans(string.ascii_uppercase, string.ascii_lowercase))
+    return value.translate(SQL_IDENTIFIER_CASE)
 
 
 def bounded_integer(literal: str, lower: int, upper: int) -> int | None:
@@ -1295,9 +1297,34 @@ def conjunctive_terms(expression: str, columns: Iterable[str] = ()) -> Iterable[
     truth = r'(?:1|true)' if "true" not in names else '1'
     is_true = r'is\s+true' if "true" not in names else r'(?!)'
     not_false = r'|is\s+not\s+false' if "false" not in names else ''
-    pending = [expression]
+    zero = r'[+-]?(?:0+(?:\.0*)?|\.0+)'
+    if "false" not in names:
+        zero = rf'(?:{zero}|false)'
+    inequality = r'(?:<>|!=|is\s+not)\s*'
+    nonzero = rf'{inequality}{zero}'
+    reverse_truth = rf'(?:{truth}{EQUALITY}|{zero}\s*{inequality})'
+    positive_suffix = rf'(?:{EQUALITY}{truth}{not_false}|{nonzero})'
+
+    def transparent(before: str, after: str) -> bool:
+        # Only recognized wrapper syntax reaches this constant probe. Keep its
+        # complete composition: BLOB('0') <> 0 accepts false, whereas a direct
+        # BLOB truth CAST rejects it. Do not approximate affinity in Python.
+        probe = sqlite3.connect(":memory:")
+        try:
+            statement = f"select coalesce(cast(({before}?{after}) as numeric), 1) != 0"
+            return [probe.execute(statement, (value,)).fetchone()[0] for value in (0, 1)] == [0, 1]
+        except sqlite3.OperationalError:
+            return False
+        finally:
+            probe.close()
+
+    pending = [(expression, "", "", False)]
     while pending:
-        term = pending.pop().strip(SQL_WHITESPACE)
+        term, before, after, verify = pending.pop()
+        start = len(term) - len(term.lstrip(SQL_WHITESPACE))
+        end = len(term.rstrip(SQL_WHITESPACE))
+        before, after = before + term[:start], term[end:] + after
+        term = term[start:end]
         active = sql_projection(term)
         depth = case_depth = 0
         cuts = []
@@ -1335,55 +1362,57 @@ def conjunctive_terms(expression: str, columns: Iterable[str] = ()) -> Iterable[
                 else:
                     cuts.append((token.start(), token.end()))
         if cuts:
+            if verify and not transparent(before, after):
+                yield before + term + after
+                continue
             edges = [0, *(end for _, end in cuts)]
             ends = [*(start for start, _ in cuts), len(term)]
-            pending.extend(reversed([term[start:end] for start, end in zip(edges, ends)]))
+            pending.extend(reversed([(term[start:end], "", "", False) for start, end in zip(edges, ends)]))
         else:
             inner = None
             if outer_start is not None and outer_end is not None:
                 prefix = sql_projection(term[:outer_start], identifiers=True).strip(SQL_WHITESPACE)
                 suffix = sql_projection(term[outer_end:], literals=True, identifiers=True).strip(SQL_WHITESPACE)
-                body = term[outer_start + 1:outer_end - 1]
+                body = (outer_start + 1, outer_end - 1)
                 # These operators wrap the whole parenthesized operand (or hint).
                 # Never strip '+' from an operand of an equality: it removes affinity.
                 unary = re.match(rf'(?:(?:[+-]|not(?![{SQL_IDENTIFIER_CHARS}]))\s*)*', prefix, SQL_FLAGS)
                 negations = len(re.findall('not', unary.group(), SQL_FLAGS))
                 operand = prefix[unary.end():]
                 boolean_suffix = re.fullmatch(
-                    rf'(?:{is_true}{not_false})', suffix, SQL_FLAGS,
+                    rf'(?:{is_true}{not_false}|{nonzero})', suffix, SQL_FLAGS,
                 )
                 whole_operand = not operand or identifier_key(unquote_identifier(operand)) in {"likely", "unlikely", "likelihood", "cast"}
                 if whole_operand and negations % 2 == 0 and (not suffix or (
                     not negations and ("-" not in unary.group() or boolean_suffix)
                 )):
                     prefix = operand
-                if not prefix and (not suffix or re.fullmatch(
-                    rf'(?:{EQUALITY}{truth}{not_false})', suffix, SQL_FLAGS
-                )):
+                verify = verify or bool(re.fullmatch(nonzero, suffix, SQL_FLAGS)
+                                        or re.match(rf'{zero}\s*{inequality}', prefix, SQL_FLAGS))
+                if not prefix and (not suffix or re.fullmatch(positive_suffix, suffix, SQL_FLAGS)):
                     inner = body
-                elif not suffix and re.fullmatch(rf'{truth}{EQUALITY}', prefix, SQL_FLAGS):
+                elif not suffix and re.fullmatch(reverse_truth, prefix, SQL_FLAGS):
                     inner = body
-                elif not suffix and identifier_key(unquote_identifier(prefix)) in {"likely", "unlikely"} and not commas:
+                elif (not suffix or re.fullmatch(positive_suffix, suffix, SQL_FLAGS)) and identifier_key(unquote_identifier(prefix)) in {"likely", "unlikely"} and not commas:
                     inner = body
-                elif not suffix and identifier_key(unquote_identifier(prefix)) == "likelihood" and len(commas) == 1:
+                elif (not suffix or re.fullmatch(positive_suffix, suffix, SQL_FLAGS)) and identifier_key(unquote_identifier(prefix)) == "likelihood" and len(commas) == 1:
                     probability = sql_projection(term[commas[0] + 1:outer_end - 1]).strip(SQL_WHITESPACE)
                     if re.fullmatch(r'(?:0(?:\.\d*)?|1(?:\.0*)?|\.\d+)', probability, SQL_FLAGS):
-                        inner = term[outer_start + 1:commas[0]]
+                        inner = (outer_start + 1, commas[0])
                 elif cast_as is not None and (
                     (prefix.lower() == "cast" and (not suffix or re.fullmatch(
-                        rf'(?:{EQUALITY}{truth}{not_false})', suffix, SQL_FLAGS
+                        positive_suffix, suffix, SQL_FLAGS
                     )))
-                    or (not suffix and re.fullmatch(rf'{truth}{EQUALITY}cast', prefix, SQL_FLAGS))
+                    or (not suffix and re.fullmatch(rf'{reverse_truth}cast', prefix, SQL_FLAGS))
                 ):
                     target = sql_projection(term[cast_as[1]:outer_end - 1], literals=True, identifiers=True)
-                    if sqlite_affinity(target.strip(SQL_WHITESPACE)) in {"INTEGER", "REAL", "NUMERIC"}:
-                        # A whole numeric truth CAST exposes required predicates,
-                        # not a converted operand of an arbitrary comparison.
-                        inner = term[outer_start + 1:cast_as[0]]
+                    verify = verify or sqlite_affinity(target.strip(SQL_WHITESPACE)) in {"TEXT", "BLOB"}
+                    inner = (outer_start + 1, cast_as[0])
             if inner is None:
-                yield term
+                yield term if not verify or transparent(before, after) else before + term + after
             else:
-                pending.append(inner)
+                start, end = inner
+                pending.append((term[start:end], before + term[:start], term[end:] + after, verify))
 
 
 def column_equality_groups(
@@ -1687,30 +1716,31 @@ def numeric_domains(
     """Rank finite domains by local predicates; the complete CHECK still decides."""
     identifier = f'({SQL_IDENTIFIER})'
     literal = f"({SQL_INTEGER})"
-    operator = r"\s*(==|!=|<>|<=|>=|=|<|>)\s*"
+    comparison = r"\s*(==|!=|<>|<=|>=|=|<|>)\s*"
     predicates: dict[str, list[tuple[str, int]]] = defaultdict(list)
-    clauses = [match.groups() for match in sql_matches(identifier + operator + literal, expression)]
+    clauses = [match.groups() for match in sql_matches(identifier + comparison + literal, expression)]
     reverse = {"<": ">", ">": "<", "<=": ">=", ">=": "<=", "=": "=", "==": "==", "!=": "!=", "<>": "<>"}
     clauses.extend((name, reverse[op], token) for token, op, name in (
-        match.groups() for match in sql_matches(literal + operator + identifier, expression)
+        match.groups() for match in sql_matches(literal + comparison + identifier, expression)
     ))
     for name, op, token in clauses:
         if (bound := bounded_integer(token, SQLITE_INT_MIN, SQLITE_INT_MAX)) is not None:
             predicates[identifier_key(unquote_identifier(name))].append((op, bound))
 
-    def score(name: str, value: object) -> int:
-        if not isinstance(value, (int, float)):
-            return -len(predicates[identifier_key(name)])
-        return sum(
-            {"=": value == bound, "==": value == bound, "!=": value != bound, "<>": value != bound,
-             "<": value < bound, ">": value > bound, "<=": value <= bound, ">=": value >= bound}[op]
-            for op, bound in predicates[identifier_key(name)]
-        )
+    comparisons = {"=": operator.eq, "==": operator.eq, "!=": operator.ne, "<>": operator.ne,
+                   "<": operator.lt, ">": operator.gt, "<=": operator.le, ">=": operator.ge}
 
-    return [
-        sorted(dict.fromkeys([values[name], *candidates]), key=lambda value: -score(name, value))
-        for name in numeric
-    ]
+    def score(terms: list, value: object) -> int:
+        if not isinstance(value, (int, float)):
+            return -len(terms)
+        return sum(compare(value, bound) for compare, bound in terms)
+
+    domains = []
+    for name in numeric:
+        terms = [(comparisons[op], bound) for op, bound in predicates[identifier_key(name)]]
+        domain = list(dict.fromkeys([values[name], *candidates]))
+        domains.append(sorted(domain, key=lambda value: -score(terms, value)) if terms else domain)
+    return domains
 
 
 def moved_row(base: dict[str, object], step: int, *, held: str | None) -> dict[str, object]:
@@ -1941,7 +1971,7 @@ def restore_repeat(
         name: value if value is None or name == column or name in references else varied(value, RESTORE_STEP)
         for name, value in zip(names, survivor)
     }
-    objection, settled = insert_seed_row(connection, table, ddl, offered, row)
+    objection, settled = insert_seed_row(connection, table, ddl, offered, row, held=(column,))
     if not objection or column in references:
         return objection, settled
     optional = {
@@ -1950,7 +1980,7 @@ def restore_repeat(
         if not (info[3] or info[5]) and str(info[1]) in references
     }
     emptied = {name: None if name in optional else value for name, value in row.items()}
-    return insert_seed_row(connection, table, ddl, offered, emptied)
+    return insert_seed_row(connection, table, ddl, offered, emptied, held=(column,))
 
 
 def insert_seed_row(
@@ -1959,6 +1989,8 @@ def insert_seed_row(
     ddl: str,
     required: list[tuple[str, str]],
     values: dict[str, object],
+    *,
+    held: Iterable[str] = (),
 ) -> tuple[str, bool]:
     """Insert ``values`` into ``table``, repairing what the schema objects to.
 
@@ -2006,14 +2038,17 @@ def insert_seed_row(
             omitted.append((str(info[1]), str(info[2]), info[4]))
     context_columns = [*names, *(name for name, _, _ in omitted), *unavailable]
     prefix_sources = {identifier_key(other) for _, _, _, other in substring_requirements(text_constraints, context_columns)}
+    json_sources = {identifier_key(unquote_identifier(match.group(2)))
+                    for match in sql_matches(JSON_TERM, text_constraints)}
     strict = is_strict_table(connection, table)
     def row_identity(row: dict[str, object]) -> tuple:
         return tuple((name, type(row[name]), row[name]) for name in names)
 
     proposed: set[tuple] = set()
+    fixed = {name: values[name] for name in held}
 
     def unseen(assignment: SeedAssignment) -> bool:
-        return row_identity({**values, **dict(assignment)}) not in proposed
+        return row_identity({**values, **dict(assignment), **fixed}) not in proposed
 
     source_progress: dict[str, tuple[int, list[int]]] = {}
     objection = ""
@@ -2037,7 +2072,25 @@ def insert_seed_row(
                 strict=strict,
             )
             derived = tuple(shaped.derived)
-            untried = [derived] if derived and unseen(derived) else []
+            documents = json_proposals(
+                connection, expression, names, text_constraints=text_constraints, context_columns=context_columns,
+            )
+            # Only malformed inputs need priority over candidates that can enable
+            # their evaluation. Valid documents retain the semantic source order:
+            # a missing-path alternative must not displace an already-valid one.
+            invalid_documents = {
+                name for name in names if identifier_key(name) in json_sources
+                and not connection.execute("select json_valid(?)", (values[name],)).fetchone()[0]
+            } if documents else set()
+            untried = next((
+                [assignment] for assignment in documents if unseen(assignment) and any(
+                    name in invalid_documents
+                    and connection.execute("select json_valid(?)", (value,)).fetchone()[0]
+                    for name, value in assignment
+                )
+            ), [])
+            if not untried:
+                untried = [derived] if derived and unseen(derived) else []
             if not untried:
                 # Required prefix sources may be defined by another CHECK. Keep
                 # their existing proposals in the semantic turn, not behind a
@@ -2051,7 +2104,7 @@ def insert_seed_row(
                 sources = [
                     shaped.numeric_fallback,
                     [*((pair,) for pair in check_proposals(expression, names, context_columns=context_columns)), *shaped.semantic_fallback,
-                     *json_proposals(connection, expression, names, text_constraints=text_constraints, context_columns=context_columns),
+                     *documents,
                      *((pair,) for pair in related_proposals)],
                 ]
                 # Finish each source's forward pass before either wraps. Otherwise
@@ -2076,6 +2129,9 @@ def insert_seed_row(
             if not untried:
                 return objection, True
             values.update(untried[0])
+            # A repeat offer fixes its held value, not every other cell in a
+            # proposed row. Deduplication above sees this same atomic assignment.
+            values.update(fixed)
         else:
             return "", True
     return f"{SEED_ATTEMPTS} attempts did not produce a row the schema accepts; last was {objection}", False
@@ -2177,7 +2233,10 @@ def seed_representative_rows(db_path: Path) -> tuple[dict[str, str], dict[str, s
             # construction and still has to be seeded.
             strict = is_strict_table(connection, table)
             base = {column: representative_value(column, declared, strict=strict) for column, declared in every}
-            objection, settled = insert_seed_row(connection, table, ddl, every, dict(base))
+            maximal = dict(base)
+            objection, settled = insert_seed_row(connection, table, ddl, every, maximal)
+            if not objection:
+                base = maximal
             offered = every
             if objection:
                 refused[f"{table}, every column at once"] = objection
@@ -2192,7 +2251,7 @@ def seed_representative_rows(db_path: Path) -> tuple[dict[str, str], dict[str, s
             steps = 0
             for steps, column in enumerate(() if objection else base, start=1):
                 refusal, decided = insert_seed_row(
-                    connection, table, ddl, offered, moved_row(base, steps, held=column)
+                    connection, table, ddl, offered, moved_row(base, steps, held=column), held=(column,)
                 )
                 if not refusal:
                     repeated.append(column)

--- a/scripts/migration_release_guard.py
+++ b/scripts/migration_release_guard.py
@@ -851,9 +851,11 @@ SEED_ROWS = 2
 RESTORE_STEP = SEED_ATTEMPTS
 
 
-def sqlite_affinity(declared_type: str) -> str:
+def sqlite_affinity(declared_type: str, *, strict: bool = False) -> str:
     """SQLite's ordered declared-type rules, shared by seed and repair candidates."""
     kind = declared_type.upper()
+    if strict and kind == "ANY":
+        return "BLOB"
     if "INT" in kind:
         return "INTEGER"
     if any(marker in kind for marker in ("CHAR", "CLOB", "TEXT")):
@@ -865,6 +867,11 @@ def sqlite_affinity(declared_type: str) -> str:
     return "NUMERIC"
 
 
+def is_strict_table(connection: sqlite3.Connection, table: str) -> bool:
+    quoted = table.replace('"', '""')
+    return any(row[5] for row in connection.execute(f'pragma main.table_list("{quoted}")'))
+
+
 def substring_requirements(expression: str) -> Iterable[tuple[str, str, str, str]]:
     """Normalize either operand order into (target, start, width, source)."""
     identifier = r'"?(\w+)"?'
@@ -873,7 +880,7 @@ def substring_requirements(expression: str) -> Iterable[tuple[str, str, str, str
         yield target, start, width, source
 
 
-def representative_value(column: str, declared_type: str) -> object:
+def representative_value(column: str, declared_type: str, *, strict: bool = False) -> object:
     """A value of ``declared_type`` that SQLite will store in ``column``.
 
     Typed off the declaration rather than off the column's meaning, because meaning is
@@ -883,10 +890,10 @@ def representative_value(column: str, declared_type: str) -> object:
     migration that parses a timestamp, an address, or a JSON document gets something
     parseable rather than ``'x'``.
     """
-    kind = sqlite_affinity(declared_type)
+    kind = sqlite_affinity(declared_type, strict=strict)
     if kind in {"INTEGER", "REAL", "NUMERIC"}:
         return 0
-    if kind == "BLOB" and declared_type:
+    if kind == "BLOB" and declared_type and not (strict and declared_type.upper() == "ANY"):
         return b""
     if column.endswith(("_at", "_time")):
         return "1970-01-01T00:00:00+00:00"
@@ -942,6 +949,9 @@ def check_proposals(expression: str, columns: Iterable[str]) -> list[tuple[str, 
     whether the resulting row is admissible, so a bad proposal costs an attempt rather
     than producing a row the schema would have refused.
     """
+    # Paths and member values already belong to semantic JSON proposals; offering
+    # them to ordinary columns can overwrite an otherwise successful repair.
+    expression = JSON_REQUIREMENT.sub("", expression)
     literals = re.findall(r"'([^']*)'", expression)
     folded = identifier_key(expression)
     named = [column for column in columns if re.search(rf"\b{re.escape(identifier_key(column))}\b", folded)]
@@ -1094,6 +1104,12 @@ def glob_witness(
     return None
 
 
+@dataclass
+class ShapeProposals:
+    derived: list[tuple[str, object]]
+    numeric_fallback: list[tuple[str, object]]
+
+
 def shape_proposals(
     connection: sqlite3.Connection,
     expression: str,
@@ -1103,8 +1119,8 @@ def shape_proposals(
     text_constraints: str | None = None,
     omitted: Iterable[tuple[str, str, str | None]] = (),
     unavailable: Iterable[str] = (),
-    allow_unvalidated_numeric: bool = True,
-) -> list[tuple[str, object]]:
+    strict: bool = False,
+) -> ShapeProposals:
     """Derive bounded text-shape and numeric candidates from the rejected CHECK.
 
     This extends the literal/JSON proposals, not the seeder's coverage claim. Unsupported
@@ -1164,7 +1180,8 @@ def shape_proposals(
     }
     numeric = [
         name for name, declared in required
-        if sqlite_affinity(declared) in {"INTEGER", "REAL", "NUMERIC"}
+        if (sqlite_affinity(declared, strict=strict) in {"INTEGER", "REAL", "NUMERIC"}
+            or (strict and declared.upper() == "ANY"))
         and re.search(rf"\b{re.escape(identifier_key(name))}\b", identifier_key(expression))
     ]
     candidates = list(dict.fromkeys(
@@ -1173,11 +1190,11 @@ def shape_proposals(
     ))
     fallback = [
         (name, candidate) for candidate in candidates for name in numeric if candidate != values[name]
-    ] if allow_unvalidated_numeric else []
+    ]
     if any(re.search(rf"\b{re.escape(identifier_key(name))}\b", identifier_key(expression)) for name in unavailable):
-        return [*proposals, *fallback]
+        return ShapeProposals(proposals, fallback)
     if not numeric or not candidates:
-        return proposals
+        return ShapeProposals(proposals, [])
     domains = numeric_domains(expression, numeric, values, candidates)
     assignments = numeric_assignments(domains, tuple(values[name] for name in numeric), candidates)
     # Native typed insertion models affinity, but scratch DML must never change
@@ -1214,12 +1231,16 @@ def shape_proposals(
         for _, _, default in omitted:
             if default is not None:
                 evaluation.execute(f"explain select ({default})").fetchall()
-        evaluation.execute(f"create table {table} ({', '.join(declarations)})")
+        evaluation.execute(f"create table {table} ({', '.join(declarations)})" + (" STRICT" if strict else ""))
         for assignment in itertools.islice(assignments, SEED_ATTEMPTS):
             changes = dict(zip(numeric, assignment))
             parameters = [changes.get(column, values[column]) for column, _ in required]
             evaluation.execute(f"delete from {table}")
-            evaluation.execute(f"insert into {table} ({columns}) values ({placeholders})", parameters)
+            try:
+                evaluation.execute(f"insert into {table} ({columns}) values ({placeholders})", parameters)
+            except sqlite3.IntegrityError:
+                # STRICT storage can reject a candidate before its CHECK is evaluated.
+                continue
             accepted = evaluation.execute(
                 f"select coalesce(cast(({expression}) as numeric), 1) != 0 from {table}"
             ).fetchone()[0]
@@ -1228,10 +1249,10 @@ def shape_proposals(
                 break
     except sqlite3.OperationalError:
         # Unrepresentable context cannot reject a candidate; actual INSERT decides.
-        proposals.extend(fallback)
+        return ShapeProposals(proposals, fallback)
     finally:
         evaluation.close()
-    return proposals
+    return ShapeProposals(proposals, [])
 
 
 def numeric_assignments(
@@ -1260,10 +1281,11 @@ def numeric_assignments(
 
     anchors = dict.fromkeys([ranked, *uniform])
     neighborhoods = interleave(*(sparse(base) for base in anchors if base != current))
-    joint = interleave(neighborhoods, iter(uniform), itertools.product(*domains))
-    # Current-row single changes keep their own turns regardless of how many
-    # joint anchors the CHECK's literals introduced.
-    for assignment in interleave(sparse(current), joint):
+    anchors = interleave(neighborhoods, iter(uniform))
+    products = itertools.product(*domains)
+    # Cartesian search gets two direct turns; local and anchor repairs get one
+    # each. Nesting Cartesian behind anchors would dilute its finite budget.
+    for assignment in interleave(sparse(current), products, products, anchors):
         if assignment not in seen:
             seen.add(assignment)
             yield assignment
@@ -1591,9 +1613,11 @@ def insert_seed_row(
         else:
             omitted.append((str(info[1]), str(info[2]), info[4]))
     prefix_sources = {identifier_key(other) for _, _, _, other in substring_requirements(text_constraints)}
+    strict = is_strict_table(connection, table)
     proposed: set[tuple[str, object]] = set()
+    next_source = 0
     objection = ""
-    for attempt in range(SEED_ATTEMPTS):
+    for _ in range(SEED_ATTEMPTS):
         try:
             connection.execute(statement, [values[column] for column in names])
         except sqlite3.Error as exc:
@@ -1605,19 +1629,25 @@ def insert_seed_row(
             if failure is None:
                 return objection, True
             expression = check_expression(ddl, failure.group(1))
-            untried = [
-                pair
-                for pair in [
-                    *shape_proposals(
-                        connection, expression, required, values,
-                        text_constraints=text_constraints, omitted=omitted, unavailable=unavailable,
-                        allow_unvalidated_numeric=attempt < SEED_ATTEMPTS // 2,
-                    ),
-                    *json_proposals(connection, expression, names),
-                    *check_proposals(expression, names),
+            shaped = shape_proposals(
+                connection, expression, required, values,
+                text_constraints=text_constraints, omitted=omitted, unavailable=unavailable,
+                strict=strict,
+            )
+            untried = [pair for pair in shaped.derived if pair not in proposed and values[pair[0]] != pair[1]]
+            if not untried:
+                sources = [
+                    shaped.numeric_fallback,
+                    [*check_proposals(expression, names), *json_proposals(connection, expression, names)],
                 ]
-                if pair not in proposed and values[pair[0]] != pair[1]
-            ]
+                # Derived repairs precede guesses. Both guess sources remain live
+                # throughout the INSERT budget, with JSON after generic literals.
+                for offset in range(len(sources)):
+                    source = (next_source + offset) % len(sources)
+                    untried = [pair for pair in sources[source] if pair not in proposed and values[pair[0]] != pair[1]]
+                    if untried:
+                        next_source = (source + 1) % len(sources)
+                        break
             if not untried:
                 # Follow only prefix-source dependencies into other CHECKs. Unrelated
                 # literals must not overwrite columns that already satisfy their checks.
@@ -1731,7 +1761,8 @@ def seed_representative_rows(db_path: Path) -> tuple[dict[str, str], dict[str, s
             # column first and fall back to what the table demands, because a table whose
             # CHECKs make some columns mutually exclusive refuses the maximal row by
             # construction and still has to be seeded.
-            base = {column: representative_value(column, declared) for column, declared in every}
+            strict = is_strict_table(connection, table)
+            base = {column: representative_value(column, declared, strict=strict) for column, declared in every}
             objection, settled = insert_seed_row(connection, table, ddl, every, dict(base))
             offered = every
             if objection:

--- a/scripts/migration_release_guard.py
+++ b/scripts/migration_release_guard.py
@@ -1051,52 +1051,76 @@ def json_proposals(
     """Whole assignments retaining the documents behind JSON member candidates.
 
     The document is built by SQLite's own ``json_set`` rather than assembled here, so the
-    path syntax is whatever SQLite accepts and not a second reading of it. All clauses for
-    one column are folded into a single document, because a constraint requiring two paths
-    is not satisfied by a document carrying either one. Missing paths remain an
-    alternative: SQLite can accept NULL comparisons without requiring a member.
+    path syntax is whatever SQLite accepts and not a second reading of it. Required whole
+    clauses across CHECKs share a document; speculative clauses from the failing CHECK
+    form a separate alternative. Missing paths remain an alternative too: SQLite can
+    accept NULL comparisons without requiring a member.
     """
     wanted = {identifier_key(column): column for column in columns}
     shapes = text_constraints if text_constraints is not None else expression
-    required: dict[str, list[tuple[str, str, object]]] = {}
-    for match in sql_matches(JSON_REQUIREMENT, shapes):
-        function, column, path, literal = match.groups()
-        path = path.replace("''", "'")
-        column = wanted.get(identifier_key(unquote_identifier(column)))
-        if column is None:
-            continue
-        if function.lower() == "type":
-            named = literal.strip("'").lower()
-            if named not in JSON_TYPE_MEMBERS:
+    context_columns = tuple(context_columns)
+    terms = [sql_projection(term, literals=True, identifiers=True).strip()
+             for term in conjunctive_terms(shapes, (*wanted.values(), *context_columns))]
+    scopes = [
+        tuple(match.groups() for term in terms if (match := JSON_REQUIREMENT.fullmatch(term))),
+        tuple(match.groups() for match in sql_matches(JSON_REQUIREMENT, expression)),
+    ]
+    proposals = []
+    missing = []
+    for scope in dict.fromkeys(scopes):
+        required: dict[str, list[tuple[str, str, object]]] = {}
+        for function, column, path, literal in scope:
+            path = path.replace("''", "'")
+            column = wanted.get(identifier_key(unquote_identifier(column)))
+            if column is None:
                 continue
-            member = JSON_TYPE_MEMBERS[named]
-            # JSON composites and booleans need their JSON type, not SQL text/integers.
-            term = "json(?)" if named in {"array", "object", "true", "false"} else "?"
-            required.setdefault(column, []).append((path, term, member))
-        elif literal.startswith("'"):
-            required.setdefault(column, []).append((path, "?", literal[1:-1].replace("''", "'")))
-        else:
-            required.setdefault(column, []).append((path, "json(?)", str(Decimal(literal))))
+            if function.lower() == "type":
+                named = literal.strip("'").lower()
+                if named not in JSON_TYPE_MEMBERS:
+                    continue
+                member = JSON_TYPE_MEMBERS[named]
+                # Composites and booleans need JSON types, not SQL text/integers.
+                value_term = "json(?)" if named in {"array", "object", "true", "false"} else "?"
+                required.setdefault(column, []).append((path, value_term, member))
+            elif literal.startswith("'"):
+                required.setdefault(column, []).append((path, "?", literal[1:-1].replace("''", "'")))
+            else:
+                required.setdefault(column, []).append((path, "json(?)", str(Decimal(literal))))
 
-    documents = {}
-    for column, clauses in required.items():
-        document = "'{}'"
-        parameters: list[object] = []
-        for path, term, value in clauses:
-            document = f"json_set({document}, ?, {term})"
-            parameters.extend([path, value])
-        documents[column] = str(connection.execute(f"select {document}", parameters).fetchone()[0])
-    if not documents:
-        return []
+        documents = {}
+        for column, clauses in required.items():
+            document = "'{}'"
+            parameters: list[object] = []
+            for path, value_term, value in clauses:
+                document = f"json_set({document}, ?, {value_term})"
+                parameters.extend([path, value])
+            try:
+                documents[column] = str(connection.execute(f"select {document}", parameters).fetchone()[0])
+            except sqlite3.Error:
+                # A speculative clause may be unreachable in the real CHECK.
+                # Reject its document, not the seeding process or native refusal.
+                continue
+        if not documents:
+            continue
+        proposals.extend(json_member_assignments(connection, documents, terms, shapes, wanted, context_columns))
+        missing.extend(((column, "{}"),) for column, document in documents.items() if document != "{}")
+    # Populated documents/dependents precede missing-path alternatives in every scope.
+    return list(dict.fromkeys([*proposals, *missing]))
+
+
+def json_member_assignments(
+    connection: sqlite3.Connection, documents: dict[str, str], terms: list[str],
+    shapes: str, wanted: dict[str, str], context_columns: Iterable[str],
+) -> list[SeedAssignment]:
+    """Keep native dependent candidates attached to one constructed document scope."""
     preferred = dict(documents)
     recipients = semantic_recipients(shapes, wanted.values(), context_columns=context_columns)
     identifier = f'({SQL_IDENTIFIER})'
     alternatives = []
-    for term in conjunctive_terms(shapes, (*wanted.values(), *context_columns)):
-        active = sql_projection(term, literals=True, identifiers=True)
+    for term in terms:
         for reverse in (False, True):
             operands = (identifier, JSON_TERM) if reverse else (JSON_TERM, identifier)
-            match = re.fullmatch(rf'\s*{operands[0]}{EQUALITY}{operands[1]}\s*', active, re.IGNORECASE)
+            match = re.fullmatch(rf'\s*{operands[0]}{EQUALITY}{operands[1]}\s*', term, re.IGNORECASE)
             if match is None:
                 continue
             if reverse:
@@ -1105,9 +1129,12 @@ def json_proposals(
                 function, source, path, target = match.groups()
             source, target = wanted.get(identifier_key(unquote_identifier(source))), wanted.get(identifier_key(unquote_identifier(target)))
             if source in documents and target is not None and target not in documents:
-                preferred[target] = connection.execute(
-                    f"select json_{function.lower()}(?, ?)", (documents[source], path.replace("''", "'"))
-                ).fetchone()[0]
+                try:
+                    preferred[target] = connection.execute(
+                        f"select json_{function.lower()}(?, ?)", (documents[source], path.replace("''", "'"))
+                    ).fetchone()[0]
+                except sqlite3.Error:
+                    continue
         # A functional operand is not an alias. Retain the native member as a
         # guess for that term's dependents, always together with its document.
         for match in sql_matches(JSON_TERM, term):
@@ -1118,16 +1145,16 @@ def json_proposals(
             targets = [name for name in wanted.values() if name in recipients[source] and name not in documents]
             if not targets:
                 continue
-            value = connection.execute(
-                f"select json_{function.lower()}(?, ?)", (documents[source], path.replace("''", "'"))
-            ).fetchone()[0]
+            try:
+                value = connection.execute(
+                    f"select json_{function.lower()}(?, ?)", (documents[source], path.replace("''", "'"))
+                ).fetchone()[0]
+            except sqlite3.Error:
+                # Dead/optional paths cannot abort an otherwise usable document.
+                continue
             alternatives.append(tuple({**documents, **dict.fromkeys(targets, value)}.items()))
             alternatives.extend(tuple({**documents, target: value}.items()) for target in targets)
-    proposals = [tuple(preferred.items()), tuple(documents.items()), *alternatives]
-    # Keep populated members and their dependents first; omission is a fallback,
-    # not permission to replace a document that already satisfies the CHECK.
-    proposals.extend(((column, "{}"),) for column, document in documents.items() if document != "{}")
-    return list(dict.fromkeys(proposals))
+    return [tuple(preferred.items()), tuple(documents.items()), *alternatives]
 
 
 def glob_witness(
@@ -1256,7 +1283,7 @@ def conjunctive_terms(expression: str, columns: Iterable[str] = ()) -> Iterable[
         between = False
         outer_start = outer_end = None
         commas = []
-        for token in re.finditer(r'\(|\)|,|\b(?:and|or|between|case|end)\b', active, re.IGNORECASE):
+        for token in re.finditer(rf'\(|\)|,|{SQL_IDENTIFIER}', active, re.IGNORECASE):
             kind = token.group().lower()
             if kind == '(':
                 if depth == 0 and outer_start is None:
@@ -1273,7 +1300,7 @@ def conjunctive_terms(expression: str, columns: Iterable[str] = ()) -> Iterable[
             elif kind == ',':
                 if depth == 1 and case_depth == 0:
                     commas.append(token.start())
-            elif depth == 0 and case_depth == 0:
+            elif kind in {"and", "or", "between"} and depth == 0 and case_depth == 0:
                 if kind == 'or':
                     cuts = []
                     break  # OR has lower precedence than AND.

--- a/scripts/migration_release_guard.py
+++ b/scripts/migration_release_guard.py
@@ -1018,7 +1018,19 @@ def check_proposals(expression: str, columns: Iterable[str]) -> list[tuple[str, 
     literals = [match.group()[1:-1].replace("''", "'") for match in SQL_OPAQUE.finditer(expression) if match.group().startswith("'")]
     mentioned = sql_identifiers(expression)
     named = [column for column in columns if identifier_key(column) in mentioned]
-    return [(column, literal) for column in named for literal in literals]
+    names = {identifier_key(column): column for column in named}
+    preferred = []
+    for term in conjunctive_terms(expression):
+        for reverse in (False, True):
+            operands = (SQL_STRING, SQL_IDENTIFIER) if reverse else (SQL_IDENTIFIER, SQL_STRING)
+            match = re.fullmatch(rf'\s*({operands[0]}){EQUALITY}({operands[1]})\s*', term, re.IGNORECASE)
+            if match is not None:
+                token, literal = reversed(match.groups()) if reverse else match.groups()
+                column = names.get(identifier_key(unquote_identifier(token)))
+                if column is not None:
+                    preferred.append((column, literal[1:-1].replace("''", "'")))
+    # An explicit binding should not first be broadcast into unrelated columns.
+    return list(dict.fromkeys([*preferred, *((column, literal) for column in named for literal in literals)]))
 
 
 def json_proposals(
@@ -1290,32 +1302,46 @@ def shape_proposals(
     groups = column_equality_groups(shapes, (name for name, _ in required if name in text_eligible))
     aliases = {name: members for members in groups for name in members}
     witnesses = []
-    for members in groups:
+    pending_groups = deque(groups)
+    while pending_groups:
+        members = pending_groups.popleft()
         patterns = tuple(dict.fromkeys(pattern for name in members for pattern in positive[name]))
         excluded = tuple(dict.fromkeys(pattern for name in members for pattern in negative[name]))
         if not patterns and not excluded:
             continue
         sizes = {widths[name] for name in members if name in widths}
-        if len(sizes) > 1:
-            continue  # No common text can satisfy incompatible declared widths.
         width = next(iter(sizes), None)
-        if len(members) == 1 and not isinstance(values[members[0]], str):
-            original = values[members[0]]
-            if ((width is None or connection.execute("select length(?)", (original,)).fetchone()[0] == width)
-                    and all(connection.execute("select ? glob ?", (original, pattern)).fetchone()[0] for pattern in patterns)
-                    and not any(connection.execute("select ? glob ?", (original, pattern)).fetchone()[0] for pattern in excluded)):
-                text.pop(members[0], None)
-                continue
+        def fits(value: object) -> bool:
+            return (len(sizes) <= 1
+                    and (width is None or connection.execute("select length(?)", (value,)).fetchone()[0] == width)
+                    and all(connection.execute("select ? glob ?", (value, pattern)).fetchone()[0] for pattern in patterns)
+                    and not any(connection.execute("select ? glob ?", (value, pattern)).fetchone()[0] for pattern in excluded))
+
+        # Already-valid native values need no text promotion, including groups.
+        if all(fits(values[name]) and connection.execute(
+                "select ? is ?", (values[members[0]], values[name])
+        ).fetchone()[0] for name in members):
+            for name in members:
+                if isinstance(values[name], str):
+                    text[name] = values[name]
+                else:
+                    text.pop(name, None)
+            witnesses.extend(values[name] for name in members if isinstance(values[name], str))
+            continue
         witness = next((text[name] for name in members if name in text
-                        and (width is None or len(text[name]) == width)
-                        and all(connection.execute("select ? glob ?", (text[name], pattern)).fetchone()[0] for pattern in patterns)
-                        and not any(connection.execute("select ? glob ?", (text[name], pattern)).fetchone()[0] for pattern in excluded)), None)
-        if witness is None:
+                        and fits(text[name])), None)
+        if witness is None and len(sizes) <= 1:
             alphabet = "".join(dict.fromkeys(string.printable + "".join((*patterns, *excluded))))
             witness = glob_witness(connection, patterns, excluded=excluded, width=width, alphabet=alphabet)
         if witness is not None:
             text.update((name, witness) for name in members)
             witnesses.append(witness)
+        elif len(members) > 1:
+            # Equality may use collation/affinity rather than byte identity.
+            # Reuse independent shape search; the target INSERT decides equality.
+            for name in members:
+                aliases[name] = [name]
+                pending_groups.append([name])
     for name, start, width, other in substring_requirements(shapes):
         name, other = names.get(identifier_key(name), name), names.get(identifier_key(other), other)
         position = bounded_integer(start, 1, SEED_TEXT_LIMIT)
@@ -1428,9 +1454,9 @@ def numeric_assignments(
     seen = {ranked}
     yield ranked
     local = sparse(current)
-    # Reserve half the budget for later local alternatives as well as the first
-    # opportunity per column. Larger domains still obey the same total cap.
-    for assignment in itertools.islice(local, max(len(domains), SEED_ATTEMPTS // 2)):
+    # A column-count-dependent reservation can exclude every joint candidate.
+    # Retain later local alternatives, but leave half the budget for mixed search.
+    for assignment in itertools.islice(local, SEED_ATTEMPTS // 2):
         if assignment not in seen:
             seen.add(assignment)
             yield assignment
@@ -1806,7 +1832,8 @@ def insert_seed_row(
                 text_constraints=text_constraints, omitted=omitted, unavailable=unavailable,
                 strict=strict,
             )
-            untried = [(pair,) for pair in shaped.derived if unseen((pair,))]
+            derived = tuple(shaped.derived)
+            untried = [derived] if derived and unseen(derived) else []
             if not untried:
                 sources = [
                     shaped.numeric_fallback,

--- a/scripts/migration_release_guard.py
+++ b/scripts/migration_release_guard.py
@@ -817,15 +817,24 @@ JSON_VARIED_MEMBER = "__seed_step__"
 # which is the same three things the plain literal form carries -- so both are read the
 # same way rather than treated as unseedable.
 SQL_QUOTED_IDENTIFIER = r'"(?:[^"]|"")*"|`(?:[^`]|``)*`|\[[^\]]*\]'
-SQL_IDENTIFIER = rf'(?:{SQL_QUOTED_IDENTIFIER}|(?<![\w$])[^\W\d][\w$]*)'
-SUBSTRING_TERM = rf'\bsubstr\s*\(\s*({SQL_IDENTIFIER})\s*,\s*(\d+)\s*,\s*(\d+)\s*\)'
-EQUALITY = r'\s*(?:==|=(?!=)|\bis\b(?!\s+not\b))\s*'
+# SQLite treats non-ASCII characters as identifier characters, not Python's
+# Unicode word/digit/space classes. A BOM is special only at the token's start.
+SQL_IDENTIFIER_CHARS = r'A-Za-z_0-9$\x80-\U0010ffff'
+SQL_FLAGS = re.IGNORECASE | re.ASCII
+SQL_WHITESPACE = " \t\n\r\f"
+SQL_IDENTIFIER = rf'(?:{SQL_QUOTED_IDENTIFIER}|(?<![{SQL_IDENTIFIER_CHARS}])(?!\ufeff)[A-Za-z_\x80-\U0010ffff][{SQL_IDENTIFIER_CHARS}]*)'
+# These scalar-function results have no column affinity for unary '+' to erase.
+SQL_UNARY_PLUS = r'(?:\+\s*)*'
+SUBSTRING_TERM = rf'(?<![{SQL_IDENTIFIER_CHARS}]){SQL_UNARY_PLUS}substr\s*\(\s*({SQL_IDENTIFIER})\s*,\s*(\d+)\s*,\s*(\d+)\s*\)'
+EQUALITY = rf'\s*(?:==|=(?!=)|(?<![{SQL_IDENTIFIER_CHARS}])is(?![{SQL_IDENTIFIER_CHARS}])(?!\s+not(?![{SQL_IDENTIFIER_CHARS}])))\s*'
 SQL_STRING = r"'(?:[^']|'')*'"
-JSON_TERM = rf"\bjson_(extract|type)\s*\(\s*({SQL_IDENTIFIER})\s*,\s*'((?:[^']|'')*)'\s*\)"
-JSON_REQUIREMENT = re.compile(JSON_TERM + EQUALITY + rf"({SQL_STRING}|-?[0-9]+(?:\.[0-9]+)?)", re.IGNORECASE)
+SQL_INTEGER = rf"(?<![{SQL_IDENTIFIER_CHARS}.])-?[0-9]+(?![{SQL_IDENTIFIER_CHARS}.])"
+JSON_TERM = rf"(?<![{SQL_IDENTIFIER_CHARS}]){SQL_UNARY_PLUS}json_(extract|type)\s*\(\s*({SQL_IDENTIFIER})\s*,\s*'((?:[^']|'')*)'\s*\)"
+JSON_REQUIREMENT = re.compile(JSON_TERM + EQUALITY + rf"({SQL_STRING}|-?[0-9]+(?:\.[0-9]+)?)", SQL_FLAGS)
 GLOB_REQUIREMENT = rf"({SQL_IDENTIFIER})\s+(not\s+)?glob\s*'((?:[^']|'')*)'"
 SQL_OPAQUE = re.compile(
     SQL_STRING + '|' + SQL_QUOTED_IDENTIFIER + r'|--[^\n]*|/\*[\s\S]*?(?:\*/|$)'
+    + rf'|(?<![{SQL_IDENTIFIER_CHARS}])\ufeff+'
 )
 
 # Every name SQLite's `json_type` can return, against the emptiest document member of that
@@ -892,11 +901,11 @@ def sql_matches(pattern: str | re.Pattern, expression: str) -> Iterable[re.Match
     active = sql_projection(expression, identifiers=True)
     opaque = [(token.start(), token.end()) for token in SQL_OPAQUE.finditer(expression)]
     searchable = sql_projection(expression, literals=True, identifiers=True)
-    compiled = re.compile(pattern, 0 if isinstance(pattern, re.Pattern) else re.IGNORECASE)
+    compiled = re.compile(pattern, 0 if isinstance(pattern, re.Pattern) else SQL_FLAGS)
     position = 0
     while match := compiled.search(searchable, position):
         enclosing = next(((start, end) for start, end in opaque if start <= match.start() < end), None)
-        if enclosing and (match.start() > enclosing[0] or not active[match.start()].strip()):
+        if enclosing and (match.start() > enclosing[0] or not active[match.start()].strip(SQL_WHITESPACE)):
             # An invalid cross-token match must not consume the following real operand.
             position = enclosing[1]
             continue
@@ -931,7 +940,7 @@ def substring_requirements(expression: str, columns: Iterable[str] = ()) -> Iter
         active = sql_projection(term, identifiers=True)
         for reverse in (False, True):
             operands = (identifier, SUBSTRING_TERM) if reverse else (SUBSTRING_TERM, identifier)
-            match = re.fullmatch(rf'\s*{operands[0]}{EQUALITY}{operands[1]}\s*', active, re.IGNORECASE)
+            match = re.fullmatch(rf'\s*{operands[0]}{EQUALITY}{operands[1]}\s*', active, SQL_FLAGS)
             if match is not None:
                 if reverse:
                     source, target, start, width = match.groups()
@@ -971,7 +980,7 @@ def check_expression(ddl: str, name: str) -> str:
     # SQLite stores the DDL as it was written, so the keywords are whatever case the
     # migration that created the table happened to use.
     active = sql_projection(ddl)
-    marker = next((match for match in sql_matches(rf'\bCONSTRAINT\s+({SQL_IDENTIFIER})\s+CHECK\s*\(', ddl)
+    marker = next((match for match in sql_matches(rf'(?<![{SQL_IDENTIFIER_CHARS}])CONSTRAINT\s+({SQL_IDENTIFIER})\s+CHECK\s*\(', ddl)
                    if identifier_key(unquote_identifier(match.group(1))) == identifier_key(name)), None)
     if marker is None:
         return ""
@@ -1031,7 +1040,7 @@ def check_proposals(
     for term in conjunctive_terms(expression, (*columns, *context_columns)):
         for reverse in (False, True):
             operands = (SQL_STRING, SQL_IDENTIFIER) if reverse else (SQL_IDENTIFIER, SQL_STRING)
-            match = re.fullmatch(rf'\s*({operands[0]}){EQUALITY}({operands[1]})\s*', term, re.IGNORECASE)
+            match = re.fullmatch(rf'\s*({operands[0]}){EQUALITY}({operands[1]})\s*', term, SQL_FLAGS)
             if match is not None:
                 token, literal = reversed(match.groups()) if reverse else match.groups()
                 column = names.get(identifier_key(unquote_identifier(token)))
@@ -1059,7 +1068,7 @@ def json_proposals(
     wanted = {identifier_key(column): column for column in columns}
     shapes = text_constraints if text_constraints is not None else expression
     context_columns = tuple(context_columns)
-    terms = [sql_projection(term, literals=True, identifiers=True).strip()
+    terms = [sql_projection(term, literals=True, identifiers=True).strip(SQL_WHITESPACE)
              for term in conjunctive_terms(shapes, (*wanted.values(), *context_columns))]
     scopes = [
         tuple(match.groups() for term in terms if (match := JSON_REQUIREMENT.fullmatch(term))),
@@ -1120,7 +1129,7 @@ def json_member_assignments(
     for term in terms:
         for reverse in (False, True):
             operands = (identifier, JSON_TERM) if reverse else (JSON_TERM, identifier)
-            match = re.fullmatch(rf'\s*{operands[0]}{EQUALITY}{operands[1]}\s*', term, re.IGNORECASE)
+            match = re.fullmatch(rf'\s*{operands[0]}{EQUALITY}{operands[1]}\s*', term, SQL_FLAGS)
             if match is None:
                 continue
             if reverse:
@@ -1273,17 +1282,18 @@ def conjunctive_terms(expression: str, columns: Iterable[str] = ()) -> Iterable[
     """Descend through required conjunctions and transparent truth wrappers."""
     names = {identifier_key(name) for name in columns}
     truth = r'(?:1|true)' if "true" not in names else '1'
+    is_true = r'is\s+true' if "true" not in names else r'(?!)'
     not_false = r'|is\s+not\s+false' if "false" not in names else ''
     pending = [expression]
     while pending:
-        term = pending.pop().strip()
+        term = pending.pop().strip(SQL_WHITESPACE)
         active = sql_projection(term)
         depth = case_depth = 0
         cuts = []
         between = False
         outer_start = outer_end = None
         commas = []
-        for token in re.finditer(rf'\(|\)|,|{SQL_IDENTIFIER}', active, re.IGNORECASE):
+        for token in re.finditer(rf'\(|\)|,|{SQL_IDENTIFIER}', active, SQL_FLAGS):
             kind = token.group().lower()
             if kind == '(':
                 if depth == 0 and outer_start is None:
@@ -1317,22 +1327,33 @@ def conjunctive_terms(expression: str, columns: Iterable[str] = ()) -> Iterable[
         else:
             inner = None
             if outer_start is not None and outer_end is not None:
-                prefix = sql_projection(term[:outer_start], identifiers=True).strip()
-                suffix = sql_projection(term[outer_end:], literals=True, identifiers=True).strip()
+                prefix = sql_projection(term[:outer_start], identifiers=True).strip(SQL_WHITESPACE)
+                suffix = sql_projection(term[outer_end:], literals=True, identifiers=True).strip(SQL_WHITESPACE)
                 body = term[outer_start + 1:outer_end - 1]
+                # These operators wrap the whole parenthesized operand (or hint).
+                # Never strip '+' from an operand of an equality: it removes affinity.
+                unary = re.match(rf'(?:(?:[+-]|not(?![{SQL_IDENTIFIER_CHARS}]))\s*)*', prefix, SQL_FLAGS)
+                negations = len(re.findall('not', unary.group(), SQL_FLAGS))
+                operand = prefix[unary.end():]
+                boolean_suffix = re.fullmatch(
+                    rf'(?:{is_true}{not_false})', suffix, SQL_FLAGS,
+                )
+                whole_operand = not operand or identifier_key(unquote_identifier(operand)) in {"likely", "unlikely", "likelihood"}
+                if whole_operand and negations % 2 == 0 and (not suffix or (
+                    not negations and ("-" not in unary.group() or boolean_suffix)
+                )):
+                    prefix = operand
                 if not prefix and (not suffix or re.fullmatch(
-                    rf'(?:{EQUALITY}{truth}{not_false})', suffix, re.IGNORECASE
+                    rf'(?:{EQUALITY}{truth}{not_false})', suffix, SQL_FLAGS
                 )):
                     inner = body
-                elif not suffix and re.fullmatch(rf'{truth}{EQUALITY}', prefix, re.IGNORECASE):
-                    inner = body
-                elif not suffix and re.fullmatch(r'not\s+not', prefix, re.IGNORECASE):
+                elif not suffix and re.fullmatch(rf'{truth}{EQUALITY}', prefix, SQL_FLAGS):
                     inner = body
                 elif not suffix and identifier_key(unquote_identifier(prefix)) in {"likely", "unlikely"} and not commas:
                     inner = body
                 elif not suffix and identifier_key(unquote_identifier(prefix)) == "likelihood" and len(commas) == 1:
-                    probability = sql_projection(term[commas[0] + 1:outer_end - 1]).strip()
-                    if re.fullmatch(r'(?:0(?:\.\d*)?|1(?:\.0*)?|\.\d+)', probability):
+                    probability = sql_projection(term[commas[0] + 1:outer_end - 1]).strip(SQL_WHITESPACE)
+                    if re.fullmatch(r'(?:0(?:\.\d*)?|1(?:\.0*)?|\.\d+)', probability, SQL_FLAGS):
                         inner = term[outer_start + 1:commas[0]]
             if inner is None:
                 yield term
@@ -1348,7 +1369,7 @@ def column_equality_groups(
     groups = {name: [name] for name in names.values()}
     pattern = rf'\s*({SQL_IDENTIFIER}){EQUALITY}({SQL_IDENTIFIER})\s*'
     for term in conjunctive_terms(expression, (*names.values(), *context_columns)):
-        match = re.fullmatch(pattern, sql_projection(term, identifiers=True), re.IGNORECASE)
+        match = re.fullmatch(pattern, sql_projection(term, identifiers=True), SQL_FLAGS)
         if match is None:
             continue
         left, right = (names.get(identifier_key(unquote_identifier(token))) for token in match.groups())
@@ -1402,7 +1423,7 @@ def shape_proposals(
     # Occurrences inside optional/negative branches are not required shapes.
     shape_terms = [sql_projection(term, literals=True, identifiers=True) for term in conjunctive_terms(shapes, context_columns)]
     for term in shape_terms:
-        match = re.fullmatch(rf'\s*length\s*\(\s*({SQL_IDENTIFIER})\s*\)\s*=\s*(\d+)\s*', term, re.IGNORECASE)
+        match = re.fullmatch(rf'\s*{SQL_UNARY_PLUS}length\s*\(\s*({SQL_IDENTIFIER})\s*\)\s*=\s*(\d+)\s*', term, SQL_FLAGS)
         if match is None:
             continue
         name, width = match.groups()
@@ -1414,7 +1435,7 @@ def shape_proposals(
                 text.setdefault(name, "x")
                 text[name] = text[name][:size].ljust(size, "0")
     globs = (match.groups() for term in shape_terms
-             if (match := re.fullmatch(rf'\s*{GLOB_REQUIREMENT}\s*', term, re.IGNORECASE)) is not None)
+             if (match := re.fullmatch(rf'\s*{GLOB_REQUIREMENT}\s*', term, SQL_FLAGS)) is not None)
     positive: dict[str, list[str]] = defaultdict(list)
     negative: dict[str, list[str]] = defaultdict(list)
     for name, negated, quoted in globs:
@@ -1510,7 +1531,7 @@ def shape_proposals(
     )
     bounds = {
         bound
-        for token in re.findall(r"(?<![\w.])-?[0-9]+(?![\w.])", numeric_text)
+        for token in re.findall(SQL_INTEGER, numeric_text)
         if (bound := bounded_integer(token, SQLITE_INT_MIN, SQLITE_INT_MAX)) is not None
     }
     numeric = [
@@ -1640,7 +1661,7 @@ def numeric_domains(
 ) -> list[list[object]]:
     """Rank finite domains by local predicates; the complete CHECK still decides."""
     identifier = f'({SQL_IDENTIFIER})'
-    literal = r"(-?[0-9]+)(?![\w.])"
+    literal = f"({SQL_INTEGER})"
     operator = r"\s*(==|!=|<>|<=|>=|=|<|>)\s*"
     predicates: dict[str, list[tuple[str, int]]] = defaultdict(list)
     clauses = [match.groups() for match in sql_matches(identifier + operator + literal, expression)]
@@ -1944,7 +1965,7 @@ def insert_seed_row(
     # together so declaration order does not decide whether a prefix can be offered.
     constraints = [
         check_expression(ddl, unquote_identifier(match.group(1)))
-        for match in sql_matches(rf'\bconstraint\s+({SQL_IDENTIFIER})\s+check\s*\(', ddl)
+        for match in sql_matches(rf'(?<![{SQL_IDENTIFIER_CHARS}])constraint\s+({SQL_IDENTIFIER})\s+check\s*\(', ddl)
     ]
     text_constraints = " AND ".join(f"({constraint}\n)" for constraint in constraints)
     omitted = []

--- a/scripts/migration_release_guard.py
+++ b/scripts/migration_release_guard.py
@@ -925,14 +925,19 @@ def sql_identifiers(expression: str) -> set[str]:
 
 
 def substring_requirements(expression: str) -> Iterable[tuple[str, str, str, str]]:
-    """Normalize either operand order into (target, start, width, source)."""
+    """Normalize required whole equalities into (target, start, width, source)."""
     identifier = f'({SQL_IDENTIFIER})'
-    for match in sql_matches(SUBSTRING_TERM + EQUALITY + identifier, expression):
-        target, start, width, source = match.groups()
-        yield unquote_identifier(target), start, width, unquote_identifier(source)
-    for match in sql_matches(identifier + EQUALITY + SUBSTRING_TERM, expression):
-        source, target, start, width = match.groups()
-        yield unquote_identifier(target), start, width, unquote_identifier(source)
+    for term in conjunctive_terms(expression):
+        active = sql_projection(term, identifiers=True)
+        for reverse in (False, True):
+            operands = (identifier, SUBSTRING_TERM) if reverse else (SUBSTRING_TERM, identifier)
+            match = re.fullmatch(rf'\s*{operands[0]}{EQUALITY}{operands[1]}\s*', active, re.IGNORECASE)
+            if match is not None:
+                if reverse:
+                    source, target, start, width = match.groups()
+                else:
+                    target, start, width, source = match.groups()
+                yield unquote_identifier(target), start, width, unquote_identifier(source)
 
 
 def representative_value(column: str, declared_type: str, *, strict: bool = False) -> object:
@@ -1036,12 +1041,13 @@ def check_proposals(expression: str, columns: Iterable[str]) -> list[tuple[str, 
 def json_proposals(
     connection: sqlite3.Connection, expression: str, columns: Iterable[str]
 ) -> list[tuple[str, object]]:
-    """``(column, document)`` pairs satisfying every JSON-path clause ``expression`` states.
+    """``(column, document)`` candidates suggested by JSON-path clauses.
 
     The document is built by SQLite's own ``json_set`` rather than assembled here, so the
     path syntax is whatever SQLite accepts and not a second reading of it. All clauses for
     one column are folded into a single document, because a constraint requiring two paths
-    is not satisfied by a document carrying either one.
+    is not satisfied by a document carrying either one. Missing paths remain an
+    alternative: SQLite can accept NULL comparisons without requiring a member.
     """
     wanted = {identifier_key(column): column for column in columns}
     required: dict[str, list[tuple[str, str, object]]] = {}
@@ -1083,6 +1089,9 @@ def json_proposals(
         if source in documents and target is not None:
             value = connection.execute(f"select json_{function.lower()}(?, ?)", (documents[source], path.replace("''", "'"))).fetchone()[0]
             proposals.append((target, value))
+    # Keep populated members and their dependents first; omission is a fallback,
+    # not permission to replace a document that already satisfies the CHECK.
+    proposals.extend((column, "{}") for column, document in documents.items() if document != "{}")
     return proposals
 
 
@@ -1282,7 +1291,13 @@ def shape_proposals(
     text = {name: value for name, value in values.items() if name in text_eligible and isinstance(value, str)}
     widths = {}
     shapes = text_constraints if text_constraints is not None else expression
-    for match in sql_matches(rf'\blength\s*\(\s*({SQL_IDENTIFIER})\s*\)\s*=\s*(\d+)', shapes):
+    # Only required whole terms may force a shape during an unrelated repair.
+    # Occurrences inside OR/NOT/CASE/functions are not required shapes.
+    shape_terms = [sql_projection(term, literals=True, identifiers=True) for term in conjunctive_terms(shapes)]
+    for term in shape_terms:
+        match = re.fullmatch(rf'\s*length\s*\(\s*({SQL_IDENTIFIER})\s*\)\s*=\s*(\d+)\s*', term, re.IGNORECASE)
+        if match is None:
+            continue
         name, width = match.groups()
         name = names.get(identifier_key(unquote_identifier(name)), name)
         size = bounded_integer(width, 0, SEED_TEXT_LIMIT)
@@ -1291,7 +1306,8 @@ def shape_proposals(
             if isinstance(values[name], str) or connection.execute("select length(?)", (values[name],)).fetchone()[0] != size:
                 text.setdefault(name, "x")
                 text[name] = text[name][:size].ljust(size, "0")
-    globs = (match.groups() for match in sql_matches(GLOB_REQUIREMENT, shapes))
+    globs = (match.groups() for term in shape_terms
+             if (match := re.fullmatch(rf'\s*{GLOB_REQUIREMENT}\s*', term, re.IGNORECASE)) is not None)
     positive: dict[str, list[str]] = defaultdict(list)
     negative: dict[str, list[str]] = defaultdict(list)
     for name, negated, quoted in globs:
@@ -1403,6 +1419,7 @@ def shape_proposals(
     )
     columns = ', '.join(quote_identifier(name) for name, _ in required)
     placeholders = ', '.join('?' for _ in required)
+    rejected: list[SeedAssignment] = []
     try:
         evaluation.execute(f"create table {table} ({', '.join(declarations)})" + (" STRICT" if strict else ""))
         # Let SQLite resolve overloads and enforce expression-index determinism.
@@ -1426,13 +1443,17 @@ def shape_proposals(
             ).fetchone()[0]
             if accepted:
                 proposals.extend((name, value) for name, value in changes.items() if value != values[name])
-                break
+                return ShapeProposals(proposals, [], text_fallback)
+            # Not an accepted row, but still a storage-valid origin for another
+            # bounded search. The INSERT loop owns progress, deduplication and
+            # its total budget; do not discard all partial numeric repairs here.
+            rejected.append(assignment)
     except sqlite3.OperationalError:
         # Unrepresentable context cannot reject a candidate; actual INSERT decides.
         return ShapeProposals(proposals, fallback, text_fallback)
     finally:
         evaluation.close()
-    return ShapeProposals(proposals, [], text_fallback)
+    return ShapeProposals(proposals, rejected, text_fallback)
 
 
 def numeric_assignments(
@@ -1844,9 +1865,19 @@ def insert_seed_row(
             derived = tuple(shaped.derived)
             untried = [derived] if derived and unseen(derived) else []
             if not untried:
+                # Required prefix sources may be defined by another CHECK. Keep
+                # their existing proposals in the semantic turn, not behind a
+                # numeric source that can remain live for the whole budget.
+                related_proposals = [
+                    pair
+                    for related in constraints
+                    for pair in [*check_proposals(related, names), *json_proposals(connection, related, names)]
+                    if identifier_key(pair[0]) in prefix_sources
+                ]
                 sources = [
                     shaped.numeric_fallback,
-                    [(pair,) for pair in [*check_proposals(expression, names), *shaped.text_fallback, *json_proposals(connection, expression, names)]],
+                    [(pair,) for pair in [*check_proposals(expression, names), *shaped.text_fallback,
+                                         *json_proposals(connection, expression, names), *related_proposals]],
                 ]
                 # Derived repairs precede guesses. Both guess sources remain live
                 # throughout the INSERT budget, with JSON after generic literals.
@@ -1862,15 +1893,6 @@ def insert_seed_row(
                     if untried:
                         source_progress[expression] = ((source + 1) % len(sources), source_positions)
                         break
-            if not untried:
-                # Follow only prefix-source dependencies into other CHECKs. Unrelated
-                # literals must not overwrite columns that already satisfy their checks.
-                untried = [
-                    (pair,)
-                    for related in constraints
-                    for pair in [*check_proposals(related, names), *json_proposals(connection, related, names)]
-                    if identifier_key(pair[0]) in prefix_sources and unseen((pair,))
-                ]
             if not untried:
                 return objection, True
             values.update(untried[0])

--- a/scripts/migration_release_guard.py
+++ b/scripts/migration_release_guard.py
@@ -816,13 +816,14 @@ JSON_VARIED_MEMBER = "__seed_step__"
 # `json_type(col,'$.p') = 'array'` both name the column, the path, and what belongs at it,
 # which is the same three things the plain literal form carries -- so both are read the
 # same way rather than treated as unseedable.
-JSON_REQUIREMENT = re.compile(
-    r"json_(extract|type)\s*\(\s*\"?(\w+)\"?\s*,\s*'([^']*)'\s*\)\s*(?:==|=|is)\s*"
-    r"('[^']*'|-?[0-9]+(?:\.[0-9]+)?)",
-    re.IGNORECASE,
-)
 SUBSTRING_TERM = r'\bsubstr\s*\(\s*"?(\w+)"?\s*,\s*(\d+)\s*,\s*(\d+)\s*\)'
 EQUALITY = r'\s*(?:==|=(?!=)|\bis\b(?!\s+not\b))\s*'
+SQL_STRING = r"'(?:[^']|'')*'"
+JSON_TERM = r"\bjson_(extract|type)\s*\(\s*\"?(\w+)\"?\s*,\s*'((?:[^']|'')*)'\s*\)"
+JSON_REQUIREMENT = re.compile(JSON_TERM + EQUALITY + rf"({SQL_STRING}|-?[0-9]+(?:\.[0-9]+)?)", re.IGNORECASE)
+SQL_OPAQUE = re.compile(
+    SQL_STRING + r'|"(?:[^"]|"")*"|`(?:[^`]|``)*`|\[[^\]]*\]|--[^\n]*|/\*[\s\S]*?(?:\*/|$)'
+)
 
 # Every name SQLite's `json_type` can return, against the emptiest document member of that
 # type. A `json_type` clause states the type where the `json_extract` form states the
@@ -830,8 +831,8 @@ EQUALITY = r'\s*(?:==|=(?!=)|\bis\b(?!\s+not\b))\s*'
 # whether the result is admissible either way.
 JSON_TYPE_MEMBERS: dict[str, object] = {
     "null": None,
-    "true": 1,
-    "false": 0,
+    "true": "true",
+    "false": "false",
     "integer": 0,
     "real": 0.0,
     "text": "",
@@ -872,9 +873,32 @@ def is_strict_table(connection: sqlite3.Connection, table: str) -> bool:
     return any(row[5] for row in connection.execute(f'pragma main.table_list("{quoted}")'))
 
 
+def sql_projection(expression: str, *, literals: bool = False) -> str:
+    """An offset-preserving code view for the seeder's bounded expression grammar."""
+    def project(match: re.Match) -> str:
+        token = match.group()
+        if token.startswith("'") and literals:
+            return token
+        if token[0] in '\"`[':
+            identifier = token[1:-1]
+            if re.fullmatch(r"\w+", identifier):
+                return identifier.ljust(len(token))
+        return " " * len(token)
+    return SQL_OPAQUE.sub(project, expression)
+
+
+def sql_matches(pattern: str | re.Pattern, expression: str) -> Iterable[re.Match]:
+    """Allow literal operands without interpreting their contents as expressions."""
+    active = sql_projection(expression)
+    for match in re.finditer(pattern, sql_projection(expression, literals=True), 0 if isinstance(pattern, re.Pattern) else re.IGNORECASE):
+        if active[match.start():match.start() + 1].strip():
+            yield match
+
+
 def substring_requirements(expression: str) -> Iterable[tuple[str, str, str, str]]:
     """Normalize either operand order into (target, start, width, source)."""
     identifier = r'"?(\w+)"?'
+    expression = sql_projection(expression)
     yield from re.findall(SUBSTRING_TERM + EQUALITY + identifier, expression, re.IGNORECASE)
     for source, target, start, width in re.findall(identifier + EQUALITY + SUBSTRING_TERM, expression, re.IGNORECASE):
         yield target, start, width, source
@@ -908,15 +932,16 @@ def check_expression(ddl: str, name: str) -> str:
     """Constraint ``name``'s expression as ``ddl`` declares it, or ``''`` if it has none."""
     # SQLite stores the DDL as it was written, so the keywords are whatever case the
     # migration that created the table happened to use.
-    marker = re.search(rf'CONSTRAINT\s+"?{re.escape(name)}"?\s+CHECK\s*\(', ddl, re.IGNORECASE)
+    active = sql_projection(ddl)
+    marker = re.search(rf'CONSTRAINT\s+"?{re.escape(name)}"?\s+CHECK\s*\(', active, re.IGNORECASE)
     if marker is None:
         return ""
     depth = 1
     index = marker.end()
     for offset in range(index, len(ddl)):
-        if ddl[offset] == "(":
+        if active[offset] == "(":
             depth += 1
-        elif ddl[offset] == ")":
+        elif active[offset] == ")":
             depth -= 1
             if depth == 0:
                 return ddl[index:offset]
@@ -951,16 +976,20 @@ def check_proposals(expression: str, columns: Iterable[str]) -> list[tuple[str, 
     """
     # Paths and member values already belong to semantic JSON proposals; offering
     # them to ordinary columns can overwrite an otherwise successful repair.
-    expression = JSON_REQUIREMENT.sub("", expression)
-    literals = re.findall(r"'([^']*)'", expression)
-    folded = identifier_key(expression)
+    parts = list(sql_projection(expression, literals=True))
+    for pattern in (JSON_REQUIREMENT, JSON_TERM):
+        for match in sql_matches(pattern, expression):
+            parts[match.start():match.end()] = " " * (match.end() - match.start())
+    expression = "".join(parts)
+    literals = [match.group()[1:-1].replace("''", "'") for match in re.finditer(SQL_STRING, expression)]
+    folded = identifier_key(sql_projection(expression))
     named = [column for column in columns if re.search(rf"\b{re.escape(identifier_key(column))}\b", folded)]
     return [(column, literal) for column in named for literal in literals]
 
 
 def json_proposals(
     connection: sqlite3.Connection, expression: str, columns: Iterable[str]
-) -> list[tuple[str, str]]:
+) -> list[tuple[str, object]]:
     """``(column, document)`` pairs satisfying every JSON-path clause ``expression`` states.
 
     The document is built by SQLite's own ``json_set`` rather than assembled here, so the
@@ -970,7 +999,9 @@ def json_proposals(
     """
     wanted = {identifier_key(column): column for column in columns}
     required: dict[str, list[tuple[str, str, object]]] = {}
-    for function, column, path, literal in JSON_REQUIREMENT.findall(expression):
+    for match in sql_matches(JSON_REQUIREMENT, expression):
+        function, column, path, literal = match.groups()
+        path = path.replace("''", "'")
         column = wanted.get(identifier_key(column))
         if column is None:
             continue
@@ -979,12 +1010,11 @@ def json_proposals(
             if named not in JSON_TYPE_MEMBERS:
                 continue
             member = JSON_TYPE_MEMBERS[named]
-            # A composite has to be spliced in as a document; anything else is a scalar and
-            # would be stored as one whatever `json_set` is handed.
-            term = "json(?)" if named in {"array", "object"} else "?"
+            # JSON composites and booleans need their JSON type, not SQL text/integers.
+            term = "json(?)" if named in {"array", "object", "true", "false"} else "?"
             required.setdefault(column, []).append((path, term, member))
         elif literal.startswith("'"):
-            required.setdefault(column, []).append((path, "?", literal[1:-1]))
+            required.setdefault(column, []).append((path, "?", literal[1:-1].replace("''", "'")))
         else:
             required.setdefault(column, []).append((path, "json(?)", str(Decimal(literal))))
 
@@ -996,6 +1026,17 @@ def json_proposals(
             document = f"json_set({document}, ?, {term})"
             parameters.extend([path, value])
         proposals.append((column, str(connection.execute(f"select {document}", parameters).fetchone()[0])))
+    documents = dict(proposals)
+    identifier = r'"?(\w+)"?\b'
+    dependencies = [match.groups() for match in sql_matches(JSON_TERM + EQUALITY + identifier, expression)]
+    dependencies.extend((function, source, path, target) for target, function, source, path in (
+        match.groups() for match in sql_matches(identifier + EQUALITY + JSON_TERM, expression)
+    ))
+    for function, source, path, target in dependencies:
+        source, target = wanted.get(identifier_key(source)), wanted.get(identifier_key(target))
+        if source in documents and target is not None:
+            value = connection.execute(f"select json_{function.lower()}(?, ?)", (documents[source], path.replace("''", "'"))).fetchone()[0]
+            proposals.append((target, value))
     return proposals
 
 
@@ -1127,27 +1168,27 @@ def shape_proposals(
     expressions still fail visibly; every proposed value must survive a real insert.
     """
     names = {identifier_key(name): name for name in values}
-    text = {name: value for name, value in values.items() if isinstance(value, str)}
+    text_eligible = {name for name, declared in required if not strict or declared.upper() in {"TEXT", "ANY"}}
+    text = {name: value for name, value in values.items() if name in text_eligible and isinstance(value, str)}
     widths = {}
     shapes = text_constraints if text_constraints is not None else expression
-    for name, width in re.findall(r'\blength\s*\(\s*"?(\w+)"?\s*\)\s*=\s*(\d+)', shapes, re.IGNORECASE):
+    for name, width in re.findall(r'\blength\s*\(\s*"?(\w+)"?\s*\)\s*=\s*(\d+)', sql_projection(shapes), re.IGNORECASE):
         name = names.get(identifier_key(name), name)
         size = bounded_integer(width, 0, SEED_TEXT_LIMIT)
-        if name in values and size is not None:
+        if name in text_eligible and size is not None:
             text.setdefault(name, "x")
             widths[name] = size
             text[name] = text[name][:size].ljust(size, "0")
-    globs = re.findall(
+    globs = (match.groups() for match in sql_matches(
         r"\b\"?(\w+)\"?\s+(not\s+)?glob\s*'((?:[^']|'')*)'",
         shapes,
-        re.IGNORECASE,
-    )
+    ))
     positive: dict[str, list[str]] = defaultdict(list)
     negative: dict[str, list[str]] = defaultdict(list)
     alphabets: dict[str, str] = defaultdict(lambda: string.printable)
     for name, negated, quoted in globs:
         name = names.get(identifier_key(name), name)
-        if name in values:
+        if name in text_eligible:
             text.setdefault(name, "x")
             pattern = quoted.replace("''", "'")
             alphabets[name] += pattern
@@ -1166,23 +1207,28 @@ def shape_proposals(
         name, other = names.get(identifier_key(name), name), names.get(identifier_key(other), other)
         position = bounded_integer(start, 1, SEED_TEXT_LIMIT)
         size = bounded_integer(width, 0, SEED_TEXT_LIMIT)
-        if name in values and isinstance(text.get(other, values.get(other)), str) and position is not None and size is not None:
+        if name in text_eligible and isinstance(text.get(other, values.get(other)), str) and position is not None and size is not None:
             text.setdefault(name, "x")
             offset = position - 1
             source = text.get(other, str(values[other]))
             if len(source) == size:
                 text[name] = text[name][:offset].ljust(offset, "0") + source + text[name][offset + size :]
     proposals: list[tuple[str, object]] = [(name, value) for name, value in text.items() if value != values[name]]
+    active = sql_projection(expression)
+    numeric_text = active + " " + " ".join(
+        match.group()[1:-1] for match in re.finditer(SQL_STRING, sql_projection(expression, literals=True))
+        if re.fullmatch(r"-?[0-9]+", match.group()[1:-1])
+    )
     bounds = {
         bound
-        for token in re.findall(r"(?<![\w.])-?[0-9]+(?![\w.])", expression)
+        for token in re.findall(r"(?<![\w.])-?[0-9]+(?![\w.])", numeric_text)
         if (bound := bounded_integer(token, SQLITE_INT_MIN, SQLITE_INT_MAX)) is not None
     }
     numeric = [
         name for name, declared in required
         if (sqlite_affinity(declared, strict=strict) in {"INTEGER", "REAL", "NUMERIC"}
             or (strict and declared.upper() == "ANY"))
-        and re.search(rf"\b{re.escape(identifier_key(name))}\b", identifier_key(expression))
+        and re.search(rf"\b{re.escape(identifier_key(name))}\b", identifier_key(active))
     ]
     candidates = list(dict.fromkeys(
         value for bound in sorted(bounds) for value in (bound, bound + 1, bound - 1)
@@ -1191,7 +1237,10 @@ def shape_proposals(
     fallback = [
         (name, candidate) for candidate in candidates for name in numeric if candidate != values[name]
     ]
-    if any(re.search(rf"\b{re.escape(identifier_key(name))}\b", identifier_key(expression)) for name in unavailable):
+    omitted, unavailable = tuple(omitted), tuple(unavailable)
+    declared_names = {identifier_key(name) for name, _ in required} | {identifier_key(name) for name, _, _ in omitted} | {identifier_key(name) for name in unavailable}
+    implicit = {"rowid", "_rowid_", "oid"} - declared_names
+    if any(re.search(rf"\b{re.escape(identifier_key(name))}\b", identifier_key(active)) for name in (*unavailable, *implicit)):
         return ShapeProposals(proposals, fallback)
     if not numeric or not candidates:
         return ShapeProposals(proposals, [])
@@ -1207,7 +1256,6 @@ def shape_proposals(
     def declaration(name: str, declared: str) -> str:
         return quote(name) + (f' {quote(declared)}' if declared else '')
 
-    omitted = tuple(omitted)
     declarations = [declaration(name, declared) for name, declared in required]
     declarations.extend(
         declaration(name, declared) + (f' default ({default})' if default is not None else '')
@@ -1273,6 +1321,13 @@ def numeric_assignments(
 
     seen = {ranked}
     yield ranked
+    local = sparse(current)
+    # Every candidate-bearing column gets its initial sparse opportunity before
+    # family mixing can dilute it. Larger domains still obey the same total cap.
+    for assignment in itertools.islice(local, len(domains)):
+        if assignment not in seen:
+            seen.add(assignment)
+            yield assignment
     uniform = [tuple(candidate for _ in domains) for candidate in candidates]
 
     def interleave(*families):
@@ -1285,7 +1340,7 @@ def numeric_assignments(
     products = itertools.product(*domains)
     # Cartesian search gets two direct turns; local and anchor repairs get one
     # each. Nesting Cartesian behind anchors would dilute its finite budget.
-    for assignment in interleave(sparse(current), products, products, anchors):
+    for assignment in interleave(local, products, products, anchors):
         if assignment not in seen:
             seen.add(assignment)
             yield assignment
@@ -1299,9 +1354,11 @@ def numeric_domains(
     literal = r"(-?[0-9]+)(?![\w.])"
     operator = r"\s*(==|!=|<>|<=|>=|=|<|>)\s*"
     predicates: dict[str, list[tuple[str, int]]] = defaultdict(list)
-    clauses = re.findall(identifier + operator + literal, expression)
+    clauses = [match.groups() for match in sql_matches(identifier + operator + literal, expression)]
     reverse = {"<": ">", ">": "<", "<=": ">=", ">=": "<=", "=": "=", "==": "==", "!=": "!=", "<>": "<>"}
-    clauses.extend((name, reverse[op], token) for token, op, name in re.findall(literal + operator + identifier, expression))
+    clauses.extend((name, reverse[op], token) for token, op, name in (
+        match.groups() for match in sql_matches(literal + operator + identifier, expression)
+    ))
     for name, op, token in clauses:
         if (bound := bounded_integer(token, SQLITE_INT_MIN, SQLITE_INT_MAX)) is not None:
             predicates[identifier_key(name)].append((op, bound))
@@ -1598,7 +1655,7 @@ def insert_seed_row(
     # together so declaration order does not decide whether a prefix can be offered.
     constraints = [
         check_expression(ddl, name)
-        for name in re.findall(r'\bconstraint\s+"?(\w+)"?\s+check\s*\(', ddl, re.IGNORECASE)
+        for name in re.findall(r'\bconstraint\s+"?(\w+)"?\s+check\s*\(', sql_projection(ddl), re.IGNORECASE)
     ]
     text_constraints = "\n".join(constraints)
     omitted = []

--- a/scripts/migration_release_guard.py
+++ b/scripts/migration_release_guard.py
@@ -795,7 +795,7 @@ def describe_schema_gap(db_path: Path) -> str:
 # SQLite names the one constraint an insert tripped, which is what makes the repair below
 # a guided search rather than a guess: the database says what it objected to, and the
 # objection itself carries the values it would have accepted.
-CHECK_FAILURE = re.compile(r"CHECK constraint failed: (\w+)")
+CHECK_FAILURE = re.compile(r"CHECK constraint failed: (.+)", re.DOTALL)
 
 # Enough attempts to satisfy every constraint a row trips one at a time, and few enough
 # that a table whose constraints cannot be satisfied this way is given up on rather than
@@ -816,13 +816,15 @@ JSON_VARIED_MEMBER = "__seed_step__"
 # `json_type(col,'$.p') = 'array'` both name the column, the path, and what belongs at it,
 # which is the same three things the plain literal form carries -- so both are read the
 # same way rather than treated as unseedable.
-SUBSTRING_TERM = r'\bsubstr\s*\(\s*"?(\w+)"?\s*,\s*(\d+)\s*,\s*(\d+)\s*\)'
+SQL_QUOTED_IDENTIFIER = r'"(?:[^"]|"")*"|`(?:[^`]|``)*`|\[[^\]]*\]'
+SQL_IDENTIFIER = rf'(?:{SQL_QUOTED_IDENTIFIER}|(?<![\w$])[^\W\d][\w$]*)'
+SUBSTRING_TERM = rf'\bsubstr\s*\(\s*({SQL_IDENTIFIER})\s*,\s*(\d+)\s*,\s*(\d+)\s*\)'
 EQUALITY = r'\s*(?:==|=(?!=)|\bis\b(?!\s+not\b))\s*'
 SQL_STRING = r"'(?:[^']|'')*'"
-JSON_TERM = r"\bjson_(extract|type)\s*\(\s*\"?(\w+)\"?\s*,\s*'((?:[^']|'')*)'\s*\)"
+JSON_TERM = rf"\bjson_(extract|type)\s*\(\s*({SQL_IDENTIFIER})\s*,\s*'((?:[^']|'')*)'\s*\)"
 JSON_REQUIREMENT = re.compile(JSON_TERM + EQUALITY + rf"({SQL_STRING}|-?[0-9]+(?:\.[0-9]+)?)", re.IGNORECASE)
 SQL_OPAQUE = re.compile(
-    SQL_STRING + r'|"(?:[^"]|"")*"|`(?:[^`]|``)*`|\[[^\]]*\]|--[^\n]*|/\*[\s\S]*?(?:\*/|$)'
+    SQL_STRING + '|' + SQL_QUOTED_IDENTIFIER + r'|--[^\n]*|/\*[\s\S]*?(?:\*/|$)'
 )
 
 # Every name SQLite's `json_type` can return, against the emptiest document member of that
@@ -869,39 +871,67 @@ def sqlite_affinity(declared_type: str, *, strict: bool = False) -> str:
 
 
 def is_strict_table(connection: sqlite3.Connection, table: str) -> bool:
-    quoted = table.replace('"', '""')
-    return any(row[5] for row in connection.execute(f'pragma main.table_list("{quoted}")'))
+    return any(row[5] for row in connection.execute(f'pragma main.table_list({quote_identifier(table)})'))
 
 
-def sql_projection(expression: str, *, literals: bool = False) -> str:
+def sql_projection(expression: str, *, literals: bool = False, identifiers: bool = False) -> str:
     """An offset-preserving code view for the seeder's bounded expression grammar."""
     def project(match: re.Match) -> str:
         token = match.group()
         if token.startswith("'") and literals:
             return token
-        if token[0] in '\"`[':
-            identifier = token[1:-1]
-            if re.fullmatch(r"\w+", identifier):
-                return identifier.ljust(len(token))
+        if identifiers and token[0] in '\"`[':
+            return token
         return " " * len(token)
     return SQL_OPAQUE.sub(project, expression)
 
 
 def sql_matches(pattern: str | re.Pattern, expression: str) -> Iterable[re.Match]:
     """Allow literal operands without interpreting their contents as expressions."""
-    active = sql_projection(expression)
-    for match in re.finditer(pattern, sql_projection(expression, literals=True), 0 if isinstance(pattern, re.Pattern) else re.IGNORECASE):
-        if active[match.start():match.start() + 1].strip():
+    active = sql_projection(expression, identifiers=True)
+    opaque = [(token.start(), token.end()) for token in SQL_OPAQUE.finditer(expression)]
+    searchable = sql_projection(expression, literals=True, identifiers=True)
+    compiled = re.compile(pattern, 0 if isinstance(pattern, re.Pattern) else re.IGNORECASE)
+    position = 0
+    while match := compiled.search(searchable, position):
+        enclosing = next(((start, end) for start, end in opaque if start <= match.start() < end), None)
+        if enclosing and (match.start() > enclosing[0] or not active[match.start()].strip()):
+            # An invalid cross-token match must not consume the following real operand.
+            position = enclosing[1]
+            continue
+        # An identifier can be an operand, but no match can start/end inside its payload.
+        if any(start < match.end() < end for start, end in opaque):
+            position = match.start() + 1
+        else:
             yield match
+            position = max(match.end(), match.start() + 1)
+
+
+def unquote_identifier(token: str) -> str:
+    if token.startswith('['):
+        return token[1:-1]
+    if token.startswith(('"', '`')):
+        return token[1:-1].replace(token[0] * 2, token[0])
+    return token
+
+
+def quote_identifier(name: str) -> str:
+    return '"' + name.replace('"', '""') + '"'
+
+
+def sql_identifiers(expression: str) -> set[str]:
+    return {identifier_key(unquote_identifier(match.group())) for match in sql_matches(SQL_IDENTIFIER, expression)}
 
 
 def substring_requirements(expression: str) -> Iterable[tuple[str, str, str, str]]:
     """Normalize either operand order into (target, start, width, source)."""
-    identifier = r'"?(\w+)"?'
-    expression = sql_projection(expression)
-    yield from re.findall(SUBSTRING_TERM + EQUALITY + identifier, expression, re.IGNORECASE)
-    for source, target, start, width in re.findall(identifier + EQUALITY + SUBSTRING_TERM, expression, re.IGNORECASE):
-        yield target, start, width, source
+    identifier = f'({SQL_IDENTIFIER})'
+    for match in sql_matches(SUBSTRING_TERM + EQUALITY + identifier, expression):
+        target, start, width, source = match.groups()
+        yield unquote_identifier(target), start, width, unquote_identifier(source)
+    for match in sql_matches(identifier + EQUALITY + SUBSTRING_TERM, expression):
+        source, target, start, width = match.groups()
+        yield unquote_identifier(target), start, width, unquote_identifier(source)
 
 
 def representative_value(column: str, declared_type: str, *, strict: bool = False) -> object:
@@ -914,10 +944,12 @@ def representative_value(column: str, declared_type: str, *, strict: bool = Fals
     migration that parses a timestamp, an address, or a JSON document gets something
     parseable rather than ``'x'``.
     """
-    kind = sqlite_affinity(declared_type, strict=strict)
-    if kind in {"INTEGER", "REAL", "NUMERIC"}:
+    # Affinity governs storage/evaluation, not the established representative family:
+    # flexible DATE/DECIMAL/ANY declarations still admit semantic text seeds.
+    kind = declared_type.upper()
+    if any(marker in kind for marker in ("INT", "REAL", "NUM", "DOUB", "FLOA", "BOOL")):
         return 0
-    if kind == "BLOB" and declared_type and not (strict and declared_type.upper() == "ANY"):
+    if "BLOB" in kind:
         return b""
     if column.endswith(("_at", "_time")):
         return "1970-01-01T00:00:00+00:00"
@@ -933,7 +965,8 @@ def check_expression(ddl: str, name: str) -> str:
     # SQLite stores the DDL as it was written, so the keywords are whatever case the
     # migration that created the table happened to use.
     active = sql_projection(ddl)
-    marker = re.search(rf'CONSTRAINT\s+"?{re.escape(name)}"?\s+CHECK\s*\(', active, re.IGNORECASE)
+    marker = next((match for match in sql_matches(rf'\bCONSTRAINT\s+({SQL_IDENTIFIER})\s+CHECK\s*\(', ddl)
+                   if identifier_key(unquote_identifier(match.group(1))) == identifier_key(name)), None)
     if marker is None:
         return ""
     depth = 1
@@ -976,14 +1009,14 @@ def check_proposals(expression: str, columns: Iterable[str]) -> list[tuple[str, 
     """
     # Paths and member values already belong to semantic JSON proposals; offering
     # them to ordinary columns can overwrite an otherwise successful repair.
-    parts = list(sql_projection(expression, literals=True))
+    parts = list(sql_projection(expression, literals=True, identifiers=True))
     for pattern in (JSON_REQUIREMENT, JSON_TERM):
         for match in sql_matches(pattern, expression):
             parts[match.start():match.end()] = " " * (match.end() - match.start())
     expression = "".join(parts)
-    literals = [match.group()[1:-1].replace("''", "'") for match in re.finditer(SQL_STRING, expression)]
-    folded = identifier_key(sql_projection(expression))
-    named = [column for column in columns if re.search(rf"\b{re.escape(identifier_key(column))}\b", folded)]
+    literals = [match.group()[1:-1].replace("''", "'") for match in SQL_OPAQUE.finditer(expression) if match.group().startswith("'")]
+    mentioned = sql_identifiers(expression)
+    named = [column for column in columns if identifier_key(column) in mentioned]
     return [(column, literal) for column in named for literal in literals]
 
 
@@ -1002,7 +1035,7 @@ def json_proposals(
     for match in sql_matches(JSON_REQUIREMENT, expression):
         function, column, path, literal = match.groups()
         path = path.replace("''", "'")
-        column = wanted.get(identifier_key(column))
+        column = wanted.get(identifier_key(unquote_identifier(column)))
         if column is None:
             continue
         if function.lower() == "type":
@@ -1027,13 +1060,13 @@ def json_proposals(
             parameters.extend([path, value])
         proposals.append((column, str(connection.execute(f"select {document}", parameters).fetchone()[0])))
     documents = dict(proposals)
-    identifier = r'"?(\w+)"?\b'
+    identifier = f'({SQL_IDENTIFIER})'
     dependencies = [match.groups() for match in sql_matches(JSON_TERM + EQUALITY + identifier, expression)]
     dependencies.extend((function, source, path, target) for target, function, source, path in (
         match.groups() for match in sql_matches(identifier + EQUALITY + JSON_TERM, expression)
     ))
     for function, source, path, target in dependencies:
-        source, target = wanted.get(identifier_key(source)), wanted.get(identifier_key(target))
+        source, target = wanted.get(identifier_key(unquote_identifier(source))), wanted.get(identifier_key(unquote_identifier(target)))
         if source in documents and target is not None:
             value = connection.execute(f"select json_{function.lower()}(?, ?)", (documents[source], path.replace("''", "'"))).fetchone()[0]
             proposals.append((target, value))
@@ -1172,22 +1205,23 @@ def shape_proposals(
     text = {name: value for name, value in values.items() if name in text_eligible and isinstance(value, str)}
     widths = {}
     shapes = text_constraints if text_constraints is not None else expression
-    for name, width in re.findall(r'\blength\s*\(\s*"?(\w+)"?\s*\)\s*=\s*(\d+)', sql_projection(shapes), re.IGNORECASE):
-        name = names.get(identifier_key(name), name)
+    for match in sql_matches(rf'\blength\s*\(\s*({SQL_IDENTIFIER})\s*\)\s*=\s*(\d+)', shapes):
+        name, width = match.groups()
+        name = names.get(identifier_key(unquote_identifier(name)), name)
         size = bounded_integer(width, 0, SEED_TEXT_LIMIT)
         if name in text_eligible and size is not None:
             text.setdefault(name, "x")
             widths[name] = size
             text[name] = text[name][:size].ljust(size, "0")
     globs = (match.groups() for match in sql_matches(
-        r"\b\"?(\w+)\"?\s+(not\s+)?glob\s*'((?:[^']|'')*)'",
+        rf"({SQL_IDENTIFIER})\s+(not\s+)?glob\s*'((?:[^']|'')*)'",
         shapes,
     ))
     positive: dict[str, list[str]] = defaultdict(list)
     negative: dict[str, list[str]] = defaultdict(list)
     alphabets: dict[str, str] = defaultdict(lambda: string.printable)
     for name, negated, quoted in globs:
-        name = names.get(identifier_key(name), name)
+        name = names.get(identifier_key(unquote_identifier(name)), name)
         if name in text_eligible:
             text.setdefault(name, "x")
             pattern = quoted.replace("''", "'")
@@ -1215,6 +1249,7 @@ def shape_proposals(
                 text[name] = text[name][:offset].ljust(offset, "0") + source + text[name][offset + size :]
     proposals: list[tuple[str, object]] = [(name, value) for name, value in text.items() if value != values[name]]
     active = sql_projection(expression)
+    mentioned = sql_identifiers(expression)
     numeric_text = active + " " + " ".join(
         match.group()[1:-1] for match in re.finditer(SQL_STRING, sql_projection(expression, literals=True))
         if re.fullmatch(r"-?[0-9]+", match.group()[1:-1])
@@ -1228,7 +1263,7 @@ def shape_proposals(
         name for name, declared in required
         if (sqlite_affinity(declared, strict=strict) in {"INTEGER", "REAL", "NUMERIC"}
             or (strict and declared.upper() == "ANY"))
-        and re.search(rf"\b{re.escape(identifier_key(name))}\b", identifier_key(active))
+        and identifier_key(name) in mentioned
     ]
     candidates = list(dict.fromkeys(
         value for bound in sorted(bounds) for value in (bound, bound + 1, bound - 1)
@@ -1240,7 +1275,7 @@ def shape_proposals(
     omitted, unavailable = tuple(omitted), tuple(unavailable)
     declared_names = {identifier_key(name) for name, _ in required} | {identifier_key(name) for name, _, _ in omitted} | {identifier_key(name) for name in unavailable}
     implicit = {"rowid", "_rowid_", "oid"} - declared_names
-    if any(re.search(rf"\b{re.escape(identifier_key(name))}\b", identifier_key(active)) for name in (*unavailable, *implicit)):
+    if any(identifier_key(name) in mentioned for name in (*unavailable, *implicit)):
         return ShapeProposals(proposals, fallback)
     if not numeric or not candidates:
         return ShapeProposals(proposals, [])
@@ -1250,18 +1285,15 @@ def shape_proposals(
     # the fixture connection's changes()/last_insert_rowid()/total_changes().
     evaluation = sqlite3.connect(":memory:")
     table = '"seed_candidate"'
-    def quote(name: str) -> str:
-        return '"' + name.replace('"', '""') + '"'
-
     def declaration(name: str, declared: str) -> str:
-        return quote(name) + (f' {quote(declared)}' if declared else '')
+        return quote_identifier(name) + (f' {quote_identifier(declared)}' if declared else '')
 
     declarations = [declaration(name, declared) for name, declared in required]
     declarations.extend(
         declaration(name, declared) + (f' default ({default})' if default is not None else '')
         for name, declared, default in omitted
     )
-    columns = ', '.join(quote(name) for name, _ in required)
+    columns = ', '.join(quote_identifier(name) for name, _ in required)
     placeholders = ', '.join('?' for _ in required)
     try:
         contextual = {
@@ -1350,7 +1382,7 @@ def numeric_domains(
     expression: str, numeric: list[str], values: dict[str, object], candidates: list[int]
 ) -> list[list[object]]:
     """Rank finite domains by local predicates; the complete CHECK still decides."""
-    identifier = r'"?(\w+)"?'
+    identifier = f'({SQL_IDENTIFIER})'
     literal = r"(-?[0-9]+)(?![\w.])"
     operator = r"\s*(==|!=|<>|<=|>=|=|<|>)\s*"
     predicates: dict[str, list[tuple[str, int]]] = defaultdict(list)
@@ -1361,7 +1393,7 @@ def numeric_domains(
     ))
     for name, op, token in clauses:
         if (bound := bounded_integer(token, SQLITE_INT_MIN, SQLITE_INT_MAX)) is not None:
-            predicates[identifier_key(name)].append((op, bound))
+            predicates[identifier_key(unquote_identifier(name))].append((op, bound))
 
     def score(name: str, value: object) -> int:
         if not isinstance(value, (int, float)):
@@ -1426,7 +1458,7 @@ def resolve_references(connection: sqlite3.Connection, table: str) -> None:
     ``seeded_rows_prove_repetition`` reads back.
     """
     groups: dict[int, list[tuple[str, str, str | None]]] = {}
-    for row in connection.execute(f'pragma foreign_key_list("{table}")'):
+    for row in connection.execute(f'pragma foreign_key_list({quote_identifier(table)})'):
         groups.setdefault(int(row[0]), []).append((str(row[2]), str(row[3]), row[4] and str(row[4])))
     for members in groups.values():
         parent = members[0][0]
@@ -1436,33 +1468,33 @@ def resolve_references(connection: sqlite3.Connection, table: str) -> None:
             keys = [
                 str(column[1])
                 for column in sorted(
-                    (row for row in connection.execute(f'pragma table_info("{parent}")') if row[5]),
+                    (row for row in connection.execute(f'pragma table_info({quote_identifier(parent)})') if row[5]),
                     key=lambda row: row[5],
                 )
             ]
-        selected = ", ".join('"{}"'.format(key) for key in keys)
-        held = connection.execute(f'select distinct {selected} from "{parent}"').fetchall()
+        selected = ", ".join(quote_identifier(key) for key in keys)
+        held = connection.execute(f'select distinct {selected} from {quote_identifier(parent)}').fetchall()
         if not held:
             continue
-        assignments = ", ".join(f'"{name}" = ?' for _, name, _ in members)
+        assignments = ", ".join(f'{quote_identifier(name)} = ?' for _, name, _ in members)
         try:
-            connection.execute(f'update "{table}" set {assignments}', list(held[0]))
+            connection.execute(f'update {quote_identifier(table)} set {assignments}', list(held[0]))
             continue
         except sqlite3.Error:
             pass
         nullable = {
             str(row[1]): not (row[3] or row[5])
-            for row in connection.execute(f'pragma table_info("{table}")')
+            for row in connection.execute(f'pragma table_info({quote_identifier(table)})')
         }
-        blanked = ", ".join(f'"{name}" = null' for _, name, _ in members)
-        rows = [row[0] for row in connection.execute(f'select rowid from "{table}"')]
+        blanked = ", ".join(f'{quote_identifier(name)} = null' for _, name, _ in members)
+        rows = [row[0] for row in connection.execute(f'select rowid from {quote_identifier(table)}')]
         for index, rowid in enumerate(rows):
             # Offsets so two rows start from different parents; the whole rotation because a
             # row already holding a later parent's value is in the way of the earlier one.
             for offset in range(len(held)):
                 try:
                     connection.execute(
-                        f'update "{table}" set {assignments} where rowid = ?',
+                        f'update {quote_identifier(table)} set {assignments} where rowid = ?',
                         [*held[(index + offset) % len(held)], rowid],
                     )
                     break
@@ -1476,11 +1508,11 @@ def resolve_references(connection: sqlite3.Connection, table: str) -> None:
                 remove = not all(nullable[name] for _, name, _ in members)
                 if not remove:
                     try:
-                        connection.execute(f'update "{table}" set {blanked} where rowid = ?', [rowid])
+                        connection.execute(f'update {quote_identifier(table)} set {blanked} where rowid = ?', [rowid])
                     except sqlite3.Error:
                         remove = True
                 if remove:
-                    connection.execute(f'delete from "{table}" where rowid = ?', [rowid])
+                    connection.execute(f'delete from {quote_identifier(table)} where rowid = ?', [rowid])
 
 
 def dangling_references(connection: sqlite3.Connection) -> str:
@@ -1517,8 +1549,8 @@ def seeded_rows_prove_repetition(
     """
     for column in repeated:
         shared = connection.execute(
-            f'select count(*) from (select "{column}" from "{table}" '
-            f'where "{column}" is not null group by "{column}" having count(*) > 1)'
+            f'select count(*) from (select {quote_identifier(column)} from {quote_identifier(table)} '
+            f'where {quote_identifier(column)} is not null group by {quote_identifier(column)} having count(*) > 1)'
         ).fetchone()[0]
         if not shared:
             return f"no two rows share a {column}, though a row repeating it was accepted"
@@ -1598,8 +1630,8 @@ def restore_repeat(
     granted in isolation.
     """
     names = [name for name, _ in offered]
-    selected = ", ".join(f'"{name}"' for name in names)
-    survivor = connection.execute(f'select {selected} from "{table}" limit 1').fetchone()
+    selected = ", ".join(quote_identifier(name) for name in names)
+    survivor = connection.execute(f'select {selected} from {quote_identifier(table)} limit 1').fetchone()
     if survivor is None:
         return "no row is left to copy a reference from", True
     row = {
@@ -1611,7 +1643,7 @@ def restore_repeat(
         return objection, settled
     optional = {
         str(info[1])
-        for info in connection.execute(f'pragma table_info("{table}")')
+        for info in connection.execute(f'pragma table_info({quote_identifier(table)})')
         if not (info[3] or info[5]) and str(info[1]) in references
     }
     emptied = {name: None if name in optional else value for name, value in row.items()}
@@ -1642,25 +1674,25 @@ def insert_seed_row(
     """
     if not required:
         try:
-            connection.execute(f'insert into "{table}" default values')
+            connection.execute(f'insert into {quote_identifier(table)} default values')
         except sqlite3.Error as exc:
             return str(exc), True
         return "", True
 
-    columns = ", ".join(f'"{column}"' for column, _ in required)
+    columns = ", ".join(quote_identifier(column) for column, _ in required)
     placeholders = ", ".join("?" for _ in required)
-    statement = f'insert into "{table}" ({columns}) values ({placeholders})'
+    statement = f'insert into {quote_identifier(table)} ({columns}) values ({placeholders})'
     names = [column for column, _ in required]
     # Related columns may be constrained by a later CHECK. Derive their text shapes
     # together so declaration order does not decide whether a prefix can be offered.
     constraints = [
-        check_expression(ddl, name)
-        for name in re.findall(r'\bconstraint\s+"?(\w+)"?\s+check\s*\(', sql_projection(ddl), re.IGNORECASE)
+        check_expression(ddl, unquote_identifier(match.group(1)))
+        for match in sql_matches(rf'\bconstraint\s+({SQL_IDENTIFIER})\s+check\s*\(', ddl)
     ]
     text_constraints = "\n".join(constraints)
     omitted = []
     unavailable = []
-    for info in connection.execute(f'pragma table_xinfo("{table}")'):
+    for info in connection.execute(f'pragma table_xinfo({quote_identifier(table)})'):
         if str(info[1]) in values:
             continue
         if info[6] or (info[5] and str(info[2]).upper() == "INTEGER" and info[4] is None):
@@ -1809,7 +1841,7 @@ def seed_representative_rows(db_path: Path) -> tuple[dict[str, str], dict[str, s
         for table, ddl in schema:
             info = [
                 (str(row[1]), str(row[2]), bool(row[3] or row[5]))
-                for row in connection.execute(f'pragma table_info("{table}")')
+                for row in connection.execute(f'pragma table_info({quote_identifier(table)})')
             ]
             every = [(column, declared) for column, declared, _ in info]
             mandatory = [(column, declared) for column, declared, required in info if required]
@@ -1884,7 +1916,7 @@ def seed_representative_rows(db_path: Path) -> tuple[dict[str, str], dict[str, s
             # columns together with a third, so sharing both at once is refused while sharing
             # either alone is fine. What the fixture claims for a reference is that it resolves,
             # and ``dangling_references`` is where that claim is read back.
-            references = {str(row[3]) for row in connection.execute(f'pragma foreign_key_list("{table}")')}
+            references = {str(row[3]) for row in connection.execute(f'pragma foreign_key_list({quote_identifier(table)})')}
             claimed = []
             for column in [name for name in repeated if name not in references]:
                 if not seeded_rows_prove_repetition(connection, table, [column]):
@@ -1903,7 +1935,7 @@ def seed_representative_rows(db_path: Path) -> tuple[dict[str, str], dict[str, s
                 else:
                     claimed.append(column)
             repeated = claimed
-            rows = connection.execute(f'select count(*) from "{table}"').fetchone()[0]
+            rows = connection.execute(f'select count(*) from {quote_identifier(table)}').fetchone()[0]
             if rows < SEED_ROWS:
                 short[table] = f"{rows} of {SEED_ROWS} rows; {objection or 'the schema accepted no more'}"
                 continue

--- a/scripts/migration_release_guard.py
+++ b/scripts/migration_release_guard.py
@@ -924,10 +924,10 @@ def sql_identifiers(expression: str) -> set[str]:
     return {identifier_key(unquote_identifier(match.group())) for match in sql_matches(SQL_IDENTIFIER, expression)}
 
 
-def substring_requirements(expression: str) -> Iterable[tuple[str, str, str, str]]:
+def substring_requirements(expression: str, columns: Iterable[str] = ()) -> Iterable[tuple[str, str, str, str]]:
     """Normalize required whole equalities into (target, start, width, source)."""
     identifier = f'({SQL_IDENTIFIER})'
-    for term in conjunctive_terms(expression):
+    for term in conjunctive_terms(expression, columns):
         active = sql_projection(term, identifiers=True)
         for reverse in (False, True):
             operands = (identifier, SUBSTRING_TERM) if reverse else (SUBSTRING_TERM, identifier)
@@ -1001,7 +1001,9 @@ def bounded_integer(literal: str, lower: int, upper: int) -> int | None:
     return value if lower <= value <= upper else None
 
 
-def check_proposals(expression: str, columns: Iterable[str]) -> list[tuple[str, str]]:
+def check_proposals(
+    expression: str, columns: Iterable[str], *, context_columns: Iterable[str] = (),
+) -> list[tuple[str, str]]:
     """``(column, value)`` pairs ``expression`` itself suggests, for the columns it names.
 
     A check the row tripped is a check that says what it wants: ``state in ('waiting',
@@ -1015,6 +1017,7 @@ def check_proposals(expression: str, columns: Iterable[str]) -> list[tuple[str, 
     """
     # Semantic operands already belong to their shape/JSON owners; offering them
     # to ordinary columns can overwrite an otherwise successful repair.
+    columns = tuple(columns)
     parts = list(sql_projection(expression, literals=True, identifiers=True))
     for pattern in (JSON_REQUIREMENT, JSON_TERM, GLOB_REQUIREMENT):
         for match in sql_matches(pattern, expression):
@@ -1025,7 +1028,7 @@ def check_proposals(expression: str, columns: Iterable[str]) -> list[tuple[str, 
     named = [column for column in columns if identifier_key(column) in mentioned]
     names = {identifier_key(column): column for column in named}
     preferred = []
-    for term in conjunctive_terms(expression):
+    for term in conjunctive_terms(expression, (*columns, *context_columns)):
         for reverse in (False, True):
             operands = (SQL_STRING, SQL_IDENTIFIER) if reverse else (SQL_IDENTIFIER, SQL_STRING)
             match = re.fullmatch(rf'\s*({operands[0]}){EQUALITY}({operands[1]})\s*', term, re.IGNORECASE)
@@ -1038,10 +1041,14 @@ def check_proposals(expression: str, columns: Iterable[str]) -> list[tuple[str, 
     return list(dict.fromkeys([*preferred, *((column, literal) for column in named for literal in literals)]))
 
 
+SeedAssignment = tuple[tuple[str, object], ...]
+
+
 def json_proposals(
-    connection: sqlite3.Connection, expression: str, columns: Iterable[str]
-) -> list[tuple[str, object]]:
-    """``(column, document)`` candidates suggested by JSON-path clauses.
+    connection: sqlite3.Connection, expression: str, columns: Iterable[str],
+    *, text_constraints: str | None = None, context_columns: Iterable[str] = (),
+) -> list[SeedAssignment]:
+    """Whole assignments retaining the documents behind JSON member candidates.
 
     The document is built by SQLite's own ``json_set`` rather than assembled here, so the
     path syntax is whatever SQLite accepts and not a second reading of it. All clauses for
@@ -1050,8 +1057,9 @@ def json_proposals(
     alternative: SQLite can accept NULL comparisons without requiring a member.
     """
     wanted = {identifier_key(column): column for column in columns}
+    shapes = text_constraints if text_constraints is not None else expression
     required: dict[str, list[tuple[str, str, object]]] = {}
-    for match in sql_matches(JSON_REQUIREMENT, expression):
+    for match in sql_matches(JSON_REQUIREMENT, shapes):
         function, column, path, literal = match.groups()
         path = path.replace("''", "'")
         column = wanted.get(identifier_key(unquote_identifier(column)))
@@ -1070,29 +1078,56 @@ def json_proposals(
         else:
             required.setdefault(column, []).append((path, "json(?)", str(Decimal(literal))))
 
-    proposals = []
+    documents = {}
     for column, clauses in required.items():
         document = "'{}'"
         parameters: list[object] = []
         for path, term, value in clauses:
             document = f"json_set({document}, ?, {term})"
             parameters.extend([path, value])
-        proposals.append((column, str(connection.execute(f"select {document}", parameters).fetchone()[0])))
-    documents = dict(proposals)
+        documents[column] = str(connection.execute(f"select {document}", parameters).fetchone()[0])
+    if not documents:
+        return []
+    preferred = dict(documents)
+    recipients = semantic_recipients(shapes, wanted.values(), context_columns=context_columns)
     identifier = f'({SQL_IDENTIFIER})'
-    dependencies = [match.groups() for match in sql_matches(JSON_TERM + EQUALITY + identifier, expression)]
-    dependencies.extend((function, source, path, target) for target, function, source, path in (
-        match.groups() for match in sql_matches(identifier + EQUALITY + JSON_TERM, expression)
-    ))
-    for function, source, path, target in dependencies:
-        source, target = wanted.get(identifier_key(unquote_identifier(source))), wanted.get(identifier_key(unquote_identifier(target)))
-        if source in documents and target is not None:
-            value = connection.execute(f"select json_{function.lower()}(?, ?)", (documents[source], path.replace("''", "'"))).fetchone()[0]
-            proposals.append((target, value))
+    alternatives = []
+    for term in conjunctive_terms(shapes, (*wanted.values(), *context_columns)):
+        active = sql_projection(term, literals=True, identifiers=True)
+        for reverse in (False, True):
+            operands = (identifier, JSON_TERM) if reverse else (JSON_TERM, identifier)
+            match = re.fullmatch(rf'\s*{operands[0]}{EQUALITY}{operands[1]}\s*', active, re.IGNORECASE)
+            if match is None:
+                continue
+            if reverse:
+                target, function, source, path = match.groups()
+            else:
+                function, source, path, target = match.groups()
+            source, target = wanted.get(identifier_key(unquote_identifier(source))), wanted.get(identifier_key(unquote_identifier(target)))
+            if source in documents and target is not None and target not in documents:
+                preferred[target] = connection.execute(
+                    f"select json_{function.lower()}(?, ?)", (documents[source], path.replace("''", "'"))
+                ).fetchone()[0]
+        # A functional operand is not an alias. Retain the native member as a
+        # guess for that term's dependents, always together with its document.
+        for match in sql_matches(JSON_TERM, term):
+            function, source, path = match.groups()
+            source = wanted.get(identifier_key(unquote_identifier(source)))
+            if source not in documents:
+                continue
+            targets = [name for name in wanted.values() if name in recipients[source] and name not in documents]
+            if not targets:
+                continue
+            value = connection.execute(
+                f"select json_{function.lower()}(?, ?)", (documents[source], path.replace("''", "'"))
+            ).fetchone()[0]
+            alternatives.append(tuple({**documents, **dict.fromkeys(targets, value)}.items()))
+            alternatives.extend(tuple({**documents, target: value}.items()) for target in targets)
+    proposals = [tuple(preferred.items()), tuple(documents.items()), *alternatives]
     # Keep populated members and their dependents first; omission is a fallback,
     # not permission to replace a document that already satisfies the CHECK.
-    proposals.extend((column, "{}") for column, document in documents.items() if document != "{}")
-    return proposals
+    proposals.extend(((column, "{}"),) for column, document in documents.items() if document != "{}")
+    return list(dict.fromkeys(proposals))
 
 
 def glob_witness(
@@ -1200,18 +1235,18 @@ def glob_witness(
     return None
 
 
-SeedAssignment = tuple[tuple[str, object], ...]
-
-
 @dataclass
 class ShapeProposals:
     derived: list[tuple[str, object]]
     numeric_fallback: list[SeedAssignment]
-    text_fallback: list[tuple[str, object]] = field(default_factory=list)
+    semantic_fallback: list[SeedAssignment] = field(default_factory=list)
 
 
-def conjunctive_terms(expression: str) -> Iterable[str]:
-    """Only descend through AND and grouping, never conditional boolean branches."""
+def conjunctive_terms(expression: str, columns: Iterable[str] = ()) -> Iterable[str]:
+    """Descend through required conjunctions and transparent truth wrappers."""
+    names = {identifier_key(name) for name in columns}
+    truth = r'(?:1|true)' if "true" not in names else '1'
+    not_false = r'|is\s+not\s+false' if "false" not in names else ''
     pending = [expression]
     while pending:
         term = pending.pop().strip()
@@ -1219,10 +1254,13 @@ def conjunctive_terms(expression: str) -> Iterable[str]:
         depth = case_depth = 0
         cuts = []
         between = False
-        outer_end = None
-        for token in re.finditer(r'\(|\)|\b(?:and|or|between|case|end)\b', active, re.IGNORECASE):
+        outer_start = outer_end = None
+        commas = []
+        for token in re.finditer(r'\(|\)|,|\b(?:and|or|between|case|end)\b', active, re.IGNORECASE):
             kind = token.group().lower()
             if kind == '(':
+                if depth == 0 and outer_start is None:
+                    outer_start = token.start()
                 depth += 1
             elif kind == ')':
                 depth -= 1
@@ -1232,6 +1270,9 @@ def conjunctive_terms(expression: str) -> Iterable[str]:
                 case_depth += 1
             elif kind == 'end':
                 case_depth -= 1
+            elif kind == ',':
+                if depth == 1 and case_depth == 0:
+                    commas.append(token.start())
             elif depth == 0 and case_depth == 0:
                 if kind == 'or':
                     cuts = []
@@ -1246,18 +1287,40 @@ def conjunctive_terms(expression: str) -> Iterable[str]:
             edges = [0, *(end for _, end in cuts)]
             ends = [*(start for start, _ in cuts), len(term)]
             pending.extend(reversed([term[start:end] for start, end in zip(edges, ends)]))
-        elif active.lstrip().startswith('(') and outer_end == len(active.rstrip()):
-            pending.append(term[len(active) - len(active.lstrip()) + 1:outer_end - 1])
         else:
-            yield term
+            inner = None
+            if outer_start is not None and outer_end is not None:
+                prefix = sql_projection(term[:outer_start], identifiers=True).strip()
+                suffix = sql_projection(term[outer_end:], literals=True, identifiers=True).strip()
+                body = term[outer_start + 1:outer_end - 1]
+                if not prefix and (not suffix or re.fullmatch(
+                    rf'(?:{EQUALITY}{truth}{not_false})', suffix, re.IGNORECASE
+                )):
+                    inner = body
+                elif not suffix and re.fullmatch(rf'{truth}{EQUALITY}', prefix, re.IGNORECASE):
+                    inner = body
+                elif not suffix and re.fullmatch(r'not\s+not', prefix, re.IGNORECASE):
+                    inner = body
+                elif not suffix and identifier_key(unquote_identifier(prefix)) in {"likely", "unlikely"} and not commas:
+                    inner = body
+                elif not suffix and identifier_key(unquote_identifier(prefix)) == "likelihood" and len(commas) == 1:
+                    probability = sql_projection(term[commas[0] + 1:outer_end - 1]).strip()
+                    if re.fullmatch(r'(?:0(?:\.\d*)?|1(?:\.0*)?|\.\d+)', probability):
+                        inner = term[outer_start + 1:commas[0]]
+            if inner is None:
+                yield term
+            else:
+                pending.append(inner)
 
 
-def column_equality_groups(expression: str, columns: Iterable[str]) -> list[list[str]]:
+def column_equality_groups(
+    expression: str, columns: Iterable[str], *, context_columns: Iterable[str] = (),
+) -> list[list[str]]:
     """Group bare column equalities without exposing opaque SQL or function calls."""
     names = {identifier_key(name): name for name in columns}
     groups = {name: [name] for name in names.values()}
     pattern = rf'\s*({SQL_IDENTIFIER}){EQUALITY}({SQL_IDENTIFIER})\s*'
-    for term in conjunctive_terms(expression):
+    for term in conjunctive_terms(expression, (*names.values(), *context_columns)):
         match = re.fullmatch(pattern, sql_projection(term, identifiers=True), re.IGNORECASE)
         if match is None:
             continue
@@ -1268,6 +1331,21 @@ def column_equality_groups(expression: str, columns: Iterable[str]) -> list[list
             for name in moved:
                 groups[name] = joined
     return [members for name, members in groups.items() if name == members[0]]
+
+
+def semantic_recipients(
+    expression: str, columns: Iterable[str], *, context_columns: Iterable[str] = (),
+) -> dict[str, set[str]]:
+    """Bound speculative value propagation to columns connected by CHECK terms."""
+    names = {identifier_key(name): name for name in columns}
+    connected = {name: {name} for name in names.values()}
+    for term in conjunctive_terms(expression, (*names.values(), *context_columns)):
+        identifiers = sql_identifiers(term)
+        mentioned = [name for key, name in names.items() if key in identifiers]
+        joined = set().union(*(connected[name] for name in mentioned))
+        for name in joined:
+            connected[name] = joined
+    return connected
 
 
 def shape_proposals(
@@ -1287,13 +1365,15 @@ def shape_proposals(
     expressions still fail visibly; every proposed value must survive a real insert.
     """
     names = {identifier_key(name): name for name in values}
+    omitted, unavailable = tuple(omitted), tuple(unavailable)
+    context_columns = [*values, *(name for name, _, _ in omitted), *unavailable]
     text_eligible = {name for name, declared in required if not strict or declared.upper() in {"TEXT", "ANY"}}
     text = {name: value for name, value in values.items() if name in text_eligible and isinstance(value, str)}
     widths = {}
     shapes = text_constraints if text_constraints is not None else expression
     # Only required whole terms may force a shape during an unrelated repair.
-    # Occurrences inside OR/NOT/CASE/functions are not required shapes.
-    shape_terms = [sql_projection(term, literals=True, identifiers=True) for term in conjunctive_terms(shapes)]
+    # Occurrences inside optional/negative branches are not required shapes.
+    shape_terms = [sql_projection(term, literals=True, identifiers=True) for term in conjunctive_terms(shapes, context_columns)]
     for term in shape_terms:
         match = re.fullmatch(rf'\s*length\s*\(\s*({SQL_IDENTIFIER})\s*\)\s*=\s*(\d+)\s*', term, re.IGNORECASE)
         if match is None:
@@ -1315,15 +1395,22 @@ def shape_proposals(
         if name in text_eligible:
             pattern = quoted.replace("''", "'")
             (negative if negated else positive)[name].append(pattern)
-    groups = column_equality_groups(shapes, (name for name, _ in required if name in text_eligible))
+    groups = column_equality_groups(
+        shapes, (name for name, _ in required if name in text_eligible), context_columns=context_columns,
+    )
     aliases = {name: members for members in groups for name in members}
     witnesses = []
+    semantic_fallback = []
     pending_groups = deque(groups)
     while pending_groups:
         members = pending_groups.popleft()
         patterns = tuple(dict.fromkeys(pattern for name in members for pattern in positive[name]))
         excluded = tuple(dict.fromkeys(pattern for name in members for pattern in negative[name]))
-        if not patterns and not excluded:
+        if not patterns and not excluded and not any(name in widths for name in members):
+            # Equality without a text shape still carries native alternatives.
+            # Do not force one member's value: collation and affinity may differ.
+            if len(members) > 1:
+                semantic_fallback.extend(tuple((name, values[source]) for name in members) for source in members)
             continue
         sizes = {widths[name] for name in members if name in widths}
         width = next(iter(sizes), None)
@@ -1342,7 +1429,7 @@ def shape_proposals(
                     text[name] = values[name]
                 else:
                     text.pop(name, None)
-            witnesses.extend(values[name] for name in members if isinstance(values[name], str))
+            witnesses.extend((name, values[name]) for name in members if isinstance(values[name], str))
             continue
         witness = next((text[name] for name in members if name in text
                         and fits(text[name])), None)
@@ -1351,14 +1438,14 @@ def shape_proposals(
             witness = glob_witness(connection, patterns, excluded=excluded, width=width, alphabet=alphabet)
         if witness is not None:
             text.update((name, witness) for name in members)
-            witnesses.append(witness)
+            witnesses.extend((name, witness) for name in members)
         elif len(members) > 1:
             # Equality may use collation/affinity rather than byte identity.
             # Reuse independent shape search; the target INSERT decides equality.
             for name in members:
                 aliases[name] = [name]
                 pending_groups.append([name])
-    for name, start, width, other in substring_requirements(shapes):
+    for name, start, width, other in substring_requirements(shapes, context_columns):
         name, other = names.get(identifier_key(name), name), names.get(identifier_key(other), other)
         position = bounded_integer(start, 1, SEED_TEXT_LIMIT)
         size = bounded_integer(width, 0, SEED_TEXT_LIMIT)
@@ -1374,8 +1461,22 @@ def shape_proposals(
     mentioned = sql_identifiers(expression)
     # Retain computed values for functional dependents as guesses, not aliases.
     # Raw pattern operands remain owned by the GLOB matcher.
-    text_fallback = [(name, witness) for witness in dict.fromkeys(witnesses)
-                     for name, _ in required if name in text_eligible and identifier_key(name) in mentioned]
+    recipients = semantic_recipients(
+        shapes, (name for name, _ in required), context_columns=context_columns,
+    ) if witnesses else {}
+    for source, witness in dict.fromkeys(witnesses):
+        # Keep alternatives atomic across CHECK boundaries. Per-column shapes
+        # constrain each recipient, not the functional relationship between them.
+        targets = [
+            name for name, _ in required if name in text_eligible
+            and name in recipients[source]
+            and (name not in widths or len(witness) == widths[name])
+            and all(connection.execute("select ? glob ?", (witness, pattern)).fetchone()[0] for pattern in positive[name])
+            and not any(connection.execute("select ? glob ?", (witness, pattern)).fetchone()[0] for pattern in negative[name])
+        ]
+        if targets:
+            semantic_fallback.append(tuple((name, witness) for name in targets))
+            semantic_fallback.extend(((name, witness),) for name in targets)
     numeric_text = active + " " + " ".join(
         match.group()[1:-1] for match in re.finditer(SQL_STRING, sql_projection(expression, literals=True))
         if re.fullmatch(r"-?[0-9]+", match.group()[1:-1])
@@ -1396,15 +1497,14 @@ def shape_proposals(
         if SQLITE_INT_MIN <= value <= SQLITE_INT_MAX
     ))
     if not numeric or not candidates:
-        return ShapeProposals(proposals, [], text_fallback)
+        return ShapeProposals(proposals, [], semantic_fallback)
     domains = numeric_domains(expression, numeric, values, candidates)
     assignments = numeric_assignments(domains, tuple(values[name] for name in numeric), candidates)
     fallback = [tuple(zip(numeric, assignment)) for assignment in itertools.islice(assignments, SEED_ATTEMPTS)]
-    omitted, unavailable = tuple(omitted), tuple(unavailable)
     declared_names = {identifier_key(name) for name, _ in required} | {identifier_key(name) for name, _, _ in omitted} | {identifier_key(name) for name in unavailable}
     implicit = {"rowid", "_rowid_", "oid"} - declared_names
     if any(identifier_key(name) in mentioned for name in (*unavailable, *implicit)):
-        return ShapeProposals(proposals, fallback, text_fallback)
+        return ShapeProposals(proposals, fallback, semantic_fallback)
     # Native typed insertion models affinity, but scratch DML must never change
     # the fixture connection's changes()/last_insert_rowid()/total_changes().
     evaluation = sqlite3.connect(":memory:")
@@ -1443,17 +1543,17 @@ def shape_proposals(
             ).fetchone()[0]
             if accepted:
                 proposals.extend((name, value) for name, value in changes.items() if value != values[name])
-                return ShapeProposals(proposals, [], text_fallback)
+                return ShapeProposals(proposals, [], semantic_fallback)
             # Not an accepted row, but still a storage-valid origin for another
             # bounded search. The INSERT loop owns progress, deduplication and
             # its total budget; do not discard all partial numeric repairs here.
             rejected.append(assignment)
     except sqlite3.OperationalError:
         # Unrepresentable context cannot reject a candidate; actual INSERT decides.
-        return ShapeProposals(proposals, fallback, text_fallback)
+        return ShapeProposals(proposals, fallback, semantic_fallback)
     finally:
         evaluation.close()
-    return ShapeProposals(proposals, rejected, text_fallback)
+    return ShapeProposals(proposals, rejected, semantic_fallback)
 
 
 def numeric_assignments(
@@ -1831,7 +1931,8 @@ def insert_seed_row(
             unavailable.append(str(info[1]))
         else:
             omitted.append((str(info[1]), str(info[2]), info[4]))
-    prefix_sources = {identifier_key(other) for _, _, _, other in substring_requirements(text_constraints)}
+    context_columns = [*names, *(name for name, _, _ in omitted), *unavailable]
+    prefix_sources = {identifier_key(other) for _, _, _, other in substring_requirements(text_constraints, context_columns)}
     strict = is_strict_table(connection, table)
     def row_identity(row: dict[str, object]) -> tuple:
         return tuple((name, type(row[name]), row[name]) for name in names)
@@ -1871,13 +1972,14 @@ def insert_seed_row(
                 related_proposals = [
                     pair
                     for related in constraints
-                    for pair in [*check_proposals(related, names), *json_proposals(connection, related, names)]
+                    for pair in check_proposals(related, names, context_columns=context_columns)
                     if identifier_key(pair[0]) in prefix_sources
                 ]
                 sources = [
                     shaped.numeric_fallback,
-                    [(pair,) for pair in [*check_proposals(expression, names), *shaped.text_fallback,
-                                         *json_proposals(connection, expression, names), *related_proposals]],
+                    [*((pair,) for pair in check_proposals(expression, names, context_columns=context_columns)), *shaped.semantic_fallback,
+                     *json_proposals(connection, expression, names, text_constraints=text_constraints, context_columns=context_columns),
+                     *((pair,) for pair in related_proposals)],
                 ]
                 # Derived repairs precede guesses. Both guess sources remain live
                 # throughout the INSERT budget, with JSON after generic literals.

--- a/scripts/migration_release_guard.py
+++ b/scripts/migration_release_guard.py
@@ -70,6 +70,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from decimal import Decimal
 from pathlib import Path
+from uuid import uuid4
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
@@ -821,10 +822,8 @@ JSON_REQUIREMENT = re.compile(
     r"('[^']*'|-?[0-9]+(?:\.[0-9]+)?)",
     re.IGNORECASE,
 )
-SUBSTRING_REQUIREMENT = re.compile(
-    r'\bsubstr\s*\(\s*"?(\w+)"?\s*,\s*(\d+)\s*,\s*(\d+)\s*\)\s*=\s*"?(\w+)"?',
-    re.IGNORECASE,
-)
+SUBSTRING_TERM = r'\bsubstr\s*\(\s*"?(\w+)"?\s*,\s*(\d+)\s*,\s*(\d+)\s*\)'
+EQUALITY = r'\s*(?:==|=(?!=)|\bis\b(?!\s+not\b))\s*'
 
 # Every name SQLite's `json_type` can return, against the emptiest document member of that
 # type. A `json_type` clause states the type where the `json_extract` form states the
@@ -853,6 +852,28 @@ SEED_ROWS = 2
 RESTORE_STEP = SEED_ATTEMPTS
 
 
+def sqlite_affinity(declared_type: str) -> str:
+    """SQLite's ordered declared-type rules, shared by seed and repair candidates."""
+    kind = declared_type.upper()
+    if "INT" in kind:
+        return "INTEGER"
+    if any(marker in kind for marker in ("CHAR", "CLOB", "TEXT")):
+        return "TEXT"
+    if not kind or "BLOB" in kind:
+        return "BLOB"
+    if any(marker in kind for marker in ("REAL", "FLOA", "DOUB")):
+        return "REAL"
+    return "NUMERIC"
+
+
+def substring_requirements(expression: str) -> Iterable[tuple[str, str, str, str]]:
+    """Normalize either operand order into (target, start, width, source)."""
+    identifier = r'"?(\w+)"?'
+    yield from re.findall(SUBSTRING_TERM + EQUALITY + identifier, expression, re.IGNORECASE)
+    for source, target, start, width in re.findall(identifier + EQUALITY + SUBSTRING_TERM, expression, re.IGNORECASE):
+        yield target, start, width, source
+
+
 def representative_value(column: str, declared_type: str) -> object:
     """A value of ``declared_type`` that SQLite will store in ``column``.
 
@@ -863,10 +884,10 @@ def representative_value(column: str, declared_type: str) -> object:
     migration that parses a timestamp, an address, or a JSON document gets something
     parseable rather than ``'x'``.
     """
-    kind = declared_type.upper()
-    if any(marker in kind for marker in ("INT", "REAL", "NUM", "DOUB", "FLOA", "BOOL")):
+    kind = sqlite_affinity(declared_type)
+    if kind in {"INTEGER", "REAL", "NUMERIC"}:
         return 0
-    if "BLOB" in kind:
+    if kind == "BLOB":
         return b""
     if column.endswith(("_at", "_time")):
         return "1970-01-01T00:00:00+00:00"
@@ -973,6 +994,7 @@ def glob_witness(
     connection: sqlite3.Connection,
     patterns: tuple[str, ...],
     *,
+    excluded: tuple[str, ...] = (),
     width: int | None = None,
     alphabet: str = string.printable,
 ) -> str | None:
@@ -981,10 +1003,11 @@ def glob_witness(
     A state retains every possible token position after the current prefix. Stars
     both consume characters and admit an empty transition to the next token.
     """
-    if (width is not None and not 0 <= width <= SEED_TEXT_LIMIT) or sum(map(len, patterns)) > SEED_TEXT_LIMIT:
+    all_patterns = (*patterns, *excluded)
+    if (width is not None and not 0 <= width <= SEED_TEXT_LIMIT) or sum(map(len, all_patterns)) > SEED_TEXT_LIMIT:
         return None
     machines: list[list[str]] = []
-    for pattern in patterns:
+    for pattern in all_patterns:
         tokens = []
         index = 0
         while index < len(pattern):
@@ -997,7 +1020,9 @@ def glob_witness(
                     end += 1
                 closing = pattern.find("]", end)
                 if closing < 0:
-                    return None
+                    # An unterminated SQLite class matches nothing, also when negated.
+                    tokens.append(pattern[index:])
+                    break
                 end = closing + 1
             tokens.append(pattern[index:end])
             index = end
@@ -1033,7 +1058,8 @@ def glob_witness(
         key, depth = queue.popleft()
         states, _ = key
         if (width is None or depth == width) and all(
-            len(tokens) in state for tokens, state in zip(machines, states)
+            (len(tokens) in state) == (index < len(patterns))
+            for index, (tokens, state) in enumerate(zip(machines, states))
         ):
             parts = []
             cursor = key
@@ -1041,7 +1067,10 @@ def glob_witness(
                 cursor, char = parents[cursor]
                 parts.append(char)
             witness = "".join(reversed(parts))
-            if all(connection.execute("select ? glob ?", (witness, pattern)).fetchone()[0] for pattern in patterns):
+            if all(
+                bool(connection.execute("select ? glob ?", (witness, pattern)).fetchone()[0]) == (index < len(patterns))
+                for index, pattern in enumerate(all_patterns)
+            ):
                 return witness
         if depth >= (SEED_TEXT_LIMIT if width is None else width):
             continue
@@ -1054,7 +1083,7 @@ def glob_witness(
                 ))
                 for tokens, state in zip(machines, states)
             )
-            if not all(next_states):
+            if not all(next_states[:len(patterns)]):
                 continue
             next_key = (next_states, depth + 1 if width is not None else 0)
             if next_key in parents:
@@ -1097,38 +1126,25 @@ def shape_proposals(
         re.IGNORECASE,
     )
     positive: dict[str, list[str]] = defaultdict(list)
+    negative: dict[str, list[str]] = defaultdict(list)
     alphabets = {name: string.printable for name in text}
     for name, negated, quoted in globs:
         name = names.get(identifier_key(name), name)
         if name in text:
             pattern = quoted.replace("''", "'")
             alphabets[name] += pattern
-            if not negated:
-                positive[name].append(pattern)
+            (negative if negated else positive)[name].append(pattern)
     alphabets = {name: "".join(dict.fromkeys(alphabet)) for name, alphabet in alphabets.items()}
-    # Restrict the alphabet before generating a witness so later CHECK order cannot
-    # erase a required width or introduce characters forbidden by another CHECK.
-    for name, negated, quoted in globs:
-        name = names.get(identifier_key(name), name)
-        if name not in text:
+    for name in dict.fromkeys([*positive, *negative]):
+        patterns, excluded = positive[name], negative[name]
+        if all(connection.execute("select ? glob ?", (text[name], pattern)).fetchone()[0] for pattern in patterns) and not any(
+            connection.execute("select ? glob ?", (text[name], pattern)).fetchone()[0] for pattern in excluded
+        ):
             continue
-        pattern = quoted.replace("''", "'")
-        if negated and pattern.startswith("*[^") and pattern.endswith("]*"):
-            allowed = "".join(
-                char
-                for char in alphabets[name]
-                if not connection.execute("select ? glob ?", (char, pattern)).fetchone()[0]
-            )
-            alphabets[name] = allowed
-            if allowed:
-                text[name] = "".join(char if char in allowed else allowed[0] for char in text[name])
-    for name, patterns in positive.items():
-        if all(connection.execute("select ? glob ?", (text[name], pattern)).fetchone()[0] for pattern in patterns):
-            continue
-        witness = glob_witness(connection, tuple(patterns), width=widths.get(name), alphabet=alphabets[name])
+        witness = glob_witness(connection, tuple(patterns), excluded=tuple(excluded), width=widths.get(name), alphabet=alphabets[name])
         if witness is not None:
             text[name] = witness
-    for name, start, width, other in SUBSTRING_REQUIREMENT.findall(shapes):
+    for name, start, width, other in substring_requirements(shapes):
         name, other = names.get(identifier_key(name), name), names.get(identifier_key(other), other)
         position = bounded_integer(start, 1, SEED_TEXT_LIMIT)
         size = bounded_integer(width, 0, SEED_TEXT_LIMIT)
@@ -1143,18 +1159,10 @@ def shape_proposals(
         for token in re.findall(r"(?<![\w.])-?[0-9]+(?![\w.])", expression)
         if (bound := bounded_integer(token, SQLITE_INT_MIN, SQLITE_INT_MAX)) is not None
     }
-    projection = ", ".join(
-        f'cast(? as {declared}) as "{name}"' if declared else f'? as "{name}"'
-        for name, declared in required
-    )
-    for name, declared, default in omitted:
-        term = f"({default})" if default is not None else "NULL"
-        if declared:
-            term = f"cast({term} as {declared})"
-        projection += f', {term} as "{name}"'
     numeric = [
         name for name, declared in required
-        if "INT" in declared.upper() and re.search(rf"\b{re.escape(identifier_key(name))}\b", identifier_key(expression))
+        if sqlite_affinity(declared) in {"INTEGER", "REAL", "NUMERIC"}
+        and re.search(rf"\b{re.escape(identifier_key(name))}\b", identifier_key(expression))
     ]
     candidates = list(dict.fromkeys(
         value for bound in sorted(bounds) for value in (bound, bound + 1, bound - 1)
@@ -1163,35 +1171,80 @@ def shape_proposals(
     fallback = [(name, candidate) for candidate in candidates for name in numeric if candidate != values[name]]
     if any(re.search(rf"\b{re.escape(identifier_key(name))}\b", identifier_key(expression)) for name in unavailable):
         return [*proposals, *fallback]
-    # Reserve half the budget for whole-row boundary assignments before a large
-    # single-column search or Cartesian prefix can starve coordinated moves.
-    domains = [list(dict.fromkeys([values[name], *candidates])) for name in numeric]
-    single_changes = (
-        tuple(candidate if name == changed else values[name] for name in numeric)
-        for changed in numeric for candidate in candidates if candidate != values[changed]
-    )
+    if not numeric or not candidates:
+        return proposals
+    domains = numeric_domains(expression, numeric, values, candidates)
+    products = itertools.product(*domains)
     assignments = itertools.chain(
-        itertools.islice(single_changes, SEED_ATTEMPTS // 2),
+        itertools.islice(products, 1),
         (tuple(candidate for _ in numeric) for candidate in candidates),
-        single_changes,
-        itertools.product(*domains),
-    ) if numeric else ()
-    for assignment in itertools.islice(assignments, SEED_ATTEMPTS):
-        changes = dict(zip(numeric, assignment))
-        parameters = [changes.get(column, values[column]) for column, _ in required]
-        try:
+        products,
+    )
+    # CAST is not insertion affinity. A private typed table lets SQLite supply
+    # real defaults and storage classes without altering the fixture's schema.
+    table = f'"seed_candidate_{uuid4().hex}"'
+    def quote(name: str) -> str:
+        return '"' + name.replace('"', '""') + '"'
+
+    def declaration(name: str, declared: str) -> str:
+        return quote(name) + (f' {quote(declared)}' if declared else '')
+
+    declarations = [declaration(name, declared) for name, declared in required]
+    declarations.extend(
+        declaration(name, declared) + (f' default ({default})' if default is not None else '')
+        for name, declared, default in omitted
+    )
+    columns = ', '.join(quote(name) for name, _ in required)
+    placeholders = ', '.join('?' for _ in required)
+    try:
+        connection.execute(f"create temp table {table} ({', '.join(declarations)})")
+        for assignment in itertools.islice(assignments, SEED_ATTEMPTS):
+            changes = dict(zip(numeric, assignment))
+            parameters = [changes.get(column, values[column]) for column, _ in required]
+            connection.execute(f"delete from {table}")
+            connection.execute(f"insert into {table} ({columns}) values ({placeholders})", parameters)
             accepted = connection.execute(
-                f"select coalesce(cast(({expression}) as numeric), 1) != 0 from (select {projection})", parameters
+                f"select coalesce(cast(({expression}) as numeric), 1) != 0 from {table}"
             ).fetchone()[0]
-        except sqlite3.OperationalError:
-            # Generated columns or unsupported context cannot reject a candidate.
-            # Offer the bounded values to the real INSERT, which supplies that context.
-            proposals.extend(fallback)
-            break
-        if accepted:
-            proposals.extend((name, value) for name, value in changes.items() if value != values[name])
-            break
+            if accepted:
+                proposals.extend((name, value) for name, value in changes.items() if value != values[name])
+                break
+    except sqlite3.OperationalError:
+        # Unrepresentable context cannot reject a candidate; actual INSERT decides.
+        proposals.extend(fallback)
+    finally:
+        connection.execute(f"drop table if exists {table}")
     return proposals
+
+
+def numeric_domains(
+    expression: str, numeric: list[str], values: dict[str, object], candidates: list[int]
+) -> list[list[object]]:
+    """Rank finite domains by local predicates; the complete CHECK still decides."""
+    identifier = r'"?(\w+)"?'
+    literal = r"(-?[0-9]+)(?![\w.])"
+    operator = r"\s*(==|!=|<>|<=|>=|=|<|>)\s*"
+    predicates: dict[str, list[tuple[str, int]]] = defaultdict(list)
+    clauses = re.findall(identifier + operator + literal, expression)
+    reverse = {"<": ">", ">": "<", "<=": ">=", ">=": "<=", "=": "=", "==": "==", "!=": "!=", "<>": "<>"}
+    clauses.extend((name, reverse[op], token) for token, op, name in re.findall(literal + operator + identifier, expression))
+    for name, op, token in clauses:
+        if (bound := bounded_integer(token, SQLITE_INT_MIN, SQLITE_INT_MAX)) is not None:
+            predicates[identifier_key(name)].append((op, bound))
+
+    def score(name: str, value: object) -> int:
+        if not isinstance(value, (int, float)):
+            return -len(predicates[identifier_key(name)])
+        return sum(
+            {"=": value == bound, "==": value == bound, "!=": value != bound, "<>": value != bound,
+             "<": value < bound, ">": value > bound, "<=": value <= bound, ">=": value >= bound}[op]
+            for op, bound in predicates[identifier_key(name)]
+        )
+
+    return [
+        sorted(dict.fromkeys([values[name], *candidates]), key=lambda value: -score(name, value))
+        for name in numeric
+    ]
 
 
 def moved_row(base: dict[str, object], step: int, *, held: str | None) -> dict[str, object]:
@@ -1485,7 +1538,7 @@ def insert_seed_row(
             unavailable.append(str(info[1]))
         else:
             omitted.append((str(info[1]), str(info[2]), info[4]))
-    prefix_sources = {identifier_key(other) for _, _, _, other in SUBSTRING_REQUIREMENT.findall(text_constraints)}
+    prefix_sources = {identifier_key(other) for _, _, _, other in substring_requirements(text_constraints)}
     proposed: set[tuple[str, object]] = set()
     objection = ""
     for _ in range(SEED_ATTEMPTS):

--- a/scripts/migration_release_guard.py
+++ b/scripts/migration_release_guard.py
@@ -1069,6 +1069,7 @@ SeedAssignment = tuple[tuple[str, object], ...]
 def json_proposals(
     connection: sqlite3.Connection, expression: str, columns: Iterable[str],
     *, text_constraints: str | None = None, context_columns: Iterable[str] = (),
+    not_null: Iterable[str] = (),
 ) -> list[SeedAssignment]:
     """Whole assignments retaining the documents behind JSON member candidates.
 
@@ -1127,7 +1128,14 @@ def json_proposals(
         proposals.extend(json_member_assignments(connection, documents, terms, shapes, wanted, context_columns))
         missing.extend(((column, "{}"),) for column, document in documents.items() if document != "{}")
     # Populated documents/dependents precede missing-path alternatives in every scope.
-    return list(dict.fromkeys([*proposals, *missing]))
+    # A missing member can leave a CHECK comparison NULL without requiring a
+    # NULL stored column. Keep the document and other useful dependent cells;
+    # do not turn that speculative guess into a terminal NOT NULL refusal.
+    not_null = set(not_null)
+    return list(dict.fromkeys(
+        tuple((name, value) for name, value in assignment if value is not None or name not in not_null)
+        for assignment in [*proposals, *missing]
+    ))
 
 
 def json_member_assignments(
@@ -1382,7 +1390,7 @@ def conjunctive_terms(expression: str, columns: Iterable[str] = ()) -> Iterable[
                 boolean_suffix = re.fullmatch(
                     rf'(?:{is_true}{not_false}|{nonzero})', suffix, SQL_FLAGS,
                 )
-                whole_operand = not operand or identifier_key(unquote_identifier(operand)) in {"likely", "unlikely", "likelihood", "cast"}
+                whole_operand = not operand or identifier_key(unquote_identifier(operand)) in {"likely", "unlikely", "likelihood", "cast", "coalesce", "ifnull"}
                 if whole_operand and negations % 2 == 0 and (not suffix or (
                     not negations and ("-" not in unary.group() or boolean_suffix)
                 )):
@@ -1399,6 +1407,17 @@ def conjunctive_terms(expression: str, columns: Iterable[str] = ()) -> Iterable[
                     probability = sql_projection(term[commas[0] + 1:outer_end - 1]).strip(SQL_WHITESPACE)
                     if re.fullmatch(r'(?:0(?:\.\d*)?|1(?:\.0*)?|\.\d+)', probability, SQL_FLAGS):
                         inner = (outer_start + 1, commas[0])
+                elif (not suffix or re.fullmatch(positive_suffix, suffix, SQL_FLAGS)) and (
+                    null_function := re.fullmatch(rf'(?:{reverse_truth})?({SQL_IDENTIFIER})', prefix, SQL_FLAGS)
+                ) and (
+                    (identifier_key(unquote_identifier(null_function.group(1))) == "coalesce" and commas)
+                    or (identifier_key(unquote_identifier(null_function.group(1))) == "ifnull" and len(commas) == 1)
+                ):
+                    # Only the first argument is unconditional. Preserve the
+                    # complete wrapper for native truth/affinity validation;
+                    # fallback arguments never become required CHECK terms.
+                    inner = (outer_start + 1, commas[0])
+                    verify = True
                 elif cast_as is not None and (
                     (prefix.lower() == "cast" and (not suffix or re.fullmatch(
                         positive_suffix, suffix, SQL_FLAGS
@@ -1547,7 +1566,25 @@ def shape_proposals(
             for name in members:
                 aliases[name] = [name]
                 pending_groups.append([name])
-    for name, start, width, other in substring_requirements(shapes, context_columns):
+    substrings = list(substring_requirements(shapes, context_columns))
+    # Retain the containing values' shaped witnesses before the opposite
+    # direction splices their old targets into them. Native slices can flow
+    # through a chain; one scan per relationship bounds even conflicting cycles.
+    sliced = dict(text)
+    for _ in substrings:
+        previous = dict(sliced)
+        for name, start, width, other in substrings:
+            name, other = names.get(identifier_key(name), name), names.get(identifier_key(other), other)
+            position = bounded_integer(start, 1, SEED_TEXT_LIMIT)
+            size = bounded_integer(width, 0, SEED_TEXT_LIMIT)
+            if name in sliced and other in text_eligible and position is not None and size is not None:
+                value = connection.execute("select substr(?, ?, ?)", (sliced[name], position, size)).fetchone()[0]
+                sliced.update((member, value) for member in aliases[other])
+        if sliced == previous:
+            break
+    if sliced != text:
+        semantic_fallback.append(tuple(sliced.items()))
+    for name, start, width, other in substrings:
         name, other = names.get(identifier_key(name), name), names.get(identifier_key(other), other)
         position = bounded_integer(start, 1, SEED_TEXT_LIMIT)
         size = bounded_integer(width, 0, SEED_TEXT_LIMIT)
@@ -2027,7 +2064,10 @@ def insert_seed_row(
     text_constraints = " AND ".join(f"({constraint}\n)" for constraint in constraints)
     omitted = []
     unavailable = []
+    not_null = set()
     for info in connection.execute(f'pragma table_xinfo({quote_identifier(table)})'):
+        if info[3]:
+            not_null.add(str(info[1]))
         if str(info[1]) in values:
             continue
         if info[6] or (info[5] and str(info[2]).upper() == "INTEGER" and info[4] is None):
@@ -2074,6 +2114,7 @@ def insert_seed_row(
             derived = tuple(shaped.derived)
             documents = json_proposals(
                 connection, expression, names, text_constraints=text_constraints, context_columns=context_columns,
+                not_null=not_null,
             )
             # Only malformed inputs need priority over candidates that can enable
             # their evaluation. Valid documents retain the semantic source order:

--- a/scripts/migration_release_guard.py
+++ b/scripts/migration_release_guard.py
@@ -70,7 +70,6 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from decimal import Decimal
 from pathlib import Path
-from uuid import uuid4
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
@@ -1104,6 +1103,7 @@ def shape_proposals(
     text_constraints: str | None = None,
     omitted: Iterable[tuple[str, str, str | None]] = (),
     unavailable: Iterable[str] = (),
+    allow_unvalidated_numeric: bool = True,
 ) -> list[tuple[str, object]]:
     """Derive bounded text-shape and numeric candidates from the rejected CHECK.
 
@@ -1117,7 +1117,8 @@ def shape_proposals(
     for name, width in re.findall(r'\blength\s*\(\s*"?(\w+)"?\s*\)\s*=\s*(\d+)', shapes, re.IGNORECASE):
         name = names.get(identifier_key(name), name)
         size = bounded_integer(width, 0, SEED_TEXT_LIMIT)
-        if name in text and size is not None:
+        if name in values and size is not None:
+            text.setdefault(name, "x")
             widths[name] = size
             text[name] = text[name][:size].ljust(size, "0")
     globs = re.findall(
@@ -1127,10 +1128,11 @@ def shape_proposals(
     )
     positive: dict[str, list[str]] = defaultdict(list)
     negative: dict[str, list[str]] = defaultdict(list)
-    alphabets = {name: string.printable for name in text}
+    alphabets: dict[str, str] = defaultdict(lambda: string.printable)
     for name, negated, quoted in globs:
         name = names.get(identifier_key(name), name)
-        if name in text:
+        if name in values:
+            text.setdefault(name, "x")
             pattern = quoted.replace("''", "'")
             alphabets[name] += pattern
             (negative if negated else positive)[name].append(pattern)
@@ -1148,7 +1150,8 @@ def shape_proposals(
         name, other = names.get(identifier_key(name), name), names.get(identifier_key(other), other)
         position = bounded_integer(start, 1, SEED_TEXT_LIMIT)
         size = bounded_integer(width, 0, SEED_TEXT_LIMIT)
-        if name in text and isinstance(values.get(other), str) and position is not None and size is not None:
+        if name in values and isinstance(text.get(other, values.get(other)), str) and position is not None and size is not None:
+            text.setdefault(name, "x")
             offset = position - 1
             source = text.get(other, str(values[other]))
             if len(source) == size:
@@ -1168,7 +1171,9 @@ def shape_proposals(
         value for bound in sorted(bounds) for value in (bound, bound + 1, bound - 1)
         if SQLITE_INT_MIN <= value <= SQLITE_INT_MAX
     ))
-    fallback = [(name, candidate) for candidate in candidates for name in numeric if candidate != values[name]]
+    fallback = [
+        (name, candidate) for candidate in candidates for name in numeric if candidate != values[name]
+    ] if allow_unvalidated_numeric else []
     if any(re.search(rf"\b{re.escape(identifier_key(name))}\b", identifier_key(expression)) for name in unavailable):
         return [*proposals, *fallback]
     if not numeric or not candidates:
@@ -1180,15 +1185,17 @@ def shape_proposals(
         (tuple(candidate for _ in numeric) for candidate in candidates),
         products,
     )
-    # CAST is not insertion affinity. A private typed table lets SQLite supply
-    # real defaults and storage classes without altering the fixture's schema.
-    table = f'"seed_candidate_{uuid4().hex}"'
+    # Native typed insertion models affinity, but scratch DML must never change
+    # the fixture connection's changes()/last_insert_rowid()/total_changes().
+    evaluation = sqlite3.connect(":memory:")
+    table = '"seed_candidate"'
     def quote(name: str) -> str:
         return '"' + name.replace('"', '""') + '"'
 
     def declaration(name: str, declared: str) -> str:
         return quote(name) + (f' {quote(declared)}' if declared else '')
 
+    omitted = tuple(omitted)
     declarations = [declaration(name, declared) for name, declared in required]
     declarations.extend(
         declaration(name, declared) + (f' default ({default})' if default is not None else '')
@@ -1197,13 +1204,20 @@ def shape_proposals(
     columns = ', '.join(quote(name) for name, _ in required)
     placeholders = ', '.join('?' for _ in required)
     try:
-        connection.execute(f"create temp table {table} ({', '.join(declarations)})")
+        context = identifier_key(expression + "\n" + "\n".join(default or "" for _, _, default in omitted))
+        contextual = {
+            str(row[0]) for row in evaluation.execute("pragma function_list")
+            if not int(row[5]) & 0x800  # SQLITE_DETERMINISTIC
+        }
+        if any(re.search(rf"\b{re.escape(name)}\b", context) for name in contextual):
+            return [*proposals, *fallback]
+        evaluation.execute(f"create table {table} ({', '.join(declarations)})")
         for assignment in itertools.islice(assignments, SEED_ATTEMPTS):
             changes = dict(zip(numeric, assignment))
             parameters = [changes.get(column, values[column]) for column, _ in required]
-            connection.execute(f"delete from {table}")
-            connection.execute(f"insert into {table} ({columns}) values ({placeholders})", parameters)
-            accepted = connection.execute(
+            evaluation.execute(f"delete from {table}")
+            evaluation.execute(f"insert into {table} ({columns}) values ({placeholders})", parameters)
+            accepted = evaluation.execute(
                 f"select coalesce(cast(({expression}) as numeric), 1) != 0 from {table}"
             ).fetchone()[0]
             if accepted:
@@ -1213,7 +1227,7 @@ def shape_proposals(
         # Unrepresentable context cannot reject a candidate; actual INSERT decides.
         proposals.extend(fallback)
     finally:
-        connection.execute(f"drop table if exists {table}")
+        evaluation.close()
     return proposals
 
 
@@ -1541,7 +1555,7 @@ def insert_seed_row(
     prefix_sources = {identifier_key(other) for _, _, _, other in substring_requirements(text_constraints)}
     proposed: set[tuple[str, object]] = set()
     objection = ""
-    for _ in range(SEED_ATTEMPTS):
+    for attempt in range(SEED_ATTEMPTS):
         try:
             connection.execute(statement, [values[column] for column in names])
         except sqlite3.Error as exc:
@@ -1559,9 +1573,10 @@ def insert_seed_row(
                     *shape_proposals(
                         connection, expression, required, values,
                         text_constraints=text_constraints, omitted=omitted, unavailable=unavailable,
+                        allow_unvalidated_numeric=attempt < SEED_ATTEMPTS // 2,
                     ),
-                    *check_proposals(expression, names),
                     *json_proposals(connection, expression, names),
+                    *check_proposals(expression, names),
                 ]
                 if pair not in proposed and values[pair[0]] != pair[1]
             ]

--- a/tests/test_migration_release_guard.py
+++ b/tests/test_migration_release_guard.py
@@ -1017,6 +1017,123 @@ def test_shape_repairs_follow_constraints_not_column_names(tmp_path, minimum, or
         assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
 
 
+@pytest.mark.parametrize("columns,expression,witness", [
+    ("code TEXT NOT NULL,state TEXT NOT NULL", "code GLOB 'ready' AND state=lower(code)", ('ready', 'ready')),
+    ("a TEXT NOT NULL,b TEXT NOT NULL", "a GLOB 'A' AND b GLOB 'B' AND (a=b OR 1)", ('A', 'B')),
+    ("state TEXT NOT NULL,value BLOB NOT NULL", "typeof(value)='blob' AND length(value)=0 AND state='ready'", ('ready', b'')),
+    ("n0 INTEGER NOT NULL,n1 INTEGER NOT NULL,n2 INTEGER NOT NULL", "max(n1,n2)=2 AND (n0>0)+(n1>0)+(n2>0)=1", (0, 2, 0)),
+])
+def test_candidate_boundaries_preserve_native_seedable_rows(tmp_path, columns, expression, witness):
+    db_path = tmp_path / 'candidate-boundaries.sqlite'
+    ddl = f'create table shaped({columns},constraint ck check({expression}))'
+    with sqlite3.connect(':memory:') as connection:
+        connection.execute(ddl)
+        connection.execute('insert into shaped values(' + ','.join('?' for _ in witness) + ')', witness)
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(ddl)
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute(f'select count(*) from shaped where {expression}').fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute('pragma integrity_check').fetchall() == [('ok',)]
+
+
+@pytest.mark.parametrize("dependency", ["state=lower(code)", "lower(code)=state", 'state="lower"(code)', 'state=trim(code)'])
+@pytest.mark.parametrize("reverse,separate", itertools.product([False, True], repeat=2))
+@pytest.mark.parametrize("pattern", ['ready', 'r[ea]ady', "it''s ready"])
+def test_computed_glob_values_remain_candidates_for_functional_dependents(tmp_path, dependency, reverse, separate, pattern):
+    clauses = [f"code glob '{pattern}'", dependency]
+    if reverse:
+        clauses.reverse()
+    checks = ','.join(f'constraint ck{i} check({clause})' for i, clause in enumerate(clauses)) if separate else f"constraint ck check({' and '.join(clauses)})"
+    db_path = tmp_path / 'functional-glob.sqlite'
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f'create table shaped(state text not null,code text not null,{checks})')
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute('select count(*) from shaped where state=code').fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute('pragma integrity_check').fetchall() == [('ok',)]
+
+
+@pytest.mark.parametrize("condition", [
+    '(a=b OR 1)', 'NOT(a=b)', 'NOT NOT(a=b OR 1)',
+    'CASE WHEN a=b THEN 0 ELSE 1 END', 'iif(a=b,0,1)',
+    '(a=b)=0', '(a=b) IS FALSE', '(a=b) BETWEEN 0 AND 1',
+])
+@pytest.mark.parametrize("reverse,separate", itertools.product([False, True], repeat=2))
+def test_conditional_equalities_do_not_restrict_independent_shapes(tmp_path, condition, reverse, separate):
+    clauses = ["a glob 'A'", "b glob 'B'", condition]
+    if reverse:
+        clauses.reverse()
+    checks = ','.join(f'constraint ck{i} check({clause})' for i, clause in enumerate(clauses)) if separate else f"constraint ck check({' and '.join(clauses)})"
+    db_path = tmp_path / 'conditional-equality.sqlite'
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f'create table shaped(a text not null,b text not null,{checks})')
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("select count(*) from shaped where a='A' and b='B'").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute('pragma integrity_check').fetchall() == [('ok',)]
+
+
+@pytest.mark.parametrize("expression,joined", [
+    ('a=b OR a=c AND b=c', False),
+    ('NOT (a=b AND b=c)', False),
+    ('CASE WHEN 1 THEN a=b AND b=c ELSE 1 END', False),
+    ('(a=b) AND (((b=c)))', True),
+    ('/* note */ ((a=b AND b=c)) -- end\n', True),
+    ('1 BETWEEN 0 AND 2 AND a=b AND b=c', True),
+    ('a=b AND b=c AND (a=c OR 1)', True),
+])
+def test_equality_groups_require_unconditional_whole_terms(expression, joined):
+    assert guard.column_equality_groups(expression, ['a', 'b', 'c']) == ([['a', 'b', 'c']] if joined else [['a'], ['b'], ['c']])
+
+
+@pytest.mark.parametrize("value,declared", [(b'', 'BLOB'), (b'ab', 'BLOB'), (b'\x00a', 'BLOB'), (17, 'INTEGER'), (1.5, 'REAL')])
+@pytest.mark.parametrize("with_glob", [False, True])
+def test_already_valid_native_shapes_preserve_storage(value, declared, with_glob):
+    with sqlite3.connect(':memory:') as connection:
+        width = connection.execute('select length(?)', (value,)).fetchone()[0]
+        expression = f'length(value)={width} and state=\'ready\''
+        if with_glob:
+            expression += " and value not glob 'X*'"
+        proposals = guard.shape_proposals(connection, expression, [('state', 'TEXT'), ('value', declared)], {'state': 'x', 'value': value})
+        assert not any(name == 'value' for name, _ in proposals.derived)
+
+
+@pytest.mark.parametrize("function", ['max(n1,n2)', 'MAX(n1,n2,0)', '"max"(n1,n2)', 'max /* call */ (n1,n2)', 'max(min(n1,2),n2)'])
+@pytest.mark.parametrize("reverse", [False, True])
+def test_scalar_overloads_keep_native_joint_evaluation(tmp_path, function, reverse):
+    clauses = [f'{function}=2', '(n0>0)+(n1>0)+(n2>0)=1']
+    if reverse:
+        clauses.reverse()
+    db_path = tmp_path / 'scalar-overload.sqlite'
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table shaped(n0 int not null,n1 int not null,n2 int not null,constraint ck check({' and '.join(clauses)}))")
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute('select count(*) from shaped').fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute('pragma integrity_check').fetchall() == [('ok',)]
+
+
+@pytest.mark.parametrize("default", ['max(1,2)', 'min(2,3,4)', 'min(max(1,2),3)'])
+def test_scalar_overloads_in_defaults_preserve_native_candidates(default):
+    with sqlite3.connect(':memory:') as connection:
+        proposals = guard.shape_proposals(connection, 'n=2 and tag=2', [('n', 'INTEGER')], {'n': 0}, omitted=[('tag', 'INTEGER', default)])
+        assert proposals.derived == [('n', 2)]
+        assert proposals.numeric_fallback == []
+
+
+@pytest.mark.parametrize("function", ['max(n)', 'min(n)', 'max(n,random())', 'min(n,changes())'])
+def test_aggregate_and_contextual_overloads_still_defer(function):
+    with sqlite3.connect(':memory:') as connection:
+        proposals = guard.shape_proposals(connection, f'n>0 and {function}=2', [('n', 'INTEGER')], {'n': 0})
+        assert proposals.derived == []
+        assert proposals.numeric_fallback
+
+
 def test_numeric_candidates_use_the_column_affinity():
     with sqlite3.connect(":memory:") as connection:
         proposals = guard.shape_proposals(connection, "n > '0'", [("n", "INTEGER")], {"n": 0}).derived

--- a/tests/test_migration_release_guard.py
+++ b/tests/test_migration_release_guard.py
@@ -1112,7 +1112,7 @@ def test_json_type_dependencies_use_sqlite_member_semantics(tmp_path, member_typ
 
 @pytest.mark.parametrize("payload", [
     "x=substr(email,5,1)", "substr(email,5,1)=x", "length(email)=2",
-    "email glob '[A-Z]*'", "json_extract(email,'$.x')='ready'", "n=9999",
+    "email glob '[A-Z]*'", "json_extract(email,'$.x')='ready'", "n=9999", "email=x",
 ])
 @pytest.mark.parametrize("wrapper", ["/* {} */", "-- {}\n", "'{}'", '"{}"', '`{}`', '[{}]'])
 def test_candidate_extractors_share_opaque_sql_boundaries(payload, wrapper):
@@ -1120,6 +1120,7 @@ def test_candidate_extractors_share_opaque_sql_boundaries(payload, wrapper):
     expression = wrapper.format(encoded)
     assert list(guard.substring_requirements(expression)) == []
     assert list(guard.sql_matches(guard.JSON_REQUIREMENT, expression)) == []
+    assert guard.column_equality_groups(expression, ["email", "x", "n"]) == [["email"], ["x"], ["n"]]
     with sqlite3.connect(":memory:") as connection:
         proposals = guard.shape_proposals(connection, expression, [("email", "TEXT"), ("x", "TEXT"), ("n", "INTEGER")], {"email": "seed@example.invalid", "x": "x", "n": 0})
         assert proposals.derived == []
@@ -1450,6 +1451,116 @@ def test_glob_patterns_remain_in_their_semantic_candidate_owner(tmp_path, negate
     with sqlite3.connect(db_path) as connection:
         assert connection.execute(f'select count(*) from shaped where {expression}').fetchone()[0] >= guard.SEED_ROWS
         assert connection.execute('pragma integrity_check').fetchall() == [('ok',)]
+
+
+@pytest.mark.parametrize("equality", ["=", "==", "IS"])
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize("separate", [False, True])
+@pytest.mark.parametrize("order", list(itertools.permutations(range(3))))
+def test_equal_columns_share_composed_glob_witnesses(tmp_path, equality, reverse, separate, order):
+    left, right = ('"code value"', 'state') if not reverse else ('state', '"code value"')
+    clauses = [f"{left} {equality} {right}", "\"code value\" glob 'A*'", "length(state)=4 and state glob '*Z' and state not glob '*0*'"]
+    clauses = [clauses[index] for index in order]
+    checks = ','.join(f'constraint ck{index} check({clause})' for index, clause in enumerate(clauses)) if separate else f"constraint ck check({' and '.join(clauses)})"
+    db_path = tmp_path / 'equal-shapes.sqlite'
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f'create table shaped("code value" text not null,state text not null,{checks})')
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute('select count(*) from shaped where "code value"=state').fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute('pragma integrity_check').fetchall() == [('ok',)]
+
+
+@pytest.mark.parametrize("order", list(itertools.permutations(range(3))))
+@pytest.mark.parametrize("pattern", ["ready", "r*dy", "it''s ready"])
+def test_glob_equalities_propagate_through_chains_and_cycles(tmp_path, order, pattern):
+    names = ['code', 'state', 'label']
+    equalities = [f'{names[index]}={names[(index+1)%3]}' for index in order]
+    db_path = tmp_path / 'shape-cycle.sqlite'
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table shaped({','.join(name+' text not null' for name in reversed(names))},constraint ck check(code glob '{pattern}' and {' and '.join(equalities)}))")
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute('select count(*) from shaped where code=state and state=label').fetchone()[0] >= guard.SEED_ROWS
+
+
+@pytest.mark.parametrize("order", list(itertools.permutations(range(4))))
+@pytest.mark.parametrize("reverse", [False, True])
+def test_equal_shape_groups_survive_substring_repairs(tmp_path, order, reverse):
+    equalities = ['state=code', 'substr(code,1,2)=source'] if not reverse else ['code=state', 'source=substr(code,1,2)']
+    clauses = ["source glob 'AB'", "code glob 'A*'", *equalities]
+    db_path = tmp_path / 'equal-substring.sqlite'
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table shaped(source text not null,state text not null,code text not null,constraint ck check({' and '.join(clauses[index] for index in order)}))")
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute('select count(*) from shaped where state=code and substr(code,1,2)=source').fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute('pragma integrity_check').fetchall() == [('ok',)]
+
+
+@pytest.mark.parametrize("reverse_checks,reverse_columns", itertools.product([False, True], repeat=2))
+@pytest.mark.parametrize("position", [1, 10, 20])
+def test_candidate_progress_belongs_to_the_failing_check(tmp_path, reverse_checks, reverse_columns, position):
+    kinds = [f"'kind{i}'" for i in range(position)] + ["'target'"] + [f"'kind{i}'" for i in range(position, 40)]
+    states = ["'ready'"] + [f"'state{i}'" for i in range(60)]
+    checks = [f"constraint ck_kind check(kind in ({','.join(kinds)}) and kind='target')", f"constraint ck_state check(state in ({','.join(states)}) and state='ready')"]
+    columns = ['kind', 'state']
+    if reverse_checks:
+        checks.reverse()
+    if reverse_columns:
+        columns.reverse()
+    db_path = tmp_path / 'check-progress.sqlite'
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table shaped({','.join(name+' text not null' for name in columns)},{','.join(checks)})")
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("select count(*) from shaped where kind='target' and state='ready'").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute('pragma integrity_check').fetchall() == [('ok',)]
+
+
+@pytest.mark.parametrize("expression", ['code=state()', 'state()=code', 'code=t.state', 't.code=state'])
+def test_function_and_qualified_operands_are_not_bare_column_aliases(expression):
+    assert guard.column_equality_groups(expression, ['code', 'state', 't']) == [['code'], ['state'], ['t']]
+
+
+@pytest.mark.parametrize("strict", [False, True])
+@pytest.mark.parametrize("style", ['"{}"', '`{}`', '[{}]'])
+def test_equal_shape_groups_preserve_valid_common_values_and_identifier_identity(strict, style):
+    source, target = style.format('Source Value'), style.format('Target Value')
+    expression = f"{source} glob 'r*' and {target} IS {source}"
+    required = [('Source Value', 'TEXT'), ('Target Value', 'ANY' if strict else 'DATE')]
+    values = {'Source Value': 'ready', 'Target Value': 'ready'}
+    with sqlite3.connect(':memory:') as connection:
+        assert guard.shape_proposals(connection, expression, required, values, strict=strict).derived == []
+        values['Target Value'] = 'x'
+        assert guard.shape_proposals(connection, expression, required, values, strict=strict).derived == [('Target Value', 'ready')]
+
+
+def test_equal_shape_groups_do_not_promote_strict_numeric_columns_to_text():
+    with sqlite3.connect(':memory:') as connection:
+        proposals = guard.shape_proposals(connection, "code glob 'ready' and n=code", [('code', 'TEXT'), ('n', 'INTEGER')], {'code': 'x', 'n': 0}, strict=True)
+        assert proposals.derived == [('code', 'ready')]
+
+
+@pytest.mark.parametrize("reverse_checks,reverse_columns", itertools.product([False, True], repeat=2))
+def test_numeric_fallback_progress_is_scoped_to_each_check(tmp_path, reverse_checks, reverse_columns):
+    checks = ['constraint first check(g=0 and a=1 and b=2)', 'constraint second check(g=0 and c=3 and d=4)']
+    names = ['a', 'b', 'c', 'd']
+    if reverse_checks:
+        checks.reverse()
+    if reverse_columns:
+        names.reverse()
+    db_path = tmp_path / 'numeric-check-progress.sqlite'
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table shaped({','.join(name+' integer not null' for name in names)},g integer generated always as(0),{','.join(checks)})")
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute('select count(*) from shaped where a=1 and b=2 and c=3 and d=4').fetchone()[0] >= guard.SEED_ROWS
 
 
 def test_numeric_fallback_exhaustion_stays_visible(tmp_path):

--- a/tests/test_migration_release_guard.py
+++ b/tests/test_migration_release_guard.py
@@ -1197,6 +1197,122 @@ def test_large_numeric_domains_reach_joint_candidates(tmp_path, count, context, 
         assert connection.execute('pragma integrity_check').fetchall() == [('ok',)]
 
 
+@pytest.mark.parametrize("changed", range(39))
+@pytest.mark.parametrize("reverse", [False, True])
+def test_sparse_wave_past_half_budget_reaches_every_column(tmp_path, changed, reverse):
+    names = [f'n{i}' for i in range(39)]
+    clauses = ['+'.join(f'({name}>0)' for name in names) + '=1', f'abs(n{changed})>0']
+    if reverse:
+        names.reverse()
+        clauses.reverse()
+    db_path = tmp_path / 'wide-sparse.sqlite'
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table shaped({','.join(name+' integer not null' for name in names)},constraint ck check({' and '.join(clauses)}))")
+        witness = [int(name == f'n{changed}') for name in names]
+        connection.execute('insert into shaped values (' + ','.join('?' for _ in names) + ')', witness)
+        assert connection.execute('pragma integrity_check').fetchall() == [('ok',)]
+        connection.execute('delete from shaped')
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute('select count(*) from shaped').fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute('pragma integrity_check').fetchall() == [('ok',)]
+
+
+@pytest.mark.parametrize("count", range(31, 57))
+@pytest.mark.parametrize("ranked_first", [False, True])
+def test_first_sparse_wave_and_joint_anchors_share_fitting_budget(count, ranked_first):
+    candidates = [0, 1, -1, 2]
+    domain = [1, 0, -1, 2] if ranked_first else candidates
+    current = (0,) * count
+    expected = {tuple(value for _ in range(count)) for value in candidates}
+    expected.update((*current[:index], 1, *current[index+1:]) for index in range(count))
+    assert len(expected) <= guard.SEED_ATTEMPTS
+    prefix = list(itertools.islice(guard.numeric_assignments([domain] * count, current, candidates), guard.SEED_ATTEMPTS))
+    assert len(prefix) == len(set(prefix)) == guard.SEED_ATTEMPTS
+    assert expected <= set(prefix)
+
+
+@pytest.mark.parametrize("count", [31, 38, 40, 50, 55, 56])
+@pytest.mark.parametrize("reverse", [False, True])
+def test_wide_sparse_boundary_consumers_keep_last_column(tmp_path, count, reverse):
+    names = [f'n{i}' for i in range(count)]
+    clauses = ['+'.join(f'({name}>0)' for name in names) + '=1', f'abs(n{count-1})>0']
+    if reverse:
+        names.reverse()
+        clauses.reverse()
+    db_path = tmp_path / 'sparse-boundary.sqlite'
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table shaped({','.join(name+' integer not null' for name in names)},constraint ck check({' and '.join(clauses)}))")
+    short, _ = guard.seed_representative_rows(db_path)
+    with sqlite3.connect(db_path) as connection:
+        rows = connection.execute('select count(*) from shaped').fetchone()[0]
+        if count <= 40:
+            assert short == {}
+            assert rows >= guard.SEED_ROWS
+        else:
+            # First-wave coverage is not a promise to exhaust later anchor
+            # neighborhoods when constructing repeated rows. A shortfall must
+            # still fail visibly rather than accepting a one-row fixture.
+            assert rows >= 1
+            assert bool(short) == (rows < guard.SEED_ROWS)
+        assert connection.execute('pragma integrity_check').fetchall() == [('ok',)]
+
+
+@pytest.mark.parametrize("count", [31, 39, 59, 60, 80])
+@pytest.mark.parametrize("target", [-1, 1, 2])
+@pytest.mark.parametrize("context", [False, True])
+def test_wide_joint_anchors_precede_remaining_sparse_wave(tmp_path, count, target, context):
+    names = [f'n{i}' for i in range(count)]
+    expression = '+'.join(f'abs({name}-({target}))' for name in names) + '=0'
+    if context:
+        expression += ' and changes()>=0'
+    db_path = tmp_path / 'wide-joint-anchor.sqlite'
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table shaped({','.join(name+' integer not null' for name in names)},constraint ck check({expression}))")
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute('select count(*) from shaped').fetchone()[0] >= guard.SEED_ROWS
+        assert set(connection.execute('select * from shaped')) == {(target,) * count}
+        assert connection.execute('pragma integrity_check').fetchall() == [('ok',)]
+
+
+@pytest.mark.parametrize("count", [31, 59, 80])
+@pytest.mark.parametrize("held", [0, 1, -1])
+def test_wide_fallback_anchor_survives_rebased_sparse_rows(count, held):
+    names = [f'n{i}' for i in range(count)]
+    expression = '+'.join(f'abs({name}-1)' for name in names) + '=0 and changes()>=0'
+    with sqlite3.connect(':memory:') as connection:
+        ddl = f"create table shaped({','.join(name+' integer' for name in names)},constraint ck check({expression}))"
+        connection.execute(ddl)
+        values = dict.fromkeys(names, 2)
+        values[names[held]] = 1
+        attempts = []
+        connection.set_trace_callback(lambda sql: attempts.append(sql) if sql.startswith('insert into "shaped"') else None)
+        assert guard.insert_seed_row(connection, 'shaped', ddl, [(name, 'INTEGER') for name in names], values) == ('', True)
+        assert len(attempts) == 3
+        assert connection.execute('select * from shaped').fetchall() == [(1,) * count]
+
+
+@pytest.mark.parametrize("count", [31, 59, 80])
+@pytest.mark.parametrize("context", [False, True])
+def test_wide_ranked_assignment_survives_many_uniform_anchors(tmp_path, count, context):
+    names = [f'n{i}' for i in range(count)]
+    expression = ' and '.join(f'{name}={i+1}' for i, name in enumerate(names))
+    if context:
+        expression += ' and changes()>=0'
+    db_path = tmp_path / 'wide-ranked.sqlite'
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table shaped({','.join(name+' integer not null' for name in names)},constraint ck check({expression}))")
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute('select count(*) from shaped').fetchone()[0] >= guard.SEED_ROWS
+        assert set(connection.execute('select * from shaped')) == {tuple(range(1, count+1))}
+        assert connection.execute('pragma integrity_check').fetchall() == [('ok',)]
+
+
 @pytest.mark.parametrize("function", ['max(n1,n2)', 'MAX(n1,n2,0)', '"max"(n1,n2)', 'max /* call */ (n1,n2)', 'max(min(n1,2),n2)'])
 @pytest.mark.parametrize("reverse", [False, True])
 def test_scalar_overloads_keep_native_joint_evaluation(tmp_path, function, reverse):

--- a/tests/test_migration_release_guard.py
+++ b/tests/test_migration_release_guard.py
@@ -1641,6 +1641,116 @@ def test_json_literals_keep_sql_comment_markers_and_expression_text(path):
         assert connection.execute("select json_extract(?,?)", (proposals["doc"], path)).fetchone()[0] == value
 
 
+@pytest.mark.parametrize("required,optional,witness", [
+    ("json_extract(doc,'$.x')=1", "json_extract(doc,'$.x')=2", '{"x":1}'),
+    ("json_type(doc,'$.x')='integer'", "json_type(doc,'$.x')='text'", '{"x":0}'),
+])
+@pytest.mark.parametrize("wrapper", [
+    "{} OR 1", "1 OR {}", "NOT ({}) OR 1", "CASE WHEN 1 THEN 1 ELSE {} END",
+    "({})=0 OR 1", "coalesce(({}),1)=0 OR 1", "json_valid(doc) AND likely(({}) OR 1)",
+])
+@pytest.mark.parametrize("reverse,separate", itertools.product([False, True], repeat=2))
+def test_optional_json_clauses_cannot_replace_required_documents(tmp_path, required, optional, witness, wrapper, reverse, separate):
+    mandatory = f"(json_valid(doc) AND {required}) IS TRUE"
+    terms = [mandatory, wrapper.format(optional)]
+    if reverse:
+        terms.reverse()
+    checks = ",".join(f"constraint ck{i} check({term})" for i, term in enumerate(terms)) if separate else f"constraint ck check({' AND '.join(f'({term})' for term in terms)})"
+    ddl = f"create table shaped(doc text not null,{checks})"
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute(ddl)
+        connection.execute("insert into shaped values(?)", (witness,))
+        assignments = guard.json_proposals(connection, " AND ".join(f"({term})" for term in terms), ["doc"])
+        first = dict(assignments[0])["doc"]
+        assert connection.execute(f"select {mandatory} from (select ? as doc)", (first,)).fetchone()[0] == 1
+    db_path = tmp_path / "required-json.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(ddl)
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute(f"select count(*) from shaped where {mandatory}").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("optional", [
+    "json_extract(doc,'invalid')=2",
+    "state IS lower(json_extract(doc,'invalid'))",
+    "state IS json_type(doc,'invalid')",
+])
+@pytest.mark.parametrize("reverse,separate", itertools.product([False, True], repeat=2))
+def test_dead_json_paths_cannot_abort_other_repairs(tmp_path, optional, reverse, separate):
+    terms = [
+        "(json_valid(doc) AND json_extract(doc,'$.x')=1) IS TRUE",
+        f"CASE WHEN 1 THEN 1 ELSE {optional} END AND state='ready'",
+    ]
+    if reverse:
+        terms.reverse()
+    checks = ",".join(f"constraint ck{i} check({term})" for i, term in enumerate(terms)) if separate else f"constraint ck check({' AND '.join(f'({term})' for term in terms)})"
+    ddl = f"create table shaped(doc text not null,state text not null,{checks})"
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute(ddl)
+        connection.execute("insert into shaped values(?,?)", ('{"x":1}', "ready"))
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+    db_path = tmp_path / "dead-json-path.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(ddl)
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        rows = connection.execute("select json_extract(doc,'$.x'),state from shaped").fetchall()
+        assert len(rows) >= guard.SEED_ROWS and set(rows) == {(1, "ready")}
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("branch", [
+    "(json_extract(doc,'$.x')=1 OR state='ready')",
+    "CASE WHEN state='x' THEN json_extract(doc,'$.x')=1 ELSE 1 END",
+])
+def test_local_optional_json_comparisons_remain_speculative_candidates(tmp_path, branch):
+    expression = "json_valid(doc) AND " + branch
+    db_path = tmp_path / "optional-json-alternatives.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table shaped(doc text not null,state text not null,constraint ck check({expression}))")
+        assignments = guard.json_proposals(connection, expression, ["doc", "state"])
+        assert any(dict(assignment).get("doc") == '{"x":1}' for assignment in assignments)
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute(f"select count(*) from shaped where {expression}").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("path", ["invalid", "$["])
+def test_invalid_json_candidate_paths_preserve_native_refusal(tmp_path, path):
+    expression = f"(json_valid(doc) AND json_extract(doc,'{path}')=1) IS TRUE"
+    ddl = f"create table shaped(doc text not null,constraint ck check({expression}))"
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute(ddl)
+        with pytest.raises(sqlite3.Error) as native:
+            connection.execute("insert into shaped values('{}')")
+        objection, settled = guard.insert_seed_row(connection, "shaped", ddl, [("doc", "TEXT")], {"doc": "{}"})
+        assert settled and objection == str(native.value)
+        assert connection.execute("select count(*) from shaped").fetchone()[0] == 0
+    db_path = tmp_path / "invalid-json-path.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(ddl)
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("select count(*) from shaped").fetchone()[0] == 0
+
+
+def test_dead_invalid_json_candidate_does_not_change_opaque_document():
+    expression = "CASE WHEN 1 THEN 1 ELSE json_extract(doc,'invalid')=2 END AND state='ready'"
+    ddl = f"create table shaped(doc text not null,state text not null,constraint ck check({expression}))"
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute(ddl)
+        assert guard.insert_seed_row(connection, "shaped", ddl, [("doc", "TEXT"), ("state", "TEXT")],
+                                     {"doc": "opaque", "state": "x"}) == ("", True)
+        assert connection.execute("select * from shaped").fetchall() == [("opaque", "ready")]
+
+
 @pytest.mark.parametrize("wrapper", [
     "(({}))", "({}) IS TRUE", "({})=1", "1=({})", "({}) == TRUE",
     "({}) IS NOT FALSE", "NOT NOT ({})", "likely({})", '\"likely\"({})',
@@ -2321,6 +2431,43 @@ def test_open_storage_columns_retain_semantic_seeds(tmp_path, declared, name, ch
 def test_explicit_storage_defaults_still_take_precedence(declared, expected):
     for name in ["payload_json", "created_at", "elapsed_time", "email_address", "label"]:
         assert guard.representative_value(name, declared) == expected
+
+
+@pytest.mark.parametrize("keyword", ["and", "or", "between", "case", "end"])
+@pytest.mark.parametrize("placement", ["value${}", "{}$value", "value${}$tail"])
+@pytest.mark.parametrize("kind", ["glob", "length", "substring", "equality", "json", "literal", "numeric"])
+def test_complete_unquoted_identifiers_survive_every_candidate_owner(tmp_path, keyword, placement, kind):
+    name = placement.format(keyword)
+    expressions = {
+        "glob": f"{name} GLOB 'ready'",
+        "length": f"length({name})=5",
+        "substring": f"substr({name},1,5)=peer",
+        "equality": f"{name}=peer",
+        "json": f"json_valid({name}) AND json_extract({name},'$.x')='ready'",
+        "literal": f"{name}='ready'",
+        "numeric": f"{name}=2",
+    }
+    # Real control tokens still have their meaning beside complete identifiers.
+    conjunction = f"n BETWEEN 0 AND 2 AND {name} GLOB 'A' AND CASE WHEN n=0 THEN 1 ELSE 0 END"
+    assert list(guard.conjunctive_terms(conjunction)) == [
+        "n BETWEEN 0 AND 2", f"{name} GLOB 'A'", "CASE WHEN n=0 THEN 1 ELSE 0 END",
+    ]
+    predicate = expressions[kind]
+    declared = "INTEGER" if kind == "numeric" else "TEXT"
+    witness = 2 if kind == "numeric" else '{"x":"ready"}' if kind == "json" else "ready"
+    ddl = f"create table shaped({name} {declared} not null,peer text not null,state text not null,constraint ck check({predicate}),constraint p check(peer='ready'),constraint s check(state='ready'))"
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute(ddl)
+        connection.execute("insert into shaped values(?,?,?)", (witness, "ready", "ready"))
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+    db_path = tmp_path / "complete-identifier.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(ddl)
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute(f"select count(*) from shaped where {predicate} AND peer='ready' AND state='ready'").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
 
 
 @pytest.mark.parametrize("quote", ['"', '`', '['])

--- a/tests/test_migration_release_guard.py
+++ b/tests/test_migration_release_guard.py
@@ -1851,6 +1851,111 @@ def test_native_truth_wrappers_preserve_required_consumers(tmp_path, wrapper, pr
 
 
 @pytest.mark.parametrize("wrapper", [
+    "({}) COLLATE BINARY", "({}) COLLATE NOCASE", "({}) COLLATE RTRIM",
+    '({}) COLLATE "BINARY"', "({}) COLLATE 'BINARY'",
+    "({}) COLLATE [BINARY] COLLATE `NOCASE`", "({}) /* suffix */ COLLATE/**/BINARY",
+    "-({}) COLLATE BINARY", "NOT NOT ({}) COLLATE BINARY",
+    '"likely"({}) COLLATE NOCASE', "likelihood({},.5) COLLATE BINARY",
+    "CAST({} AS TEXT) COLLATE NOCASE", "ifnull({},1) COLLATE BINARY",
+    "({}) COLLATE BINARY IS TRUE", "0<>(({}) COLLATE BINARY)",
+])
+@pytest.mark.parametrize("predicate", [
+    "length(a)=2", "a GLOB 'AB'", "substr(a,1,2)=b", "a=b",
+    "a='AB'", "json_extract(payload_json,'$.x') IS 'AB'",
+])
+@pytest.mark.parametrize("reverse", [False, True])
+def test_postfix_collations_preserve_required_consumers(tmp_path, wrapper, predicate, reverse):
+    expression = wrapper.format(predicate)
+    assert [guard.sql_projection(term, literals=True, identifiers=True).strip()
+            for term in guard.conjunctive_terms(expression)] == [predicate]
+    checks = [expression, "b='AB'", "state='ready'"]
+    if reverse:
+        checks.reverse()
+    ddl = "create table shaped(a text not null,b text not null,state text not null,payload_json text not null," + (
+        f"constraint ck check({' AND '.join(checks)}))"
+    )
+    db_path = tmp_path / "collated-truth.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(ddl)
+        connection.execute("insert into shaped values('AB','AB','ready','{\"x\":\"AB\"}')")
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+        connection.rollback()
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute(f"select count(*) from shaped where {expression} and b='AB' and state='ready'").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("wrapper", [
+    "({}) COLLATE NOCASE", "likely(({}) COLLATE BINARY)",
+    "CAST(({}) COLLATE BINARY AS BLOB)", "coalesce(({}) COLLATE RTRIM,1)",
+])
+@pytest.mark.parametrize("reverse,separate", itertools.product([False, True], repeat=2))
+def test_collated_conjunctions_preserve_required_terms_and_check_order(tmp_path, wrapper, reverse, separate):
+    terms = ["length(a)=2", "a GLOB 'A*'"]
+    if reverse:
+        terms.reverse()
+    wrapped = [wrapper.format(term) for term in terms] if separate else [wrapper.format(" AND ".join(terms))]
+    checks = [*wrapped, "state='ready'"]
+    if reverse:
+        checks.reverse()
+    ddl = "create table shaped(a text not null,state text not null," + ",".join(
+        f"constraint ck{i} check({check})" for i, check in enumerate(checks)
+    ) + ")"
+    db_path = tmp_path / "collated-conjunction.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(ddl)
+        connection.execute("insert into shaped values('AB','ready')")
+        connection.rollback()
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("select count(*) from shaped where length(a)=2 and a GLOB 'A*' and state='ready'").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("wrapper", [
+    "NOT ({}) COLLATE BINARY", "({}) COLLATE NOCASE=0",
+    "(({}) OR 1) COLLATE RTRIM", "(CASE WHEN 1 THEN 1 ELSE {} END) COLLATE BINARY",
+    "CAST({} AS BLOB) COLLATE BINARY<>0", "+CAST({} AS TEXT) COLLATE NOCASE<>0",
+    "coalesce(1,({}) COLLATE BINARY)", "ifnull(({}) COLLATE BINARY,1)=0",
+])
+@pytest.mark.parametrize("predicate", ["length(a)=2", "a GLOB 'B'", "substr(a,1,1)=b", "a=b"])
+def test_collations_do_not_expose_optional_or_nontransparent_predicates(wrapper, predicate):
+    expression = wrapper.format(predicate)
+    assert guard.column_equality_groups(expression, ["a", "b"]) == [["a"], ["b"]]
+    ddl = f"create table shaped(a text,b text,state text,constraint ck check({expression}),constraint ready check(state='ready'))"
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute(ddl)
+        connection.execute("insert into shaped values('A','R','ready')")
+        assert guard.insert_seed_row(connection, "shaped", ddl,
+                                     [("a", "TEXT"), ("b", "TEXT"), ("state", "TEXT")],
+                                     {"a": "A", "b": "R", "state": "x"}) == ("", True)
+        assert connection.execute("select a,b from shaped").fetchall() == [("A", "R"), ("A", "R")]
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("collation,left,right", [("NOCASE", "A", "a"), ("RTRIM", "A", "A ")])
+@pytest.mark.parametrize("comparison", [
+    "a COLLATE {}=b", "(a) COLLATE {}=b", "a=b COLLATE {}", "a=(b) COLLATE {}",
+    "((a) COLLATE {}=b) COLLATE BINARY", "(a=b COLLATE {}) COLLATE BINARY",
+])
+def test_operand_collations_keep_native_comparison_values(collation, left, right, comparison):
+    expression = comparison.format(collation)
+    assert guard.column_equality_groups(expression, ["a", "b"]) == [["a"], ["b"]]
+    ddl = f"create table shaped(a text,b text,state text,constraint ck check({expression}),constraint ready check(state='ready'))"
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute(ddl)
+        connection.execute("insert into shaped values(?,?,'ready')", (left, right))
+        assert guard.insert_seed_row(connection, "shaped", ddl,
+                                     [("a", "TEXT"), ("b", "TEXT"), ("state", "TEXT")],
+                                     {"a": left, "b": right, "state": "x"}) == ("", True)
+        assert connection.execute("select a,b from shaped").fetchall() == [(left, right), (left, right)]
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("wrapper", [
     "coalesce({},1)", "ifnull({},1)", 'coalesce({},NULL,1)', '"ifnull"({},1)',
     "-coalesce({},1)", "NOT NOT ifnull({},1)", "coalesce({},1)<>0",
     "0<>ifnull({},1)", "1=coalesce({},1)", "CAST(ifnull({},1) AS BLOB)",

--- a/tests/test_migration_release_guard.py
+++ b/tests/test_migration_release_guard.py
@@ -1095,6 +1095,114 @@ def test_joint_numeric_search_preserves_single_column_repairs(changed):
         assert guard.shape_proposals(connection, expression, required, values) == [(f"n{changed}", 1)]
 
 
+@pytest.mark.parametrize("count", [2, 5, 16])
+@pytest.mark.parametrize("dense,reverse", itertools.product([False, True], repeat=2))
+def test_numeric_search_preserves_sparse_and_dense_consumers(tmp_path, count, dense, reverse):
+    names = [f"n{index}" for index in range(count)]
+    terms = [f"({name}>0)" for name in names]
+    if reverse:
+        names.reverse()
+    positive = count - 1 if dense else 1
+    db_path = tmp_path / "sparse.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        columns = ','.join(f'{name} integer not null' for name in names)
+        connection.execute(f"create table shaped({columns},constraint ck check({'+'.join(terms)}={positive}))")
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("select count(*) from shaped").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("declared", ["", "TEXT"])
+@pytest.mark.parametrize("changed", range(16))
+def test_sparse_candidates_keep_turns_at_every_column_position(declared, changed):
+    # Extra TEXT context cannot change the numeric scheduling order.
+    required = [(f"n{index}", "INTEGER") for index in range(16)] + [("label", declared)]
+    values = {name: 0 for name, _ in required}
+    values["label"] = "held"
+    expression = '+'.join(f'(n{index}>0)' for index in range(16)) + f'=1 and abs(n{changed})>0'
+    with sqlite3.connect(":memory:") as connection:
+        assert guard.shape_proposals(connection, expression, required, values) == [(f"n{changed}", 1)]
+
+
+@pytest.mark.parametrize("declared", ["", "TEXT"])
+@pytest.mark.parametrize("name,check", [
+    ("payload_json", "json_valid(payload_json)"),
+    ("created_at", "datetime(created_at) is not null"),
+    ("elapsed_time", "datetime(elapsed_time) is not null"),
+    ("email_address", "email_address like '%@%'"),
+    ("label", "typeof(label)='text'"),
+])
+def test_open_storage_columns_retain_semantic_seeds(tmp_path, declared, name, check):
+    assert guard.representative_value(name, declared) == guard.representative_value(name, "TEXT")
+    db_path = tmp_path / "semantic.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table shaped({name} {declared} not null,constraint ck check({check}))")
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("select count(*) from shaped").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("declared,expected", [("BLOB", b""), ("INTEGER", 0), ("REAL", 0), ("NUMERIC", 0)])
+def test_explicit_storage_defaults_still_take_precedence(declared, expected):
+    for name in ["payload_json", "created_at", "elapsed_time", "email_address", "label"]:
+        assert guard.representative_value(name, declared) == expected
+
+
+@pytest.mark.parametrize("name,quoted", [
+    (name, quoted)
+    for name in ["random", "changes", "total_changes", "last_insert_rowid", "current_timestamp"]
+    for quoted in ([True] if name == "current_timestamp" else [False, True])
+])
+def test_function_named_columns_are_not_function_invocations(tmp_path, name, quoted):
+    column = f'"{name}"' if quoted else name
+    db_path = tmp_path / "names.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table shaped({column} integer not null,a integer not null,constraint ck check({column}=1 and a=2))")
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("select count(*) from shaped").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("extra", [
+    " and 'random changes current_timestamp' != ''",
+    " /* random() changes() current_timestamp */",
+    " -- random() changes() current_timestamp\n",
+])
+def test_context_screen_ignores_literal_and_comment_contents(extra):
+    with sqlite3.connect(":memory:") as connection:
+        proposals = guard.shape_proposals(connection, "a=1 and b=2" + extra, [("a", "INTEGER"), ("b", "INTEGER")], {"a": 0, "b": 0})
+        assert proposals == [("a", 1), ("b", 2)]
+
+
+@pytest.mark.parametrize("function", ["changes()", '"changes"()', "changes /* note */ ()", "current_timestamp", "CURRENT_DATE", "current_time"])
+@pytest.mark.parametrize("in_default", [False, True])
+def test_compiled_context_functions_defer_without_evaluating(monkeypatch, function, in_default):
+    connect = sqlite3.connect
+    statements = []
+    def traced_connect(*args, **kwargs):
+        connection = connect(*args, **kwargs)
+        connection.set_trace_callback(statements.append)
+        return connection
+    with connect(":memory:") as connection:
+        monkeypatch.setattr(guard.sqlite3, "connect", traced_connect)
+        expression = "n>0" if in_default else f"n>0 and ({function}) is not null"
+        omitted = [("tag", "TEXT", function)] if in_default else []
+        assert guard.shape_proposals(connection, expression, [("n", "INTEGER")], {"n": 0}, omitted=omitted, allow_unvalidated_numeric=False) == []
+    assert not any(statement.startswith("select coalesce(cast(") for statement in statements)
+
+
+@pytest.mark.parametrize("default", ["'random'", "'current_timestamp'", "1 /* changes() */", "1 -- random()\n"])
+def test_default_literals_and_comments_do_not_disable_joint_evaluation(default):
+    with sqlite3.connect(":memory:") as connection:
+        assert guard.shape_proposals(connection, "a=1 and b=2", [("a", "INTEGER"), ("b", "INTEGER")], {"a": 0, "b": 0}, omitted=[("tag", "TEXT", default)]) == [("a", 1), ("b", 2)]
+
+
 @pytest.mark.parametrize("order", list(itertools.permutations(range(3))))
 @pytest.mark.parametrize("separate", [False, True])
 @pytest.mark.parametrize("patterns", [("A*", "*Z"), ("[A-C]*", "*[Y-Z]"), ("*A*", "*Z*"), ("\u00e9*", "*]")])

--- a/tests/test_migration_release_guard.py
+++ b/tests/test_migration_release_guard.py
@@ -1633,12 +1633,182 @@ def test_json_literals_keep_sql_comment_markers_and_expression_text(path):
     quoted_path, quoted_value = path.replace("'", "''"), value.replace("'", "''")
     expression = f"json_extract(doc,'{quoted_path}')='{quoted_value}' and state=json_extract(doc,'{quoted_path}')"
     with sqlite3.connect(":memory:") as connection:
-        pairs = guard.json_proposals(connection, expression, ["doc", "state", "email"])
-        assert pairs[-1] == ("doc", "{}")
-        proposals = dict(reversed(pairs))  # Inspect the first/preferred value per column.
+        assignments = guard.json_proposals(connection, expression, ["doc", "state", "email"])
+        assert assignments[-1] == (("doc", "{}"),)
+        proposals = dict(assignments[0])
         assert set(proposals) == {"doc", "state"}
         assert proposals["state"] == value
         assert connection.execute("select json_extract(?,?)", (proposals["doc"], path)).fetchone()[0] == value
+
+
+@pytest.mark.parametrize("wrapper", [
+    "(({}))", "({}) IS TRUE", "({})=1", "1=({})", "({}) == TRUE",
+    "({}) IS NOT FALSE", "NOT NOT ({})", "likely({})", '\"likely\"({})',
+    "unlikely({})", "likelihood(({}),0.25)", "likely((({}) IS TRUE))",
+])
+@pytest.mark.parametrize("predicate", ["length(a)=2", "a GLOB 'AB'", "substr(a,1,2)=b", "a=b"])
+@pytest.mark.parametrize("reverse", [False, True])
+def test_required_truth_wrappers_preserve_seedable_shape_contracts(tmp_path, wrapper, predicate, reverse):
+    checks = [wrapper.format(predicate), "b='AB'", "state='ready'"]
+    if reverse:
+        checks.reverse()
+    ddl = "create table shaped(a text not null,b text not null,state text not null," + ",".join(
+        f"constraint ck{i} check({check})" for i, check in enumerate(checks)
+    ) + ")"
+    db_path = tmp_path / "required-wrapper.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(ddl)
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute(f"select count(*) from shaped where {predicate} and b='AB' and state='ready'").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("wrapper", [
+    "likely({})", "unlikely({})", "likelihood({},0.5)", "({}) IS TRUE", "({})=1", "NOT NOT ({})",
+])
+@pytest.mark.parametrize("predicate", ["length(a)=2", "a GLOB 'B'", "substr(a,1,1)=b", "a=b"])
+def test_truth_wrappers_do_not_make_optional_shapes_required(wrapper, predicate):
+    check = wrapper.format(f"({predicate}) OR 1")
+    ddl = f"create table shaped(a text,b text,state text,constraint ck check({check}),constraint ready check(state='ready'))"
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute(ddl)
+        values = {"a": "A", "b": "R", "state": "x"}
+        assert guard.insert_seed_row(connection, "shaped", ddl, [(name, "TEXT") for name in values], values) == ("", True)
+        assert connection.execute("select * from shaped").fetchall() == [("A", "R", "ready")]
+
+
+@pytest.mark.parametrize("wrapper", ["({}) IS FALSE", "({})=0", "NOT ({})", "coalesce(({}),0)=0", "iif(({}),0,1)"])
+def test_false_wrappers_do_not_become_required_equalities(wrapper):
+    expression = wrapper.format("a=b")
+    assert guard.column_equality_groups(expression, ["a", "b"]) == [["a"], ["b"]]
+
+
+@pytest.mark.parametrize("name,value,wrapper", [("TRUE", 0, "({}) IS TRUE"), ("false", 1, "({}) IS NOT FALSE")])
+@pytest.mark.parametrize("predicate", ["length(a)=2", "a GLOB 'B'", "substr(a,1,1)=b", "a=b"])
+@pytest.mark.parametrize("omitted,strict", itertools.product([False, True], repeat=2))
+def test_declared_boolean_names_are_not_truth_wrappers(name, value, wrapper, predicate, omitted, strict):
+    checks = [wrapper.format(predicate), "a='A'", "b='R'", "state='ready'"]
+    ddl = f"create table shaped(a text,b text,state text,{name} INTEGER DEFAULT {value}," + ",".join(
+        f"constraint ck{i} check({check})" for i, check in enumerate(checks)
+    ) + ")" + (" STRICT" if strict else "")
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute(ddl)
+        values = {"a": "A", "b": "R", "state": "x"}
+        required = [(column, "TEXT") for column in values]
+        if not omitted:
+            values[name] = value
+            required.append((name, "INTEGER"))
+        assert guard.insert_seed_row(connection, "shaped", ddl, required, values) == ("", True)
+        assert connection.execute("select a,b,state from shaped").fetchall() == [("A", "R", "ready")]
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("order", list(itertools.permutations(range(3))))
+@pytest.mark.parametrize("dependency", ["lower(a)=b", "b=lower(a)", 'b="lower"(a)', "trim(a)=b"])
+@pytest.mark.parametrize("separate", [False, True])
+def test_independent_glob_witnesses_retain_coordinated_alternatives(tmp_path, order, dependency, separate):
+    terms = ["a NOT GLOB '*[^a]*'", "b GLOB 'a'", dependency]
+    terms = [terms[i] for i in order]
+    checks = ",".join(f"constraint ck{i} check({term})" for i, term in enumerate(terms)) if separate else f"constraint ck check({' AND '.join(terms)})"
+    ddl = f"create table shaped(a text not null,b text not null,{checks})"
+    db_path = tmp_path / "coordinated-glob.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(ddl)
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        rows = connection.execute("select * from shaped").fetchall()
+        assert len(rows) >= guard.SEED_ROWS and set(rows) == {("a", "a")}
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("equality", ["=", "==", "IS"])
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize("declared", ["TEXT", "DATE", "BLOB"])
+def test_bare_equality_groups_propagate_values_without_shapes(tmp_path, equality, reverse, declared):
+    terms = ["b='A'", f"a {equality} b", f"c {equality} a"]
+    if reverse:
+        terms.reverse()
+    checks = ",".join(f"constraint ck{i} check({term})" for i, term in enumerate(terms))
+    db_path = tmp_path / "bare-equality.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table shaped(a {declared} not null,b {declared} not null,c {declared} not null,{checks})")
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        rows = connection.execute("select * from shaped").fetchall()
+        assert len(rows) >= guard.SEED_ROWS and set(rows) == {("A", "A", "A")}
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("value,declared", [(b"A", "BLOB"), (17, "INTEGER"), (1.5, "REAL"), ("A", "TEXT")])
+def test_bare_equality_alternatives_preserve_native_member_storage(value, declared):
+    with sqlite3.connect(":memory:") as connection:
+        ddl = f"create table shaped(a {declared},b {declared},constraint same check(a=b))"
+        connection.execute(ddl)
+        values = {"a": guard.representative_value("a", declared), "b": value}
+        proposed = guard.shape_proposals(connection, "a=b", [("a", declared), ("b", declared)], values)
+        assert (("a", value), ("b", value)) in proposed.semantic_fallback
+        originals = {(type(candidate), candidate) for candidate in values.values()}
+        assert all((type(candidate), candidate) in originals for assignment in proposed.semantic_fallback for _, candidate in assignment)
+        assert guard.insert_seed_row(connection, "shaped", ddl, [("a", declared), ("b", declared)], values) == ("", True)
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("function", ["lower", '"lower"', "trim", "likely"])
+@pytest.mark.parametrize("reverse,separate", itertools.product([False, True], repeat=2))
+@pytest.mark.parametrize("path", ["$.x", "$.it's"])
+def test_json_functional_candidates_retain_their_constructed_document(tmp_path, function, reverse, separate, path):
+    path_sql = path.replace("'", "''")
+    member = f"json_extract(doc,'{path_sql}')"
+    dependency = f"state IS {function}({member})" if not reverse else f"{function}({member}) IS state"
+    terms = [f"json_valid(doc) AND {member}='ready'", f"json_valid(doc) AND {dependency}"]
+    if reverse:
+        terms.reverse()
+    checks = ",".join(f"constraint ck{i} check({term})" for i, term in enumerate(terms)) if separate else f"constraint ck check({' AND '.join(terms)})"
+    ddl = f"create table shaped(doc text not null,state text not null,{checks})"
+    db_path = tmp_path / "functional-json.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(ddl)
+        assignments = guard.json_proposals(connection, terms[0], ["doc", "state"], text_constraints=" AND ".join(f"({term})" for term in terms))
+        for assignment in assignments:
+            row = dict(assignment)
+            if "state" in row:
+                assert connection.execute("select json_extract(?,?)", (row["doc"], path)).fetchone()[0] == row["state"]
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        rows = connection.execute("select state from shaped").fetchall()
+        assert len(rows) >= guard.SEED_ROWS and set(rows) == {("ready",)}
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("producer", ["glob", "json"])
+@pytest.mark.parametrize("reverse,separate", itertools.product([False, True], repeat=2))
+def test_semantic_candidates_follow_dependencies_without_poisoning_disconnected_columns(tmp_path, producer, reverse, separate):
+    if producer == "glob":
+        source = "code GLOB 'ready'"
+        dependency = "state=lower(code)"
+    else:
+        source = "json_valid(code) AND json_extract(code,'$.x')='ready'"
+        dependency = "json_valid(code) AND state IS lower(json_extract(code,'$.x'))"
+    terms = [source, dependency, "label=trim(state)", "json_extract(payload_json,'$.x')=1", "instr(email,'@')>0"]
+    if reverse:
+        terms.reverse()
+    # JSON remains guarded when its dependency precedes its defining CHECK.
+    checks = ",".join(f"constraint ck{i} check({term})" for i, term in enumerate(terms)) if separate else f"constraint ck check({' AND '.join(terms)})"
+    ddl = f"create table shaped(code text not null,state text not null,label text not null,payload_json text not null,email text not null,{checks})"
+    db_path = tmp_path / "semantic-recipients.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(ddl)
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        rows = connection.execute("select state,label,json_valid(payload_json),instr(email,'@')>0 from shaped").fetchall()
+        assert len(rows) >= guard.SEED_ROWS and set(rows) == {("ready", "ready", 1, 1)}
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
 
 
 @pytest.mark.parametrize("note", [

--- a/tests/test_migration_release_guard.py
+++ b/tests/test_migration_release_guard.py
@@ -1077,7 +1077,8 @@ def test_joint_numeric_evaluation_has_a_finite_budget():
     with sqlite3.connect(":memory:") as connection:
         connection.set_trace_callback(statements.append)
         assert guard.shape_proposals(connection, expression, required, values) == []
-    assert len(statements) == guard.SEED_ATTEMPTS
+    evaluations = [statement for statement in statements if statement.startswith("select coalesce(cast(")]
+    assert len(evaluations) == guard.SEED_ATTEMPTS
 
 
 @pytest.mark.parametrize("changed", range(6))
@@ -1124,7 +1125,8 @@ def test_glob_classes_follow_sqlite_token_semantics(tmp_path, pattern):
         assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
 
 
-def test_glob_intersection_matches_sqlite_over_a_finite_domain():
+@pytest.mark.parametrize("negate_left,negate_right", itertools.product([False, True], repeat=2))
+def test_glob_intersection_matches_sqlite_over_a_finite_domain(negate_left, negate_right):
     alphabet = "ab[]-"
     patterns = ("*", "a*", "*b", "?a", "[ab]", "[]]", "[^]]", "[[]", "[-a]", "a**b", "[a-]", "[", "[]", "[^]")
     with sqlite3.connect(":memory:") as connection:
@@ -1134,20 +1136,26 @@ def test_glob_intersection_matches_sqlite_over_a_finite_domain():
         ])
         for left, right, width in itertools.product(patterns, patterns, range(4)):
             expected = connection.execute(
-                "select value from domain where width = ? and value glob ? and value glob ? limit 1",
+                f"select value from domain where width = ? and value {'not ' if negate_left else ''}glob ? and value {'not ' if negate_right else ''}glob ? limit 1",
                 (width, left, right),
             ).fetchone()
-            witness = guard.glob_witness(connection, (left, right), width=width, alphabet=alphabet)
+            patterns = tuple(pattern for pattern, negated in [(left, negate_left), (right, negate_right)] if not negated)
+            excluded = tuple(pattern for pattern, negated in [(left, negate_left), (right, negate_right)] if negated)
+            witness = guard.glob_witness(connection, patterns, excluded=excluded, width=width, alphabet=alphabet)
             assert (witness is None) == (expected is None), (left, right, width, witness)
             if witness is not None:
                 assert len(witness) == width
-                assert connection.execute("select ? glob ? and ? glob ?", (witness, left, witness, right)).fetchone()[0]
+                assert connection.execute(
+                    f"select ? {'not ' if negate_left else ''}glob ? and ? {'not ' if negate_right else ''}glob ?",
+                    (witness, left, witness, right),
+                ).fetchone()[0]
 
 
 def test_glob_search_has_explicit_width_pattern_and_state_limits(monkeypatch):
     with sqlite3.connect(":memory:") as connection:
         assert guard.glob_witness(connection, ("*",), width=guard.SEED_TEXT_LIMIT + 1) is None
         assert guard.glob_witness(connection, ("a" * (guard.SEED_TEXT_LIMIT + 1),)) is None
+        assert guard.glob_witness(connection, (), excluded=("a" * (guard.SEED_TEXT_LIMIT + 1),)) is None
         monkeypatch.setattr(guard, "SEED_GLOB_STATES", 3)
         assert guard.glob_witness(connection, ("????",)) is None
 
@@ -1208,6 +1216,121 @@ def test_numeric_check_context_includes_omitted_columns(column, check, expected,
         objection, settled = guard.insert_seed_row(connection, "shaped", ddl, [("n", "INTEGER")], {"n": 0})
         assert (objection, settled) == ("", True)
         assert connection.execute("select n, tag from shaped").fetchall() == [(1, expected)]
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("declared", ["INTEGER", "NUMERIC", "BOOLEAN", "DECIMAL(10,2)", "REAL", "TEXT", "BLOB", ""])
+@pytest.mark.parametrize("default", ["'abc'", "' 001 '", "'3.0e+5'", "'12x'", "x'6162'", "NULL", "1.5", "'9223372036854775808'"])
+def test_numeric_context_matches_real_default_storage(declared, default):
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute(f"create table sample(tag {declared} default {default})")
+        connection.execute("insert into sample default values")
+        expected = connection.execute("select tag, typeof(tag) from sample").fetchone()
+        value_sql, type_sql = connection.execute("select quote(tag), quote(typeof(tag)) from sample").fetchone()
+        ddl = f"create table shaped(n integer not null, tag {declared} default {default}, constraint ck check(typeof(n) = 'integer' and n > 0 and tag is {value_sql} and typeof(tag) = {type_sql}))"
+        connection.execute(ddl)
+        assert guard.insert_seed_row(connection, "shaped", ddl, [("n", "INTEGER")], {"n": 0}) == ("", True)
+        assert connection.execute("select tag, typeof(tag) from shaped").fetchone() == expected
+        assert connection.execute("select name from sqlite_temp_master").fetchall() == []
+
+
+@pytest.mark.parametrize("declared", ["INTEGER", "NUMERIC", "BOOLEAN", "DECIMAL(10,2)", "REAL", "TEXT", "BLOB", "", "CHARINT", "FLOATING POINT", "STRING"])
+@pytest.mark.parametrize("offered", ["abc", " 001 ", "3.0e+5", "12x", b"ab", None, 1.5, "9223372036854775808"])
+def test_numeric_context_matches_real_supplied_storage(declared, offered):
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute(f"create table sample(tag {declared})")
+        connection.execute("insert into sample values (?)", (offered,))
+        value_sql, type_sql = connection.execute("select quote(tag), quote(typeof(tag)) from sample").fetchone()
+        expression = f"n > 0 and tag is {value_sql} and typeof(tag) = {type_sql}"
+        proposals = guard.shape_proposals(connection, expression, [("n", "INTEGER"), ("tag", declared)], {"n": 0, "tag": offered})
+        assert ("n", 1) in proposals
+        assert not any(name == "tag" for name, _ in proposals)
+        assert connection.execute("select name from sqlite_temp_master").fetchall() == []
+
+
+@pytest.mark.parametrize("expression", ["n > 0", "n > 0 and n < 0", "n > 0 and missing(n)"])
+def test_candidate_evaluation_preserves_connection_schema_and_data(expression):
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute("create table source(n integer)")
+        connection.execute("insert into source values (37)")
+        connection.execute("create temp table keep(n text)")
+        connection.execute("insert into keep values ('preserved')")
+        schema = connection.execute("select * from sqlite_master").fetchall()
+        temp_schema = connection.execute("select * from sqlite_temp_master").fetchall()
+        guard.shape_proposals(connection, expression, [("n", "INTEGER")], {"n": 0})
+        assert connection.execute("select * from sqlite_master").fetchall() == schema
+        assert connection.execute("select * from sqlite_temp_master").fetchall() == temp_schema
+        assert connection.execute("select * from source").fetchall() == [(37,)]
+        assert connection.execute("select * from keep").fetchall() == [("preserved",)]
+
+
+@pytest.mark.parametrize("count", [2, 6, 16])
+@pytest.mark.parametrize("reverse_columns,reverse_clauses,reverse_operands", itertools.product([False, True], repeat=3))
+@pytest.mark.parametrize("comparison", ["=", "==", ">=", "<", "!="])
+def test_predicate_ranked_numeric_domains_seed_nonuniform_rows(tmp_path, count, reverse_columns, reverse_clauses, reverse_operands, comparison):
+    names = [f"n{index}" for index in range(1, count + 1)]
+    clauses = [f"{index} {comparison} {name}" if reverse_operands else f"{name} {comparison} {index}" for index, name in enumerate(names, 1)]
+    if reverse_columns:
+        names.reverse()
+    if reverse_clauses:
+        clauses.reverse()
+    db_path = tmp_path / "vibe.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table shaped (id integer primary key, {', '.join(name + ' integer not null' for name in names)}, constraint ck check ({' and '.join(clauses)}))")
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("select count(*) from shaped").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("declared,storage", [("INTEGER", "integer"), ("NUMERIC", "integer"), ("BOOLEAN", "integer"), ("DECIMAL(10,2)", "integer"), ("FLOATING POINT", "integer"), ("REAL", "real"), ("DOUBLE PRECISION", "real"), ("STRING", "integer")])
+def test_numeric_repair_uses_sqlite_affinity_classification(tmp_path, declared, storage):
+    db_path = tmp_path / "vibe.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table shaped(n {declared} not null, constraint ck check(typeof(n)='{storage}' and n > 0))")
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("select count(*) from shaped").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("equality", ["=", "==", "IS"])
+@pytest.mark.parametrize("reverse_operands,reverse_checks", itertools.product([False, True], repeat=2))
+@pytest.mark.parametrize("source", ["a glob 'R-[A-C][0-9]'", "a in ('R-A0')"])
+def test_substring_dependencies_use_normalized_equality(tmp_path, equality, reverse_operands, reverse_checks, source):
+    left, right = ('substr("C", 1, 4)', '"A"')
+    if reverse_operands:
+        left, right = right, left
+    checks = [f"constraint ck_a check({source})", f"constraint ck_c check(length(c)=9 and {left} {equality} {right})"]
+    if reverse_checks:
+        checks.reverse()
+    db_path = tmp_path / "vibe.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table shaped(id integer primary key, a text not null, c text not null, {', '.join(checks)})")
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("select count(*) from shaped").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("order", list(itertools.permutations(range(3))))
+@pytest.mark.parametrize("separate", [False, True])
+def test_positive_and_negative_globs_share_one_witness(tmp_path, order, separate):
+    requirements = ["length(code)=2", "code glob '[A-Z][0-9]'", "code not glob '[A-Z]0'"]
+    expressions = [requirements[index] for index in order]
+    if not separate:
+        expressions = [" and ".join(expressions)]
+    checks = ", ".join(f"constraint ck_{index} check({expression})" for index, expression in enumerate(expressions))
+    db_path = tmp_path / "vibe.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table shaped(id integer primary key, code text not null, {checks})")
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("select count(*) from shaped").fetchone()[0] >= guard.SEED_ROWS
         assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
 
 

--- a/tests/test_migration_release_guard.py
+++ b/tests/test_migration_release_guard.py
@@ -1024,6 +1024,149 @@ def test_numeric_candidates_use_the_column_affinity():
         assert ("n", -1) not in proposals
 
 
+@pytest.mark.parametrize("declared", ["INTEGER", "REAL"])
+@pytest.mark.parametrize("shape", ["length(n)=2", "n glob '[1-9][0-9]'", "substr(n,1,2)='10'"])
+@pytest.mark.parametrize("reverse", [False, True])
+def test_strict_numeric_shape_repairs_remain_storable(tmp_path, declared, shape, reverse):
+    if declared == "REAL":
+        shape = shape.replace("length(n)=2", "length(n)=4").replace("'[1-9][0-9]'", "'[1-9][0-9].0'")
+    clauses = [shape, "n=10"]
+    if reverse:
+        clauses.reverse()
+    db_path = tmp_path / "strict-shape.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table shaped(n {declared} not null,constraint ck check({' and '.join(clauses)})) STRICT")
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("select count(*) from shaped where n=10").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("changed", range(17))
+def test_initial_sparse_round_reaches_every_column_before_joint_search(changed):
+    required = [(f"n{i}", "INTEGER") for i in range(17)]
+    expression = '+'.join(f'(n{i}>0)' for i in range(17)) + f'=1 and abs(n{changed})>0'
+    with sqlite3.connect(":memory:") as connection:
+        assert guard.shape_proposals(connection, expression, required, dict.fromkeys((n for n, _ in required), 0)).derived == [(f"n{changed}", 1)]
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize("equality", ["=", "==", "IS"])
+@pytest.mark.parametrize("literal", ["'ready'", "'it''s ready'", "17", "1.5"])
+@pytest.mark.parametrize("declared", ["", "TEXT", "NUMERIC"])
+def test_json_extraction_dependencies_keep_member_values(tmp_path, reverse, equality, literal, declared):
+    dependency = f"state {equality} json_extract(doc,'$.x')"
+    if reverse:
+        dependency = f"json_extract(doc,'$.x') {equality} state"
+    db_path = tmp_path / "json-dependency.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table shaped(doc text not null,state {declared} not null,constraint ck check(json_valid(doc) and json_extract(doc,'$.x')={literal} and {dependency}))")
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("select count(*) from shaped where state=json_extract(doc,'$.x')").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("alias", ["rowid", "_rowid_", "oid", '"ROWID"', '[oid]', '`_rowid_`'])
+def test_implicit_row_positions_are_decided_by_actual_insert(tmp_path, alias):
+    db_path = tmp_path / "row-position.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table shaped(n integer not null,constraint ck check(n>=1 and n={alias}))")
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("select count(*) from shaped where n=rowid").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("alias", ["rowid", "_rowid_", "oid", "ROWID"])
+@pytest.mark.parametrize("omitted", [False, True])
+def test_declared_rowid_names_are_ordinary_candidate_context(alias, omitted):
+    required, values = [("n", "INTEGER")], {"n": 0}
+    defaults = []
+    if omitted:
+        defaults = [(alias, "INTEGER", "2")]
+    else:
+        required.append((alias, "INTEGER"))
+        values[alias] = 2
+    with sqlite3.connect(":memory:") as connection:
+        proposals = guard.shape_proposals(connection, f'n>0 and n="{alias}" and "{alias}"=2', required, values, omitted=defaults)
+        assert proposals.derived == [("n", 2)]
+        assert proposals.numeric_fallback == []
+
+
+@pytest.mark.parametrize("member_type", list(guard.JSON_TYPE_MEMBERS))
+@pytest.mark.parametrize("reverse", [False, True])
+def test_json_type_dependencies_use_sqlite_member_semantics(tmp_path, member_type, reverse):
+    dependency = "tag=json_type(doc,'$.x')" if not reverse else "json_type(doc,'$.x')=tag"
+    db_path = tmp_path / "json-type-dependency.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table shaped(doc text not null,tag text not null,constraint ck check(json_valid(doc) and json_type(doc,'$.x')='{member_type}' and {dependency}))")
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("select count(*) from shaped where tag=json_type(doc,'$.x')").fetchone()[0] >= guard.SEED_ROWS
+
+
+@pytest.mark.parametrize("payload", [
+    "x=substr(email,5,1)", "substr(email,5,1)=x", "length(email)=2",
+    "email glob '[A-Z]*'", "json_extract(email,'$.x')='ready'", "n=9999",
+])
+@pytest.mark.parametrize("wrapper", ["/* {} */", "-- {}\n", "'{}'", '"{}"', '`{}`', '[{}]'])
+def test_candidate_extractors_share_opaque_sql_boundaries(payload, wrapper):
+    encoded = payload.replace("'", "''") if wrapper == "'{}'" else payload
+    expression = wrapper.format(encoded)
+    assert list(guard.substring_requirements(expression)) == []
+    assert list(guard.sql_matches(guard.JSON_REQUIREMENT, expression)) == []
+    with sqlite3.connect(":memory:") as connection:
+        proposals = guard.shape_proposals(connection, expression, [("email", "TEXT"), ("x", "TEXT"), ("n", "INTEGER")], {"email": "seed@example.invalid", "x": "x", "n": 0})
+        assert proposals.derived == []
+        assert proposals.numeric_fallback == []
+
+
+@pytest.mark.parametrize("literal", ["'(' || ')'", "'x)''('" , "'/* ) */ -- ('"])
+def test_check_body_boundaries_ignore_quoted_and_commented_parentheses(literal):
+    expression = f"length({literal})>0 /* ) */ and n>0 -- (\n"
+    ddl = f"create table shaped(n integer,constraint ck check({expression}))"
+    assert guard.check_expression(ddl, "ck") == expression
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute(ddl)
+        connection.execute("insert into shaped values(1)")
+
+
+@pytest.mark.parametrize("path", ["$.x", "$.it's"])
+def test_json_literals_keep_sql_comment_markers_and_expression_text(path):
+    value = "/* n=9999 */ -- length(email)=2; json_extract(email,'$.x')='bad'"
+    quoted_path, quoted_value = path.replace("'", "''"), value.replace("'", "''")
+    expression = f"json_extract(doc,'{quoted_path}')='{quoted_value}' and state=json_extract(doc,'{quoted_path}')"
+    with sqlite3.connect(":memory:") as connection:
+        proposals = dict(guard.json_proposals(connection, expression, ["doc", "state", "email"]))
+        assert set(proposals) == {"doc", "state"}
+        assert proposals["state"] == value
+        assert connection.execute("select json_extract(?,?)", (proposals["doc"], path)).fetchone()[0] == value
+
+
+@pytest.mark.parametrize("note", [
+    "1 /* x=substr(email_address,5,1) */",
+    "1 -- x=substr(email_address,5,1)\n",
+    "length('x=substr(email_address,5,1)')>0",
+    "length('quoted '' x=substr(email_address,5,1)')>0",
+])
+@pytest.mark.parametrize("order", list(itertools.permutations(range(3))))
+def test_dependency_text_is_not_executable_sql(tmp_path, note, order):
+    clauses = ["constraint ck_email check(instr(email_address,'@')>1)", f"constraint ck_note check({note})", "constraint ck_state check(state='ready')"]
+    db_path = tmp_path / "opaque-sql.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table shaped(email_address text not null,x text not null,state text not null,{','.join(clauses[i] for i in order)})")
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("select count(*) from shaped where instr(email_address,'@')>1 and state='ready'").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
 @pytest.mark.parametrize("unavailable", [(), ("generated",)])
 def test_shape_candidates_keep_derived_repairs_separate_from_numeric_guesses(unavailable):
     expression = "length(code)=4 and n>0" + (" and generated=0" if unavailable else "")

--- a/tests/test_migration_release_guard.py
+++ b/tests/test_migration_release_guard.py
@@ -1851,6 +1851,60 @@ def test_native_truth_wrappers_preserve_required_consumers(tmp_path, wrapper, pr
 
 
 @pytest.mark.parametrize("wrapper", [
+    "coalesce({},1)", "ifnull({},1)", 'coalesce({},NULL,1)', '"ifnull"({},1)',
+    "-coalesce({},1)", "NOT NOT ifnull({},1)", "coalesce({},1)<>0",
+    "0<>ifnull({},1)", "1=coalesce({},1)", "CAST(ifnull({},1) AS BLOB)",
+])
+@pytest.mark.parametrize("predicate", [
+    "length(a)=2", "a GLOB 'AB'", "substr(a,1,2)=b", "a=b",
+    "a='AB'", "json_extract(payload_json,'$.x') IS 'AB'",
+])
+@pytest.mark.parametrize("reverse", [False, True])
+def test_null_fallback_truth_guards_preserve_required_consumers(tmp_path, wrapper, predicate, reverse):
+    expression = wrapper.format(predicate)
+    assert [guard.sql_projection(term, literals=True, identifiers=True).strip()
+            for term in guard.conjunctive_terms(expression)] == [predicate]
+    checks = [expression, "b='AB'", "state='ready'"]
+    if reverse:
+        checks.reverse()
+    ddl = "create table shaped(a text not null,b text not null,state text not null,payload_json text not null," + ",".join(
+        f"constraint ck{i} check({check})" for i, check in enumerate(checks)
+    ) + ")"
+    db_path = tmp_path / "null-fallback-truth.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(ddl)
+        connection.execute("insert into shaped values('AB','AB','ready','{\"x\":\"AB\"}')")
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+        connection.rollback()
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute(f"select count(*) from shaped where {expression} and b='AB' and state='ready'").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("wrapper", [
+    "coalesce(1,{})", "ifnull(1,{})", "coalesce(NULL,1,{})",
+    "coalesce(({}) OR 1,1)", "ifnull(CASE WHEN 1 THEN 1 ELSE {} END,1)",
+    "coalesce({},1)=0", "NOT ifnull({},1)", "coalesce(CAST({} AS BLOB),1)<>0",
+    "ifnull(+CAST({} AS TEXT),1)<>0",
+])
+@pytest.mark.parametrize("predicate", ["length(a)=2", "a GLOB 'B'", "substr(a,1,1)=b", "a=b"])
+def test_null_fallback_arguments_and_negative_compositions_are_not_requirements(wrapper, predicate):
+    expression = wrapper.format(predicate)
+    assert guard.column_equality_groups(expression, ["a", "b"]) == [["a"], ["b"]]
+    ddl = f"create table shaped(a text,b text,state text,constraint ck check({expression}),constraint ready check(state='ready'))"
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute(ddl)
+        connection.execute("insert into shaped values('A','R','ready')")
+        assert guard.insert_seed_row(connection, "shaped", ddl,
+                                     [("a", "TEXT"), ("b", "TEXT"), ("state", "TEXT")],
+                                     {"a": "A", "b": "R", "state": "x"}) == ("", True)
+        assert connection.execute("select a,b from shaped").fetchall() == [("A", "R"), ("A", "R")]
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("wrapper", [
     "CAST({} AS BLOB)<>0", "(CAST({} AS BLOB))!=0", "0<>CAST({} AS BLOB)",
     "+CAST({} AS TEXT)<>0", "(+CAST({} AS TEXT)) IS NOT 0",
     "CAST(({}) OR 1 AS BLOB)", "CAST(NOT({}) AS TEXT)",
@@ -2406,6 +2460,55 @@ def test_guarded_json_inputs_are_repaired_before_enabling_candidates(tmp_path, g
         assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
 
 
+@pytest.mark.parametrize("declared", ["TEXT", "INTEGER", "BLOB"])
+@pytest.mark.parametrize("equality", ["=", "==", "IS"])
+@pytest.mark.parametrize("nullable,reverse,functional", itertools.product([False, True], repeat=3))
+def test_json_missing_dependents_respect_native_nullability(tmp_path, declared, equality, nullable, reverse, functional):
+    member = "json_extract(doc,'$.x')"
+    if functional:
+        member = f"lower({member})"
+    dependency = f"{member} {equality} state" if reverse else f"state {equality} {member}"
+    checks = ["json_valid(doc)", "json_extract(doc,'$.y') IS 'B'", dependency, "peer IS json_extract(doc,'$.y')"]
+    columns = ["doc TEXT NOT NULL", f"state {declared}" + ("" if nullable else " NOT NULL"), "peer TEXT NOT NULL"]
+    if reverse:
+        columns.reverse()
+    ddl = "create table shaped(" + ",".join(columns) + ",constraint ck check(" + " AND ".join(checks) + "))"
+    db_path = tmp_path / "json-null-dependent.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(ddl)
+        initial = guard.representative_value("state", declared)
+        if nullable or equality != "IS":
+            state = None if equality == "IS" else initial
+            connection.execute("insert into shaped(doc,state,peer) values(?,?,?)", ('{"y":"B"}', state, "B"))
+            assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+            connection.rollback()
+        assignments = guard.json_proposals(connection, " AND ".join(checks), ["doc", "state", "peer"],
+                                             not_null=[] if nullable else ["state", "peer"])
+        if not nullable:
+            assert all(dict(assignment).get("state", initial) is not None for assignment in assignments)
+    short, _ = guard.seed_representative_rows(db_path)
+    with sqlite3.connect(db_path) as connection:
+        rows = connection.execute("select doc,state,peer from shaped").fetchall()
+        if not nullable and equality == "IS":
+            assert short and not rows
+        else:
+            assert len(rows) >= guard.SEED_ROWS
+            if nullable and (not functional or equality == "IS"):
+                # Native NULL candidates remain available, but duplicate NULLs
+                # are not the guard's promised non-NULL repetition evidence.
+                message = "no two rows share a state, though a row repeating it was accepted"
+                assert short == {"shaped": message}
+                assert guard.seeded_rows_prove_repetition(connection, "shaped", ["state"]) == message
+            else:
+                assert short == {}
+            assert all(peer == "B" for _, _, peer in rows)
+            if not nullable:
+                assert all(state is not None for _, state, _ in rows)
+            elif equality == "IS":
+                assert all(state is None for _, state, _ in rows)
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
 @pytest.mark.parametrize("order", list(itertools.permutations(["a", "b", "c"])))
 def test_repeat_repairs_cannot_change_the_column_being_proved(tmp_path, order):
     ddl = "create table shaped(" + ",".join(f"{name} text not null" for name in order) + ",constraint ck check(a=b AND lower(b)=c))"
@@ -2671,6 +2774,59 @@ def test_equal_shape_groups_survive_substring_repairs(tmp_path, order, reverse):
     with sqlite3.connect(db_path) as connection:
         assert connection.execute('select count(*) from shaped where state=code and substr(code,1,2)=source').fetchone()[0] >= guard.SEED_ROWS
         assert connection.execute('pragma integrity_check').fetchall() == [('ok',)]
+
+
+@pytest.mark.parametrize("pattern,width,start,size", [("A*", 2, 1, 1), ("ÅB*", 3, 2, 1), ("A*", 2, 1, 0)])
+@pytest.mark.parametrize("equality", ["=", "==", "IS"])
+@pytest.mark.parametrize("reverse,separate", itertools.product([False, True], repeat=2))
+def test_shaped_substrings_propagate_native_slices_atomically(tmp_path, pattern, width, start, size, equality, reverse, separate):
+    left, right = f"substr(b,{start},{size})", "a"
+    if reverse:
+        left, right = right, left
+    terms = [f"b GLOB '{pattern}'", f"length(b)={width}", f"length(a)={size}", f"{left} {equality} {right}"]
+    if reverse:
+        terms.reverse()
+    columns = ["a TEXT NOT NULL", "b TEXT NOT NULL"]
+    if reverse:
+        columns.reverse()
+    checks = ",".join(f"constraint ck{i} check({term})" for i, term in enumerate(terms)) if separate else f"constraint ck check({' AND '.join(terms)})"
+    ddl = "create table shaped(" + ",".join(columns) + "," + checks + ")"
+    db_path = tmp_path / "native-shaped-slice.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(ddl)
+        b = pattern[:-1].ljust(width, "0")
+        a = connection.execute("select substr(?,?,?)", (b, start, size)).fetchone()[0]
+        connection.execute("insert into shaped(a,b) values(?,?)", (a, b))
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+        connection.rollback()
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute(f"select count(*) from shaped where {' AND '.join(terms)}").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("order", list(itertools.permutations(["a", "b", "c"])))
+@pytest.mark.parametrize("reverse,alias", itertools.product([False, True], repeat=2))
+def test_shaped_substring_chains_keep_witnesses_and_equality_aliases(tmp_path, order, reverse, alias):
+    terms = ["c GLOB 'A*'", "length(c)=3", "length(b)=2", "length(a)=1", "substr(c,1,2)=b", "substr(b,1,1)=a"]
+    columns = [f"{name} TEXT NOT NULL" for name in order]
+    if alias:
+        columns.append("peer TEXT NOT NULL")
+        terms.append("peer=b")
+    if reverse:
+        terms.reverse()
+    ddl = "create table shaped(" + ",".join(columns) + "," + ",".join(
+        f"constraint ck{i} check({term})" for i, term in enumerate(terms)
+    ) + ")"
+    db_path = tmp_path / "shaped-slice-chain.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(ddl)
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute(f"select count(*) from shaped where {' AND '.join(terms)}").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
 
 
 @pytest.mark.parametrize("reverse_checks,reverse_columns", itertools.product([False, True], repeat=2))

--- a/tests/test_migration_release_guard.py
+++ b/tests/test_migration_release_guard.py
@@ -1019,9 +1019,31 @@ def test_shape_repairs_follow_constraints_not_column_names(tmp_path, minimum, or
 
 def test_numeric_candidates_use_the_column_affinity():
     with sqlite3.connect(":memory:") as connection:
-        proposals = guard.shape_proposals(connection, "n > '0'", [("n", "INTEGER")], {"n": 0})
+        proposals = guard.shape_proposals(connection, "n > '0'", [("n", "INTEGER")], {"n": 0}).derived
         assert ("n", 1) in proposals
         assert ("n", -1) not in proposals
+
+
+@pytest.mark.parametrize("unavailable", [(), ("generated",)])
+def test_shape_candidates_keep_derived_repairs_separate_from_numeric_guesses(unavailable):
+    expression = "length(code)=4 and n>0" + (" and generated=0" if unavailable else "")
+    with sqlite3.connect(":memory:") as connection:
+        proposals = guard.shape_proposals(
+            connection, expression, [("code", "TEXT"), ("n", "INTEGER")],
+            {"code": "x000", "n": 0}, unavailable=unavailable,
+        )
+        if unavailable:
+            assert proposals.derived == []
+            assert ("n", 1) in proposals.numeric_fallback
+        else:
+            assert proposals.derived == [("n", 1)]
+            assert proposals.numeric_fallback == []
+        shaped = guard.shape_proposals(
+            connection, expression, [("code", "TEXT"), ("n", "INTEGER")],
+            {"code": "x", "n": 0}, unavailable=unavailable,
+        )
+        assert ("code", "x000") in shaped.derived
+        assert not any(name == "code" for name, _ in shaped.numeric_fallback)
 
 
 @pytest.mark.parametrize("pattern,width", [("[A-Z]*", 4), ("*[A-Z]", 4), ("[A-Z]*[A-Z]", 4), ("*[A-Z]*", 4), ("[A-Z]???", 4), ("[A-Z][A-Z][A-Z][A-Z]", 4), ("*", 0), ("*", guard.SEED_TEXT_LIMIT)])
@@ -1081,7 +1103,9 @@ def test_joint_numeric_evaluation_has_a_finite_budget(monkeypatch):
             candidate.set_trace_callback(statements.append)
             return candidate
         monkeypatch.setattr(guard.sqlite3, "connect", traced_connect)
-        assert guard.shape_proposals(connection, expression, required, values) == []
+        proposals = guard.shape_proposals(connection, expression, required, values)
+        assert proposals.derived == []
+        assert proposals.numeric_fallback == []
     evaluations = [statement for statement in statements if statement.startswith("select coalesce(cast(")]
     assert len(evaluations) == guard.SEED_ATTEMPTS
 
@@ -1092,7 +1116,138 @@ def test_joint_numeric_search_preserves_single_column_repairs(changed):
     values = {name: 0 for name, _ in required}
     expression = " and ".join(f"{name} >= 0" for name in values) + f" and n{changed} > 0"
     with sqlite3.connect(":memory:") as connection:
-        assert guard.shape_proposals(connection, expression, required, values) == [(f"n{changed}", 1)]
+        assert guard.shape_proposals(connection, expression, required, values).derived == [(f"n{changed}", 1)]
+
+
+@pytest.mark.parametrize("clauses", list(itertools.permutations(["n0 in (0)", "n1 in (2)", "n2 in (4)"])))
+def test_cartesian_repairs_keep_budget_for_unranked_predicates(tmp_path, clauses):
+    db_path = tmp_path / "cartesian.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table shaped(n0 integer not null,n1 integer not null,n2 integer not null,constraint ck check({' and '.join(clauses)}))")
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("select count(*) from shaped where n0=0 and n1=2 and n2=4").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("count", [16, 25])
+@pytest.mark.parametrize("reverse_columns,reverse_clauses", itertools.product([False, True], repeat=2))
+def test_numeric_only_fallback_remains_available_until_insert_budget(tmp_path, count, reverse_columns, reverse_clauses):
+    columns = [f'n{index} integer not null' for index in range(count)]
+    clauses = ['g=0', *(f'n{index}>=0' for index in range(count-1)), f'n{count-1}=1']
+    if reverse_columns:
+        columns.reverse()
+    if reverse_clauses:
+        clauses.reverse()
+    db_path = tmp_path / "fallback.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table shaped({','.join(columns)},g integer generated always as(0),constraint ck check({' and '.join(clauses)}))")
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("select count(*) from shaped").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("reverse_columns,not_null", itertools.product([False, True], repeat=2))
+@pytest.mark.parametrize("order", list(itertools.permutations(range(2))))
+@pytest.mark.parametrize("case_guard", [False, True])
+def test_json_and_generic_literals_preserve_each_others_repairs(tmp_path, reverse_columns, not_null, order, case_guard):
+    names = ['doc', 'state']
+    if reverse_columns:
+        names.reverse()
+    json_check = "json_extract(doc,'$.x')=1"
+    if case_guard:
+        json_check = f"case when json_valid(doc) then {json_check} else 0 end"
+    clauses = [json_check, "state='ready'"]
+    columns = ','.join(f'{name} text' + (' not null' if not_null else '') for name in names)
+    expression = ' and '.join(clauses[index] for index in order)
+    if not case_guard:
+        expression = f'json_valid(doc) and ({expression})'
+    ddl = f"create table shaped({columns},constraint ck check({expression}))"
+    db_path = tmp_path / "json.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(ddl)
+        assert guard.insert_seed_row(connection, 'shaped', ddl, [(name,'TEXT') for name in names], dict.fromkeys(names, 'x')) == ('', True)
+        assert connection.execute("select json_extract(doc,'$.x'),state from shaped").fetchall() == [(1,'ready')]
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("select count(*) from shaped where doc is not null and state is not null").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("strict,name,check", [
+    (True, "value", "lower(value)=value"),
+    (True, "payload_json", "json_valid(payload_json)"),
+    (True, "value", "typeof(value)='integer' and value>0"),
+    (False, "value", "typeof(value)='integer' and value>0"),
+])
+def test_strict_any_supports_semantic_and_integer_seeds(tmp_path, strict, name, check):
+    db_path = tmp_path / "strict.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table shaped({name} ANY not null,constraint ck check({check}))" + (' STRICT' if strict else ''))
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("select count(*) from shaped").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("strict,omitted", itertools.product([False, True], repeat=2))
+@pytest.mark.parametrize("literal", ["'000123'", "'1.25'", "1", "1.25", "x'313233'", "NULL"])
+def test_any_candidate_context_matches_native_table_mode(strict, omitted, literal):
+    with sqlite3.connect(":memory:") as connection:
+        suffix = ' STRICT' if strict else ''
+        connection.execute('create table oracle(value ANY)' + suffix)
+        connection.execute(f'insert into oracle values({literal})')
+        storage, quoted = connection.execute('select typeof(value),quote(value) from oracle').fetchone()
+        expected_quote = quoted.replace("'", "''")
+        ddl = f"create table shaped(n integer not null,value ANY default ({literal}),constraint ck check(n>0 and typeof(value)='{storage}' and quote(value)='{expected_quote}')){suffix}"
+        connection.execute(ddl)
+        required,values = [('n','INTEGER')],{'n':0}
+        if not omitted:
+            required.append(('value','ANY'))
+            values['value'] = connection.execute(f'select {literal}').fetchone()[0]
+        assert guard.insert_seed_row(connection,'shaped',ddl,required,values) == ('',True)
+        assert connection.execute('select typeof(value),quote(value) from shaped').fetchone() == (storage,quoted)
+
+
+def test_numeric_fallback_exhaustion_stays_visible(tmp_path):
+    db_path = tmp_path / "exhausted.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        columns = ','.join(f'n{index} integer not null' for index in range(30))
+        clauses = ' and '.join(['g=0', *(f'n{index}>=0' for index in range(29)), 'n29=1'])
+        connection.execute(f"create table shaped({columns},g integer generated always as(0),constraint ck check({clauses}))")
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short
+    assert all('60 attempts did not produce a row' in reason for reason in short.values())
+
+
+@pytest.mark.parametrize("member_type", list(guard.JSON_TYPE_MEMBERS))
+def test_json_member_literals_stay_in_the_semantic_source(member_type):
+    expression = f"json_valid(doc) and json_type(doc,'$.member')='{member_type}' and state='ready'"
+    proposals = guard.check_proposals(expression, ['doc', 'state'])
+    assert proposals
+    assert {value for _, value in proposals} == {'ready'}
+
+
+def test_strict_mode_comes_from_table_metadata():
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute("create table ordinary(value ANY default('STRICT'))")
+        connection.execute("create table typed(value ANY) STRICT")
+        assert not guard.is_strict_table(connection, 'ordinary')
+        assert guard.is_strict_table(connection, 'typed')
+        assert guard.sqlite_affinity('ANY') == 'NUMERIC'
+        assert guard.sqlite_affinity('ANY', strict=True) == 'BLOB'
+
+
+def test_strict_datatype_rejection_does_not_escape_candidate_evaluation():
+    with sqlite3.connect(":memory:") as connection:
+        proposals = guard.shape_proposals(connection, 'n>0', [('n','INTEGER'),('other','INTEGER')], {'n':0,'other':'not an integer'}, strict=True)
+        assert proposals.derived == []
+        assert proposals.numeric_fallback == []
 
 
 @pytest.mark.parametrize("count", [2, 5, 16])
@@ -1123,7 +1278,7 @@ def test_sparse_candidates_keep_turns_at_every_column_position(declared, changed
     values["label"] = "held"
     expression = '+'.join(f'(n{index}>0)' for index in range(16)) + f'=1 and abs(n{changed})>0'
     with sqlite3.connect(":memory:") as connection:
-        assert guard.shape_proposals(connection, expression, required, values) == [(f"n{changed}", 1)]
+        assert guard.shape_proposals(connection, expression, required, values).derived == [(f"n{changed}", 1)]
 
 
 @pytest.mark.parametrize("declared", ["", "TEXT"])
@@ -1146,7 +1301,7 @@ def test_open_storage_columns_retain_semantic_seeds(tmp_path, declared, name, ch
         assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
 
 
-@pytest.mark.parametrize("declared,expected", [("BLOB", b""), ("INTEGER", 0), ("REAL", 0), ("NUMERIC", 0)])
+@pytest.mark.parametrize("declared,expected", [("BLOB", b""), ("INTEGER", 0), ("REAL", 0), ("NUMERIC", 0), ("ANY", 0)])
 def test_explicit_storage_defaults_still_take_precedence(declared, expected):
     for name in ["payload_json", "created_at", "elapsed_time", "email_address", "label"]:
         assert guard.representative_value(name, declared) == expected
@@ -1176,7 +1331,7 @@ def test_function_named_columns_are_not_function_invocations(tmp_path, name, quo
 ])
 def test_context_screen_ignores_literal_and_comment_contents(extra):
     with sqlite3.connect(":memory:") as connection:
-        proposals = guard.shape_proposals(connection, "a=1 and b=2" + extra, [("a", "INTEGER"), ("b", "INTEGER")], {"a": 0, "b": 0})
+        proposals = guard.shape_proposals(connection, "a=1 and b=2" + extra, [("a", "INTEGER"), ("b", "INTEGER")], {"a": 0, "b": 0}).derived
         assert proposals == [("a", 1), ("b", 2)]
 
 
@@ -1193,14 +1348,16 @@ def test_compiled_context_functions_defer_without_evaluating(monkeypatch, functi
         monkeypatch.setattr(guard.sqlite3, "connect", traced_connect)
         expression = "n>0" if in_default else f"n>0 and ({function}) is not null"
         omitted = [("tag", "TEXT", function)] if in_default else []
-        assert guard.shape_proposals(connection, expression, [("n", "INTEGER")], {"n": 0}, omitted=omitted, allow_unvalidated_numeric=False) == []
+        proposals = guard.shape_proposals(connection, expression, [("n", "INTEGER")], {"n": 0}, omitted=omitted)
+        assert proposals.derived == []
+        assert ("n", 1) in proposals.numeric_fallback
     assert not any(statement.startswith("select coalesce(cast(") for statement in statements)
 
 
 @pytest.mark.parametrize("default", ["'random'", "'current_timestamp'", "1 /* changes() */", "1 -- random()\n"])
 def test_default_literals_and_comments_do_not_disable_joint_evaluation(default):
     with sqlite3.connect(":memory:") as connection:
-        assert guard.shape_proposals(connection, "a=1 and b=2", [("a", "INTEGER"), ("b", "INTEGER")], {"a": 0, "b": 0}, omitted=[("tag", "TEXT", default)]) == [("a", 1), ("b", 2)]
+        assert guard.shape_proposals(connection, "a=1 and b=2", [("a", "INTEGER"), ("b", "INTEGER")], {"a": 0, "b": 0}, omitted=[("tag", "TEXT", default)]).derived == [("a", 1), ("b", 2)]
 
 
 @pytest.mark.parametrize("order", list(itertools.permutations(range(3))))
@@ -1355,7 +1512,7 @@ def test_numeric_context_matches_real_supplied_storage(declared, offered):
         connection.execute("insert into sample values (?)", (offered,))
         value_sql, type_sql = connection.execute("select quote(tag), quote(typeof(tag)) from sample").fetchone()
         expression = f"n > 0 and tag is {value_sql} and typeof(tag) = {type_sql}"
-        proposals = guard.shape_proposals(connection, expression, [("n", "INTEGER"), ("tag", declared)], {"n": 0, "tag": offered})
+        proposals = guard.shape_proposals(connection, expression, [("n", "INTEGER"), ("tag", declared)], {"n": 0, "tag": offered}).derived
         assert ("n", 1) in proposals
         assert not any(name == "tag" for name, _ in proposals)
         assert connection.execute("select name from sqlite_temp_master").fetchall() == []
@@ -1618,7 +1775,7 @@ def test_bounded_numeric_tokens_ignore_leading_zeroes():
     assert guard.bounded_integer("0" * 5000 + "12", 0, 4096) == 12
     assert guard.bounded_integer("-" + "0" * 5000 + "12", -4096, 0) == -12
     with sqlite3.connect(":memory:") as connection:
-        assert guard.shape_proposals(connection, "substr(a, " + "9" * 5000 + ", 1) = b", [("a", "TEXT"), ("b", "TEXT")], {"a": "x", "b": "y"}) == []
+        assert guard.shape_proposals(connection, "substr(a, " + "9" * 5000 + ", 1) = b", [("a", "TEXT"), ("b", "TEXT")], {"a": "x", "b": "y"}).derived == []
 
 
 @pytest.mark.parametrize("literal", ["9223372036854775808", "0001", "1.0", "-0001.5"])

--- a/tests/test_migration_release_guard.py
+++ b/tests/test_migration_release_guard.py
@@ -1810,7 +1810,69 @@ def test_numeric_casts_compose_with_whole_truth_wrappers(wrapper):
     "-CAST(a=b AS INTEGER)=-1", "CAST(a=b AS INTEGER)=true",
 ])
 def test_casts_do_not_expose_optional_or_converted_operands(expression):
-    assert guard.column_equality_groups(expression, ["a", "b"], context_columns=["true"]) == [["a"], ["b"]]
+    # Whole TEXT/BLOB truth CASTs preserve a predicate, unlike converted
+    # comparison operands. Keep both former opaque cases as positive coverage.
+    expected = [["a", "b"]] if expression in {"CAST(a=b AS TEXT)", "CAST(a=b AS BLOB)"} else [["a"], ["b"]]
+    assert guard.column_equality_groups(expression, ["a", "b"], context_columns=["true"]) == expected
+
+
+@pytest.mark.parametrize("wrapper", [
+    "({})<>0", "({}) != 0", "0<>({})", "false != ({})", "({}) IS NOT 0",
+    "({})<>-0.0", "-({})<>0", "likely({})<>0", "(likelihood({},.5))!=false",
+    "CAST({} AS TEXT)", "CAST({} AS BLOB)", "CAST({} AS 'BLOB')",
+    "CAST({} AS BLOB) IS TRUE", "CAST({} AS TEXT)<>0",
+    "CAST(CAST({} AS BLOB) AS TEXT)", "-(CAST({} AS BLOB))<>0",
+])
+@pytest.mark.parametrize("predicate", [
+    "length(a)=2", "a GLOB 'AB'", "substr(a,1,2)=b", "a=b",
+    "a='AB'", "json_extract(payload_json,'$.x') IS 'AB'",
+])
+@pytest.mark.parametrize("reverse", [False, True])
+def test_native_truth_wrappers_preserve_required_consumers(tmp_path, wrapper, predicate, reverse):
+    expression = wrapper.format(predicate)
+    checks = [expression, "b='AB'", "state='ready'"]
+    if reverse:
+        checks.reverse()
+    ddl = "create table shaped(a text not null,b text not null,state text not null,payload_json text not null," + ",".join(
+        f"constraint ck{i} check({check})" for i, check in enumerate(checks)
+    ) + ")"
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute(ddl)
+        connection.execute("insert into shaped values('AB','AB','ready','{\"x\":\"AB\"}')")
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+    db_path = tmp_path / "truth-wrapper.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(ddl)
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute(f"select count(*) from shaped where {expression} and b='AB' and state='ready'").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("wrapper", [
+    "CAST({} AS BLOB)<>0", "(CAST({} AS BLOB))!=0", "0<>CAST({} AS BLOB)",
+    "+CAST({} AS TEXT)<>0", "(+CAST({} AS TEXT)) IS NOT 0",
+    "CAST(({}) OR 1 AS BLOB)", "CAST(NOT({}) AS TEXT)",
+    "CAST(CASE WHEN 1 THEN 1 ELSE {} END AS BLOB)", "({})<>1",
+])
+@pytest.mark.parametrize("predicate", ["length(a)=2", "a GLOB 'B'", "substr(a,1,1)=b", "a=b"])
+def test_nontransparent_truth_compositions_preserve_native_columns(wrapper, predicate):
+    expression = wrapper.format(predicate)
+    ddl = f"create table shaped(a text,b text,state text,constraint ck check({expression}),constraint ready check(state='ready'))"
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute(ddl)
+        connection.execute("insert into shaped values('A','R','ready')")
+        assert guard.insert_seed_row(connection, "shaped", ddl,
+                                     [("a", "TEXT"), ("b", "TEXT"), ("state", "TEXT")],
+                                     {"a": "A", "b": "R", "state": "x"}) == ("", True)
+        assert connection.execute("select a,b from shaped").fetchall() == [("A", "R"), ("A", "R")]
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("expression", ["(a=b)<>false", "false!=(a=b)", "(a=b) IS NOT false"])
+def test_nonzero_boolean_names_still_obey_column_shadowing(expression):
+    assert guard.column_equality_groups(expression, ["a", "b"], context_columns=["false"]) == [["a"], ["b"]]
 
 
 @pytest.mark.parametrize("wrapper", [
@@ -2309,6 +2371,127 @@ def test_json_and_generic_literals_preserve_each_others_repairs(tmp_path, revers
     with sqlite3.connect(db_path) as connection:
         assert connection.execute("select count(*) from shaped where doc is not null and state is not null").fetchone()[0] >= guard.SEED_ROWS
         assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("guarding,declared", [
+    ("state='ready'", "TEXT"), ("state>0", "INTEGER"), ("length(state)=2", "TEXT"),
+])
+@pytest.mark.parametrize("member", ["json_type(doc,'$.x')='null'", "json_type(doc,'$.x') IS 'null'",
+                                    "json_extract(doc,'$.x') IS 1"])
+@pytest.mark.parametrize("reverse", [False, True])
+def test_guarded_json_inputs_are_repaired_before_enabling_candidates(tmp_path, guarding, declared, member, reverse):
+    required = [("doc", "TEXT"), ("state", declared)]
+    if reverse:
+        required.reverse()
+    expression = f"{guarding} AND {member}"
+    ddl = "create table shaped(" + ",".join(f"{name} {kind} not null" for name, kind in required) + f",constraint ck check({expression}))"
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute(ddl)
+        native_state = 1 if declared == "INTEGER" else ("AB" if "length" in guarding else "ready")
+        document = '{"x":1}' if "extract" in member else '{"x":null}'
+        connection.execute("insert into shaped(doc,state) values(?,?)", (document, native_state))
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+    db_path = tmp_path / "guarded-json.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(ddl)
+        values = {name: guard.representative_value(name, kind) for name, kind in required}
+        attempts = []
+        connection.set_trace_callback(lambda sql: attempts.append(sql) if sql.startswith('insert into "shaped"') else None)
+        assert guard.insert_seed_row(connection, "shaped", ddl, required, values) == ("", True)
+        assert len(attempts) <= guard.SEED_ATTEMPTS
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute(f"select count(*) from shaped where json_valid(doc) AND ({expression})").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("order", list(itertools.permutations(["a", "b", "c"])))
+def test_repeat_repairs_cannot_change_the_column_being_proved(tmp_path, order):
+    ddl = "create table shaped(" + ",".join(f"{name} text not null" for name in order) + ",constraint ck check(a=b AND lower(b)=c))"
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute(ddl)
+        connection.execute("insert into shaped(a,b,c) values('x','x','x')")
+        required = [(name, "TEXT") for name in order]
+        values = {name: ("x" if name == "b" else "x-2") for name in order}
+        refusal, settled = guard.insert_seed_row(connection, "shaped", ddl, required, values, held=("b",))
+        assert settled and refusal.startswith("CHECK constraint failed:")
+        assert values["b"] == "x"
+        assert connection.execute("select a,b,c from shaped").fetchall() == [("x", "x", "x")]
+        refusal, settled = guard.restore_repeat(connection, "shaped", ddl, required, "b", set())
+        assert settled and refusal.startswith("CHECK constraint failed:")
+        assert connection.execute("select a,b,c from shaped").fetchall() == [("x", "x", "x")]
+    db_path = tmp_path / "held-repeat.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(ddl)
+    short, refused = guard.seed_representative_rows(db_path)
+    assert short == {}
+    assert all(refused[f"shaped.{name}"].startswith("CHECK constraint failed:") for name in order)
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("select count(*) from shaped").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+def test_repeat_offers_start_from_the_successfully_repaired_base(tmp_path, monkeypatch):
+    db_path = tmp_path / "repaired-base.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute("create table shaped(state text not null,n integer not null,constraint ck check(state='ready' AND n>0))")
+    insert = guard.insert_seed_row
+    repeats = []
+
+    def record(connection, table, ddl, required, values, **kwargs):
+        if held := kwargs.get("held"):
+            repeats.append({name: values[name] for name in held})
+        return insert(connection, table, ddl, required, values, **kwargs)
+
+    monkeypatch.setattr(guard, "insert_seed_row", record)
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    assert {"state": "ready"} in repeats and {"n": 1} in repeats
+    with sqlite3.connect(db_path) as connection:
+        assert guard.seeded_rows_prove_repetition(connection, "shaped", ["state", "n"]) == ""
+
+
+@pytest.mark.parametrize("count", [31, 50, 80])
+def test_held_numeric_assignments_retain_repairs_to_other_columns(count):
+    names = [f"n{i}" for i in range(count)]
+    expression = "+".join(f"({name}>0)" for name in names) + f"=1 AND abs({names[-1]})>0"
+    ddl = "create table shaped(" + ",".join(f"{name} integer not null" for name in names) + f",constraint ck check({expression}))"
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute(ddl)
+        values = dict.fromkeys(names, 2)
+        values[names[-1]] = 1
+        attempts = []
+        connection.set_trace_callback(lambda sql: attempts.append(sql) if sql.startswith('insert into "shaped"') else None)
+        assert guard.insert_seed_row(connection, "shaped", ddl, [(name, "INTEGER") for name in names],
+                                     values, held=(names[-1],)) == ("", True)
+        assert values[names[-1]] == 1
+        assert len(attempts) == len(set(attempts)) <= guard.SEED_ATTEMPTS
+        rows = connection.execute("select * from shaped").fetchall()
+        assert len(rows) == 1 and rows[0][-1] == 1
+        assert all(value <= 0 for value in rows[0][:-1])
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("current", [0, 1, -1, 1.5, "1", None])
+@pytest.mark.parametrize("reverse", [False, True])
+def test_numeric_domain_optimization_preserves_scores_and_stable_ties(current, reverse):
+    operators = ["=", "==", "!=", "<>", "<", ">", "<=", ">="]
+    names = ["UPPER", "foo$and", "Ａ", *[f"n{i}" for i in range(5)]]
+    predicates = list(zip(names, operators, range(-4, 4)))
+    expression = " AND ".join(f"{bound}{op}{name}" if reverse else f"{name}{op}{bound}" for name, op, bound in predicates)
+    candidates = [0, 1, -1, 3, -3, 1, guard.SQLITE_INT_MAX, guard.SQLITE_INT_MIN]
+
+    def score(value, op, bound):
+        if not isinstance(value, (int, float)):
+            return -1
+        left, right = (bound, value) if reverse else (value, bound)
+        return {"=": left == right, "==": left == right, "!=": left != right, "<>": left != right,
+                "<": left < right, ">": left > right, "<=": left <= right, ">=": left >= right}[op]
+
+    expected = [sorted(dict.fromkeys([current, *candidates]), key=lambda value: -score(value, op, bound))
+                for _, op, bound in predicates]
+    assert guard.numeric_domains(expression, names, dict.fromkeys(names, current), candidates) == expected
 
 
 @pytest.mark.parametrize("strict,name,check", [

--- a/tests/test_migration_release_guard.py
+++ b/tests/test_migration_release_guard.py
@@ -1438,6 +1438,168 @@ def test_json_type_dependencies_use_sqlite_member_semantics(tmp_path, member_typ
         assert connection.execute("select count(*) from shaped where tag=json_type(doc,'$.x')").fetchone()[0] >= guard.SEED_ROWS
 
 
+@pytest.mark.parametrize("wrapper", [
+    "{} OR 1", "1 OR {}", "NOT ({}) OR 1", "CASE WHEN 1 THEN 1 ELSE {} END",
+    "coalesce(({}),1)=0 OR 1", "({})=0 OR 1", "1 BETWEEN 0 AND 2 OR {}",
+])
+@pytest.mark.parametrize("equality", ["=", "==", "IS"])
+@pytest.mark.parametrize("reverse", [False, True])
+def test_optional_substring_terms_cannot_rewrite_required_columns(tmp_path, wrapper, equality, reverse):
+    left, right = 'substr("a",1,1)', '"b"'
+    if reverse:
+        left, right = right, left
+    expression = wrapper.format(f"{left} {equality} {right}")
+    assert list(guard.substring_requirements(expression)) == []
+    checks = [expression, "a='A'", "b='R'", "state='ready'"]
+    if reverse:
+        checks.reverse()
+    db_path = tmp_path / "optional-prefix.sqlite"
+    ddl = "create table shaped(a text not null,b text not null,state text not null," + ",".join(
+        f"constraint ck{index} check({check})" for index, check in enumerate(checks)
+    ) + ")"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(ddl)
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        rows = connection.execute("select a,b,state from shaped").fetchall()
+        assert len(rows) >= guard.SEED_ROWS
+        assert set(rows) == {("A", "R", "ready")}
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("shape", ["length(a)=2", "a GLOB 'B'", "a NOT GLOB 'A'", "substr(a,1,1)=b"])
+@pytest.mark.parametrize("wrapper", [
+    "({}) OR 1", "1 OR ({})", "NOT ({}) OR 1", "CASE WHEN 1 THEN 1 ELSE {} END",
+    "coalesce(({}),1)=0 OR 1", "({})=0 OR 1",
+])
+@pytest.mark.parametrize("reverse", [False, True])
+def test_only_unconditional_shape_terms_can_force_a_repair(tmp_path, shape, wrapper, reverse):
+    expression = wrapper.format(shape)
+    checks = [expression, "a='A'", "b='R'", "state='ready'"]
+    if reverse:
+        checks.reverse()
+    ddl = "create table shaped(a text not null,b text not null,state text not null," + ",".join(
+        f"constraint ck{index} check({check})" for index, check in enumerate(checks)
+    ) + ")"
+    db_path = tmp_path / "optional-shapes.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(ddl)
+        proposed = guard.shape_proposals(connection, "state='ready'",
+                                          [("a", "TEXT"), ("b", "TEXT"), ("state", "TEXT")],
+                                          {"a": "A", "b": "R", "state": "x"},
+                                          text_constraints=" AND ".join(f"({check})" for check in checks))
+        assert proposed.derived == []
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        rows = connection.execute("select * from shaped").fetchall()
+        assert len(rows) >= guard.SEED_ROWS and set(rows) == {("A", "R", "ready")}
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("wrapper", ["NOT ({})", "coalesce(({}),1)=0", "({})=0"])
+@pytest.mark.parametrize("reverse", [False, True])
+def test_nonidentity_substring_expressions_preserve_valid_bindings(wrapper, reverse):
+    term = "b=substr(a,1,1)" if reverse else "substr(a,1,1)=b"
+    expression = wrapper.format(term)
+    assert list(guard.substring_requirements(expression)) == []
+    checks = [expression, "a='A'", "b='R'", "state='ready'"]
+    if reverse:
+        checks.reverse()
+    ddl = "create table shaped(a text not null,b text not null,state text not null," + ",".join(
+        f"constraint ck{index} check({check})" for index, check in enumerate(checks)
+    ) + ")"
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute(ddl)
+        result = guard.insert_seed_row(connection, "shaped", ddl,
+                                       [("a", "TEXT"), ("b", "TEXT"), ("state", "TEXT")],
+                                       {"a": "A", "b": "R", "state": "x"})
+        assert result == ("", True)
+        assert connection.execute("select * from shaped").fetchall() == [("A", "R", "ready")]
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("order", list(itertools.permutations(["a", "b", "c"])))
+@pytest.mark.parametrize("bound", [2, 4, 12])
+@pytest.mark.parametrize("reverse,strict", itertools.product([False, True], repeat=2))
+def test_numeric_rejected_candidates_remain_origins_for_repeat_rows(tmp_path, order, bound, reverse, strict):
+    clauses = [f"abs(b)={bound}", "(a>0)+(b>0)+(c>0)=1"]
+    if reverse:
+        clauses.reverse()
+    db_path = tmp_path / "numeric-repeat.sqlite"
+    ddl = "create table shaped(" + ",".join(f'"{name}" integer not null' for name in order)
+    ddl += f",constraint ck check({' AND '.join(clauses)}))" + (" STRICT" if strict else "")
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(ddl)
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("select count(*) from shaped").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("order", list(itertools.permutations(["a", "b", "c"])))
+@pytest.mark.parametrize("initial", [(0, 1, 1), (2, 0, 2), (3, 3, 0)])
+def test_numeric_progress_reaches_insert_without_resetting_its_budget(order, initial):
+    ddl = "create table shaped(" + ",".join(f'"{name}" integer not null' for name in order)
+    ddl += ",constraint ck check(abs(b)=4 AND (a>0)+(b>0)+(c>0)=1))"
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute(ddl)
+        attempts = []
+        connection.set_trace_callback(lambda sql: attempts.append(sql) if sql.startswith('insert into "shaped"') else None)
+        values = dict(zip(["a", "b", "c"], initial))
+        result = guard.insert_seed_row(connection, "shaped", ddl, [(name, "INTEGER") for name in order], values)
+        assert result == ("", True)
+        assert len(attempts) == len(set(attempts)) <= guard.SEED_ATTEMPTS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("declared", ["DATE", "NUMERIC", "DECIMAL", "ANY"])
+@pytest.mark.parametrize("reverse", [False, True])
+def test_numeric_progress_keeps_required_prefix_semantics_reachable(declared, reverse):
+    names = ["a", "c"]
+    if reverse:
+        names.reverse()
+    ddl = "create table shaped(" + ",".join(f"{name} {declared} not null" for name in names)
+    ddl += ",constraint ck_c check(length(c)=9 and substr(c,1,4)=a),constraint ck_a check(a in ('R-A0')))"
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute(ddl)
+        attempts = []
+        connection.set_trace_callback(lambda sql: attempts.append(sql) if sql.startswith('insert into "shaped"') else None)
+        result = guard.insert_seed_row(connection, "shaped", ddl, [(name, declared) for name in names],
+                                       {name: "x" for name in names})
+        assert result == ("", True)
+        assert len(attempts) == len(set(attempts)) <= guard.SEED_ATTEMPTS
+        assert any("R-A0" in attempt for attempt in attempts)
+        assert connection.execute("select a,substr(c,1,4) from shaped").fetchall() == [("R-A0", "R-A0")]
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("path", ["$.x", "$.nested.x", "$.it's"])
+@pytest.mark.parametrize("equality", ["=", "==", "IS"])
+@pytest.mark.parametrize("reverse", [False, True])
+def test_json_missing_path_is_an_alternative_not_a_forced_member(tmp_path, path, equality, reverse):
+    quoted = path.replace("'", "''")
+    clauses = [f"json_extract(doc,'{quoted}') {equality} 1", f"json_type(doc,'{quoted}') {equality} 'false'"]
+    if reverse:
+        clauses.reverse()
+    expression = "json_valid(doc) AND " + " AND ".join(clauses)
+    db_path = tmp_path / "json-missing-path.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table shaped(doc text not null,constraint ck check({expression}))")
+    short, _ = guard.seed_representative_rows(db_path)
+    with sqlite3.connect(db_path) as connection:
+        rows = connection.execute("select doc from shaped").fetchall()
+        if equality == "IS":
+            # IS rejects a missing path: keeping the candidate must not skip CHECK.
+            assert short and rows == []
+        else:
+            assert short == {} and len(rows) >= guard.SEED_ROWS
+            assert all(connection.execute("select json_type(?,?)", (doc, path)).fetchone()[0] is None for (doc,) in rows)
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
 @pytest.mark.parametrize("payload", [
     "x=substr(email,5,1)", "substr(email,5,1)=x", "length(email)=2",
     "email glob '[A-Z]*'", "json_extract(email,'$.x')='ready'", "n=9999", "email=x",
@@ -1471,7 +1633,9 @@ def test_json_literals_keep_sql_comment_markers_and_expression_text(path):
     quoted_path, quoted_value = path.replace("'", "''"), value.replace("'", "''")
     expression = f"json_extract(doc,'{quoted_path}')='{quoted_value}' and state=json_extract(doc,'{quoted_path}')"
     with sqlite3.connect(":memory:") as connection:
-        proposals = dict(guard.json_proposals(connection, expression, ["doc", "state", "email"]))
+        pairs = guard.json_proposals(connection, expression, ["doc", "state", "email"])
+        assert pairs[-1] == ("doc", "{}")
+        proposals = dict(reversed(pairs))  # Inspect the first/preferred value per column.
         assert set(proposals) == {"doc", "state"}
         assert proposals["state"] == value
         assert connection.execute("select json_extract(?,?)", (proposals["doc"], path)).fetchone()[0] == value
@@ -1577,7 +1741,12 @@ def test_joint_numeric_evaluation_has_a_finite_budget(monkeypatch):
         monkeypatch.setattr(guard.sqlite3, "connect", traced_connect)
         proposals = guard.shape_proposals(connection, expression, required, values)
         assert proposals.derived == []
-        assert proposals.numeric_fallback == []
+        assert len(proposals.numeric_fallback) == guard.SEED_ATTEMPTS
+        connection.execute("create table rejected(" + ",".join(f"{name} integer" for name in values)
+                           + f",check({expression}))")
+        for assignment in proposals.numeric_fallback:
+            with pytest.raises(sqlite3.IntegrityError, match="CHECK constraint failed"):
+                connection.execute("insert into rejected values(?,?,?,?,?,?)", [value for _, value in assignment])
     evaluations = [statement for statement in statements if statement.startswith("select coalesce(cast(")]
     assert len(evaluations) == guard.SEED_ATTEMPTS
 

--- a/tests/test_migration_release_guard.py
+++ b/tests/test_migration_release_guard.py
@@ -1424,9 +1424,9 @@ def test_sparse_candidates_keep_turns_at_every_column_position(declared, changed
         assert guard.shape_proposals(connection, expression, required, values).derived == [(f"n{changed}", 1)]
 
 
-@pytest.mark.parametrize("declared", ["", "TEXT"])
+@pytest.mark.parametrize("declared", ["", "TEXT", "DATE", "DECIMAL", "ANY", "JSON", "UUID"])
 @pytest.mark.parametrize("name,check", [
-    ("payload_json", "json_valid(payload_json)"),
+    ("payload_json", "json_valid(payload_json) and json_type(payload_json)='object'"),
     ("created_at", "datetime(created_at) is not null"),
     ("elapsed_time", "datetime(elapsed_time) is not null"),
     ("email_address", "email_address like '%@%'"),
@@ -1444,10 +1444,96 @@ def test_open_storage_columns_retain_semantic_seeds(tmp_path, declared, name, ch
         assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
 
 
-@pytest.mark.parametrize("declared,expected", [("BLOB", b""), ("INTEGER", 0), ("REAL", 0), ("NUMERIC", 0), ("ANY", 0)])
+@pytest.mark.parametrize("declared,expected", [("BLOB", b""), ("INTEGER", 0), ("REAL", 0), ("NUMERIC", 0), ("BOOLEAN", 0)])
 def test_explicit_storage_defaults_still_take_precedence(declared, expected):
     for name in ["payload_json", "created_at", "elapsed_time", "email_address", "label"]:
         assert guard.representative_value(name, declared) == expected
+
+
+@pytest.mark.parametrize("quote", ['"', '`', '['])
+@pytest.mark.parametrize("name", ["has space", "has-dash", "123", "n=999", "length(x)=2", "has\"quote", "has`quote", "has'apostrophe", "中文", "a/*comment*/b"])
+@pytest.mark.parametrize("kind", ["literal", "shape", "numeric", "json", "substring"])
+def test_quoted_column_identity_survives_all_candidate_owners(tmp_path, quote, name, kind):
+    def quoted(value):
+        return '[' + value + ']' if quote == '[' else quote + value.replace(quote, quote * 2) + quote
+
+    column, source = quoted(name), quoted("source " + name)
+    declared = "INTEGER" if kind == "numeric" else "TEXT"
+    expressions = {
+        "literal": f"{column}='ready'",
+        "shape": f"length({column})=4 and {column} glob 'A*' and {column} glob '*Z'",
+        "numeric": f"{column}>0 and {column}=2",
+        "json": f"json_valid({source}) and json_extract({source},'$.x')='ready' and {column}=json_extract({source},'$.x')",
+        "substring": f"{source}='ready' and length({column})=8 and substr({column},1,5)={source}",
+    }
+    expression = expressions[kind]
+    db_path = tmp_path / "quoted.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table shaped({column} {declared} not null,{source} TEXT not null,constraint ck check({expression}))")
+
+    short, _ = guard.seed_representative_rows(db_path)
+
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute(f"select count(*) from shaped where {expression}").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("quote", ['"', '`', '['])
+def test_quoted_identifiers_are_tokens_not_literal_or_code_sources(quote):
+    name = "json_extract(other,'$.x')='bad'; n=999"
+    column = '[' + name + ']' if quote == '[' else quote + name.replace(quote, quote * 2) + quote
+    expression = column + "='ready'"
+    assert guard.check_proposals(expression, [name, "other", "n"]) == [(name, "ready")]
+    with sqlite3.connect(":memory:") as connection:
+        shaped = guard.shape_proposals(connection, expression, [(name, "TEXT"), ("other", "TEXT"), ("n", "INTEGER")], {name: "x", "other": "held", "n": 0})
+        assert shaped.derived == []
+        assert shaped.numeric_fallback == []
+        assert guard.json_proposals(connection, expression, [name, "other", "n"]) == []
+
+
+@pytest.mark.parametrize("payload", ['"', '`', '[', "'", '"n=999', '`n=999', '[n=999'])
+@pytest.mark.parametrize("kind", ["literal", "json", "substring", "numeric"])
+def test_opaque_delimiters_cannot_consume_later_identifiers(tmp_path, payload, kind):
+    prefix = "length('" + payload.replace("'", "''") + "')>0 AND "
+    column, source = '"has space"', '"source space"'
+    expressions = {
+        "literal": f"{column}='ready'",
+        "json": f"json_valid({source}) and json_extract({source},'$.x')='ready' and {column}=json_extract({source},'$.x')",
+        "substring": f"{source}='ready' and length({column})=8 and substr({column},1,5)={source}",
+        "numeric": f"{column}=2",
+    }
+    declared = "INTEGER" if kind == "numeric" else "TEXT"
+    expression = prefix + expressions[kind]
+    db_path = tmp_path / "delimiters.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table shaped({column} {declared} not null,{source} text not null,constraint ck check({expression}))")
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute(f"select count(*) from shaped where {expression}").fetchone()[0] >= guard.SEED_ROWS
+
+
+@pytest.mark.parametrize("name", ["has space", 'has"quote', "has`quote", "/* not a comment */", "(has parentheses)", "", "has\nnewline"])
+def test_identifier_round_trip_in_constraints_references_and_repetitions(tmp_path, name):
+    def quoted(value):
+        return '"' + value.replace('"', '""') + '"'
+
+    parent, child = quoted("parent " + name), quoted("child " + name)
+    key, foreign = quoted("key " + name), quoted("foreign " + name)
+    column, constraint = quoted(name), quoted("check " + name)
+    db_path = tmp_path / "references.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table {parent}({key} text primary key,{column} text not null,constraint {constraint} check({column}='ready'))")
+        connection.execute(f"create table {child}({foreign} text not null references {parent}({key}),{column} text not null,constraint {constraint} check({column}='ready'))")
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("pragma foreign_key_check").fetchall() == []
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+        for table in (parent, child):
+            assert connection.execute(f"select count(*) from {table} where {column}='ready'").fetchone()[0] >= guard.SEED_ROWS
+        assert guard.seeded_rows_prove_repetition(connection, "child " + name, [name]) == ""
 
 
 @pytest.mark.parametrize("name,quoted", [

--- a/tests/test_migration_release_guard.py
+++ b/tests/test_migration_release_guard.py
@@ -1177,7 +1177,7 @@ def test_shape_candidates_keep_derived_repairs_separate_from_numeric_guesses(una
         )
         if unavailable:
             assert proposals.derived == []
-            assert ("n", 1) in proposals.numeric_fallback
+            assert any(("n", 1) in assignment for assignment in proposals.numeric_fallback)
         else:
             assert proposals.derived == [("n", 1)]
             assert proposals.numeric_fallback == []
@@ -1186,7 +1186,7 @@ def test_shape_candidates_keep_derived_repairs_separate_from_numeric_guesses(una
             {"code": "x", "n": 0}, unavailable=unavailable,
         )
         assert ("code", "x000") in shaped.derived
-        assert not any(name == "code" for name, _ in shaped.numeric_fallback)
+        assert not any(name == "code" for assignment in shaped.numeric_fallback for name, _ in assignment)
 
 
 @pytest.mark.parametrize("pattern,width", [("[A-Z]*", 4), ("*[A-Z]", 4), ("[A-Z]*[A-Z]", 4), ("*[A-Z]*", 4), ("[A-Z]???", 4), ("[A-Z][A-Z][A-Z][A-Z]", 4), ("*", 0), ("*", guard.SEED_TEXT_LIMIT)])
@@ -1274,7 +1274,7 @@ def test_cartesian_repairs_keep_budget_for_unranked_predicates(tmp_path, clauses
         assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
 
 
-@pytest.mark.parametrize("count", [16, 25])
+@pytest.mark.parametrize("count", [16, 25, 30])
 @pytest.mark.parametrize("reverse_columns,reverse_clauses", itertools.product([False, True], repeat=2))
 def test_numeric_only_fallback_remains_available_until_insert_budget(tmp_path, count, reverse_columns, reverse_clauses):
     columns = [f'n{index} integer not null' for index in range(count)]
@@ -1357,11 +1357,106 @@ def test_any_candidate_context_matches_native_table_mode(strict, omitted, litera
         assert connection.execute('select typeof(value),quote(value) from shaped').fetchone() == (storage,quoted)
 
 
+@pytest.mark.parametrize("context", ["rowid>=1", "_rowid_>=1", "oid>=1", "g=0", "changes()>=0", "total_changes()>=0"])
+@pytest.mark.parametrize("reverse_columns,reverse_clauses", itertools.product([False, True], repeat=2))
+@pytest.mark.parametrize("count", [2, 3])
+def test_target_context_receives_atomic_joint_assignments(tmp_path, context, reverse_columns, reverse_clauses, count):
+    names = [f'n{i}' for i in range(count)]
+    clauses = [context, *(f'n{i}={i+1}' for i in range(count))]
+    if reverse_columns:
+        names.reverse()
+    if reverse_clauses:
+        clauses.reverse()
+    expression = ' and '.join(clauses)
+    db_path = tmp_path / 'joint-target.sqlite'
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table shaped({','.join(name+' integer not null' for name in names)},g integer generated always as(0),constraint ck check({expression}))")
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        expected = ' and '.join(f'n{i}={i+1}' for i in range(count))
+        assert connection.execute(f"select count(*) from shaped where {expected}").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute('pragma integrity_check').fetchall() == [('ok',)]
+
+
+def test_target_context_candidate_is_applied_in_one_insert():
+    with sqlite3.connect(':memory:') as connection:
+        ddl = 'create table shaped(a integer,b integer,constraint ck check(rowid>=1 and a=1 and b=2))'
+        connection.execute(ddl)
+        attempts = []
+        connection.set_trace_callback(lambda statement: attempts.append(statement) if statement.startswith('insert into "shaped"') else None)
+        assert guard.insert_seed_row(connection, 'shaped', ddl, [('a', 'INTEGER'), ('b', 'INTEGER')], {'a': 0, 'b': 0}) == ('', True)
+        assert len(attempts) == 2
+        assert connection.execute('select a,b from shaped').fetchall() == [(1, 2)]
+
+
+@pytest.mark.parametrize("order", list(itertools.permutations(range(3))))
+def test_repairs_can_return_to_a_cell_after_other_columns_change(order):
+    clauses = ["code not glob '*[^a]*'", "length(code)=0", "state='ready'"]
+    with sqlite3.connect(':memory:') as connection:
+        ddl = f"create table shaped(code text,state text,constraint ck check({' and '.join(clauses[index] for index in order)}))"
+        connection.execute(ddl)
+        attempts = []
+        connection.set_trace_callback(lambda statement: attempts.append(statement) if statement.startswith('insert into "shaped"') else None)
+        assert guard.insert_seed_row(connection, 'shaped', ddl, [('code', 'TEXT'), ('state', 'TEXT')], {'code': 'x', 'state': 'x'}) == ('', True)
+        assert connection.execute('select code,state from shaped').fetchall() == [('', 'ready')]
+        assert len(attempts) == len(set(attempts))
+        assert len(attempts) <= guard.SEED_ATTEMPTS
+
+
+@pytest.mark.parametrize("bound", range(1, 13))
+@pytest.mark.parametrize("reverse_columns,reverse_clauses", itertools.product([False, True], repeat=2))
+def test_later_sparse_alternatives_reach_real_seed_rows(tmp_path, bound, reverse_columns, reverse_clauses):
+    names = ['n0', 'n1']
+    clauses = [f'abs(n0)={bound}', 'n1 in (' + ','.join(map(str, range(bound))) + ')']
+    if reverse_columns:
+        names.reverse()
+    if reverse_clauses:
+        clauses.reverse()
+    db_path = tmp_path / 'later-sparse.sqlite'
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table shaped({','.join(name+' integer not null' for name in names)},constraint ck check({' and '.join(clauses)}))")
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute('select count(*) from shaped').fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute('pragma integrity_check').fetchall() == [('ok',)]
+
+
+@pytest.mark.parametrize("count,alternatives", [(2, 14), (5, 5), (17, 1)])
+def test_sparse_family_within_reserved_budget_is_not_diluted(count, alternatives):
+    domains = [list(range(alternatives + 1)) for _ in range(count)]
+    current = (0,) * count
+    prefix = set(itertools.islice(guard.numeric_assignments(domains, current, domains[0]), guard.SEED_ATTEMPTS))
+    assert all((*current[:index], value, *current[index+1:]) in prefix for index in range(count) for value in domains[index][1:])
+
+
+@pytest.mark.parametrize("negated,pattern", [(True, '*[^a]*'), (False, 'a*'), (False, '*z'), (True, '*[0-9]*'), (False, "a'*"), (True, "*[^a']*")])
+@pytest.mark.parametrize("reverse_columns,reverse_clauses", itertools.product([False, True], repeat=2))
+def test_glob_patterns_remain_in_their_semantic_candidate_owner(tmp_path, negated, pattern, reverse_columns, reverse_clauses):
+    term = "code " + ('not ' if negated else '') + "glob '" + pattern.replace("'", "''") + "'"
+    clauses, names = [term, "state='ready'"], ['code', 'state']
+    if reverse_clauses:
+        clauses.reverse()
+    if reverse_columns:
+        names.reverse()
+    expression = ' and '.join(clauses)
+    assert guard.check_proposals(expression, names) == [('state', 'ready')]
+    db_path = tmp_path / 'glob-literal.sqlite'
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table shaped({','.join(name+' text not null' for name in names)},constraint ck check({expression}))")
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute(f'select count(*) from shaped where {expression}').fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute('pragma integrity_check').fetchall() == [('ok',)]
+
+
 def test_numeric_fallback_exhaustion_stays_visible(tmp_path):
     db_path = tmp_path / "exhausted.sqlite"
     with sqlite3.connect(db_path) as connection:
         columns = ','.join(f'n{index} integer not null' for index in range(30))
-        clauses = ' and '.join(['g=0', *(f'n{index}>=0' for index in range(29)), 'n29=1'])
+        clauses = ' and '.join(['g=0', *(f'n{index}>=0' for index in range(29)), 'n29=1', 'n29<0'])
         connection.execute(f"create table shaped({columns},g integer generated always as(0),constraint ck check({clauses}))")
     short, _ = guard.seed_representative_rows(db_path)
     assert short
@@ -1579,7 +1674,7 @@ def test_compiled_context_functions_defer_without_evaluating(monkeypatch, functi
         omitted = [("tag", "TEXT", function)] if in_default else []
         proposals = guard.shape_proposals(connection, expression, [("n", "INTEGER")], {"n": 0}, omitted=omitted)
         assert proposals.derived == []
-        assert ("n", 1) in proposals.numeric_fallback
+        assert any(("n", 1) in assignment for assignment in proposals.numeric_fallback)
     assert not any(statement.startswith("select coalesce(cast(") for statement in statements)
 
 

--- a/tests/test_migration_release_guard.py
+++ b/tests/test_migration_release_guard.py
@@ -1102,6 +1102,101 @@ def test_already_valid_native_shapes_preserve_storage(value, declared, with_glob
         assert not any(name == 'value' for name, _ in proposals.derived)
 
 
+@pytest.mark.parametrize("declared,storage", [('BLOB', 'blob'), ('INTEGER', 'integer'), ('REAL', 'real')])
+@pytest.mark.parametrize("count", [2, 3])
+@pytest.mark.parametrize("reverse,separate", itertools.product([False, True], repeat=2))
+@pytest.mark.parametrize("state_position", [0, 1, -1])
+def test_native_glob_groups_survive_unrelated_repairs(tmp_path, declared, storage, count, reverse, separate, state_position):
+    names = [f'v{i}' for i in range(count)]
+    clauses = [*(f"typeof({name})='{storage}'" for name in names),
+               *(f'{left}={right}' for left, right in zip(names, names[1:])), "v0 not glob 'x'", "state='ready'"]
+    if reverse:
+        names.reverse()
+        clauses.reverse()
+    checks = ','.join(f'constraint ck{i} check({clause})' for i, clause in enumerate(clauses)) if separate else 'constraint ck check(' + ' and '.join(clauses) + ')'
+    columns = [name+' '+declared+' not null' for name in names]
+    columns.insert(len(columns) if state_position == -1 else state_position, 'state text not null')
+    db_path = tmp_path / 'native-group.sqlite'
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table shaped({','.join(columns)},{checks})")
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute('select count(*) from shaped').fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute('pragma integrity_check').fetchall() == [('ok',)]
+
+
+@pytest.mark.parametrize("value,declared", [(b'', 'BLOB'), (b'abc', 'BLOB'), (b'\x00a', 'BLOB'), (17, 'INTEGER'), (1.5, 'REAL')])
+@pytest.mark.parametrize("equality", ['=', '==', 'IS'])
+def test_group_storage_preservation_uses_native_shape_semantics(value, declared, equality):
+    with sqlite3.connect(':memory:') as connection:
+        width = connection.execute('select length(?)', (value,)).fetchone()[0]
+        expression = f"a {equality} b and length(a)={width} and b not glob 'X*' and state='ready'"
+        proposals = guard.shape_proposals(connection, expression, [('a', declared), ('b', declared), ('state', 'TEXT')], {'a': value, 'b': value, 'state': 'x'})
+        assert not any(name in {'a', 'b'} for name, _ in proposals.derived)
+
+
+@pytest.mark.parametrize("collation,left,right", [('NOCASE', 'A', 'a'), ('RTRIM', 'A', 'A ')])
+@pytest.mark.parametrize("equality", ['=', '==', 'IS'])
+@pytest.mark.parametrize("reverse,separate", itertools.product([False, True], repeat=2))
+def test_collated_groups_keep_independent_glob_witnesses(tmp_path, collation, left, right, equality, reverse, separate):
+    clauses = [f"a glob '{left}'", f"b glob '{right}'", f'length(a)={len(left)}', f'length(b)={len(right)}', f'a {equality} b']
+    if reverse:
+        clauses.reverse()
+    checks = ','.join(f'constraint ck{i} check({clause})' for i, clause in enumerate(clauses)) if separate else 'constraint ck check(' + ' and '.join(clauses) + ')'
+    db_path = tmp_path / 'collated-group.sqlite'
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f'create table shaped(a text collate {collation} not null,b text not null,{checks})')
+        connection.execute('insert into shaped values (?,?)', (left, right))
+        connection.execute('delete from shaped')
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute('select count(*) from shaped').fetchone()[0] >= guard.SEED_ROWS
+        assert set(connection.execute('select a,b from shaped')) == {(left, right)}
+        assert connection.execute('pragma integrity_check').fetchall() == [('ok',)]
+
+
+@pytest.mark.parametrize("operator", ['=', '==', 'IS'])
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize("name", ['state', 'quoted state', 'a"b'])
+def test_explicit_literal_bindings_precede_broadcasts(operator, reverse, name):
+    identifier = guard.quote_identifier(name)
+    literal = "'it''s ready'"
+    binding = f'{literal} {operator} {identifier}' if reverse else f'{identifier} {operator} {literal}'
+    expression = f"typeof(a)='blob' and (({binding}))"
+    assert guard.check_proposals(expression, ['a', name])[0] == (name, "it's ready")
+
+
+def test_independent_glob_witnesses_do_not_bypass_binary_equality(tmp_path):
+    db_path = tmp_path / 'binary-group.sqlite'
+    with sqlite3.connect(db_path) as connection:
+        connection.execute("create table shaped(a text not null,b text not null,constraint ck check(a glob 'A' and b glob 'a' and a=b))")
+    short, _ = guard.seed_representative_rows(db_path)
+    assert 'ck' in short['shaped']
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute('select count(*) from shaped').fetchone()[0] == 0
+
+
+@pytest.mark.parametrize("count", [31, 58, 59, 60, 80])
+@pytest.mark.parametrize("context,reverse", itertools.product([False, True], repeat=2))
+def test_large_numeric_domains_reach_joint_candidates(tmp_path, count, context, reverse):
+    names = [f'n{i}' for i in range(count)]
+    if reverse:
+        names.reverse()
+    expression = '+'.join(f'abs({name}-1)' for name in names) + '=0'
+    if context:
+        expression += ' and changes()>=0'
+    db_path = tmp_path / 'large-joint.sqlite'
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table shaped({','.join(name+' integer not null' for name in names)},constraint ck check({expression}))")
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute('select count(*) from shaped').fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute('pragma integrity_check').fetchall() == [('ok',)]
+
+
 @pytest.mark.parametrize("function", ['max(n1,n2)', 'MAX(n1,n2,0)', '"max"(n1,n2)', 'max /* call */ (n1,n2)', 'max(min(n1,2),n2)'])
 @pytest.mark.parametrize("reverse", [False, True])
 def test_scalar_overloads_keep_native_joint_evaluation(tmp_path, function, reverse):

--- a/tests/test_migration_release_guard.py
+++ b/tests/test_migration_release_guard.py
@@ -1752,6 +1752,123 @@ def test_dead_invalid_json_candidate_does_not_change_opaque_document():
 
 
 @pytest.mark.parametrize("wrapper", [
+    "+({})", "+ + /* unary */ ({})", "+(+({}))", "+({}) IS TRUE",
+    "+likely({})", "NOT NOT +({})", "+ NOT + NOT ({})",
+    "+(likelihood(({}),0.25))", "+(({})=1)",
+    "-({})", "-+({})", "-likely({})", "-({}) IS TRUE",
+    "-({}) IS NOT FALSE", "- NOT - NOT ({})",
+])
+@pytest.mark.parametrize("predicate", [
+    "length(a)=2", "a GLOB 'AB'", "substr(a,1,2)=b", "a=b",
+    "a='AB'", "json_extract(payload_json,'$.x') IS 'AB'",
+])
+@pytest.mark.parametrize("reverse", [False, True])
+def test_unary_truth_wrappers_preserve_required_whole_predicates(tmp_path, wrapper, predicate, reverse):
+    checks = [wrapper.format(predicate), "b='AB'", "state='ready'"]
+    if reverse:
+        checks.reverse()
+    ddl = "create table shaped(a text not null,b text not null,state text not null,payload_json text not null," + ",".join(
+        f"constraint ck{i} check({check})" for i, check in enumerate(checks)
+    ) + ")"
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute(ddl)
+        connection.execute("insert into shaped values('AB','AB','ready','{\"x\":\"AB\"}')")
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+    db_path = tmp_path / "unary-wrapper.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(ddl)
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute(f"select count(*) from shaped where {predicate} and b='AB' and state='ready'").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("expression", [
+    "+(length(a)=2 OR 1)", "+NOT(a=b)", "+((a=b)=0)",
+    "+(CASE WHEN 1 THEN 1 ELSE a=b END)", "+(coalesce(a=b,0)=0)",
+    "+(a)=b", "+a=b", "-(a=b)=0", "~(a=b)",
+])
+def test_unary_wrappers_do_not_force_optional_or_operand_equalities(expression):
+    ddl = f"create table shaped(a text,b integer,state text,constraint ck check({expression}),constraint ready check(state='ready'))"
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute(ddl)
+        values = {"a": "01", "b": 1, "state": "x"}
+        # Use an accepted native witness, including the operand-affinity case.
+        if expression not in {"+(a)=b", "+a=b", "+(length(a)=2 OR 1)", "+(CASE WHEN 1 THEN 1 ELSE a=b END)"}:
+            values["a"] = "A"
+        connection.execute("insert into shaped values(?,?,'ready')", (values["a"], values["b"]))
+        connection.execute("delete from shaped")
+        assert guard.column_equality_groups(expression, ["a", "b"]) == [["a"], ["b"]]
+        assert guard.insert_seed_row(connection, "shaped", ddl, [("a", "TEXT"), ("b", "INTEGER"), ("state", "TEXT")], values) == ("", True)
+        assert connection.execute("select * from shaped").fetchall() == [(values["a"], values["b"], "ready")]
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("prefix", ["+", "+ +", "+ /* scalar result */ +"])
+@pytest.mark.parametrize("predicate", ["length(a)=2", "substr(a,1,2)=b", "json_extract(payload_json,'$.x') IS 'AB'"])
+@pytest.mark.parametrize("reverse", [False, True])
+def test_unary_plus_on_known_scalar_results_retains_required_repairs(tmp_path, prefix, predicate, reverse):
+    checks = [f"{prefix}{predicate}", "b='AB'", "state='ready'"]
+    if reverse:
+        checks.reverse()
+    ddl = "create table shaped(a text not null,b text not null,payload_json text not null,state text not null," + ",".join(
+        f"constraint ck{i} check({check})" for i, check in enumerate(checks)
+    ) + ")"
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute(ddl)
+        connection.execute("insert into shaped values('AB','AB','{\"x\":\"AB\"}','ready')")
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+    db_path = tmp_path / "unary-scalar.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(ddl)
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute(f"select count(*) from shaped where {predicate}").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("name,value,suffix", [("true", 0, "IS TRUE"), ("false", 1, "IS NOT FALSE")])
+def test_unary_minus_does_not_turn_shadowed_boolean_names_into_truth(name, value, suffix):
+    ddl = f"create table shaped(a text,b text,state text,{name} integer default {value},constraint ck check(-(a=b) {suffix}),constraint ready check(state='ready'))"
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute(ddl)
+        connection.execute("insert into shaped(a,b,state) values('A','R','ready')")
+        connection.execute("delete from shaped")
+        assert guard.insert_seed_row(connection, "shaped", ddl, [("a", "TEXT"), ("b", "TEXT"), ("state", "TEXT")],
+                                     {"a": "A", "b": "R", "state": "x"}) == ("", True)
+        assert connection.execute("select a,b,state from shaped").fetchall() == [("A", "R", "ready")]
+
+
+def test_unary_column_affinity_is_still_decided_by_actual_insert():
+    ddl = "create table shaped(a text not null,constraint ck check(+a=1))"
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute(ddl)
+        assert connection.execute("select '1'=1").fetchone() == (0,)
+        assert list(guard.conjunctive_terms("+a=1")) == ["+a=1"]
+        with pytest.raises(sqlite3.IntegrityError) as native:
+            connection.execute("insert into shaped values('1')")
+        objection, settled = guard.insert_seed_row(connection, "shaped", ddl, [("a", "TEXT")], {"a": "1"})
+        assert settled and objection == str(native.value)
+        assert connection.execute("select count(*) from shaped").fetchone()[0] == 0
+
+
+@pytest.mark.parametrize("expression", ["-(a=b)=1", "-1=(a=b)", "-TRUE=(a=b)"])
+def test_signed_comparison_operands_are_not_whole_truth_wrappers(expression):
+    assert list(guard.conjunctive_terms(expression)) == [expression]
+    assert guard.column_equality_groups(expression, ["a", "b"]) == [["a"], ["b"]]
+    ddl = f"create table shaped(a text,b text,constraint ck check({expression}))"
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute(ddl)
+        with pytest.raises(sqlite3.IntegrityError) as native:
+            connection.execute("insert into shaped values('A','A')")
+        objection, settled = guard.insert_seed_row(connection, "shaped", ddl, [("a", "TEXT"), ("b", "TEXT")], {"a": "A", "b": "A"})
+        assert settled and objection == str(native.value)
+        assert connection.execute("select count(*) from shaped").fetchone()[0] == 0
+
+
+@pytest.mark.parametrize("wrapper", [
     "(({}))", "({}) IS TRUE", "({})=1", "1=({})", "({}) == TRUE",
     "({}) IS NOT FALSE", "NOT NOT ({})", "likely({})", '\"likely\"({})',
     "unlikely({})", "likelihood(({}),0.25)", "likely((({}) IS TRUE))",
@@ -2431,6 +2548,79 @@ def test_open_storage_columns_retain_semantic_seeds(tmp_path, declared, name, ch
 def test_explicit_storage_defaults_still_take_precedence(declared, expected):
     for name in ["payload_json", "created_at", "elapsed_time", "email_address", "label"]:
         assert guard.representative_value(name, declared) == expected
+
+
+@pytest.mark.parametrize("name", [
+    "١", "\u0080", "\u0085", "\u00a0", "\u0301", "😀", "×", "中",
+    "a\u2003", "a\ufeff", "x😀999", "\u00a0and",
+])
+@pytest.mark.parametrize("kind", ["glob", "length", "substring", "equality", "json", "literal", "numeric"])
+def test_native_non_ascii_identifier_identity_survives_all_candidate_owners(tmp_path, name, kind):
+    expressions = {
+        "glob": f"{name} GLOB 'ready'",
+        "length": f"length({name})=5",
+        "substring": f"substr({name},1,5)=peer",
+        "equality": f"{name}=peer",
+        "json": f"json_valid({name}) AND json_extract({name},'$.x')='ready'",
+        "literal": f"{name}='ready'",
+        "numeric": f"{name}=2",
+    }
+    predicate = expressions[kind]
+    declared = "INTEGER" if kind == "numeric" else "TEXT"
+    witness = 2 if kind == "numeric" else '{"x":"ready"}' if kind == "json" else "ready"
+    # Constraint identity uses the same token rules, including trailing Unicode space.
+    ddl = f"create table shaped({name} {declared} not null,peer text not null,state text not null,constraint \u0301ck\u00a0 check({predicate}),constraint p check(peer='ready'),constraint s check(state='ready'))"
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute(ddl)
+        assert connection.execute("pragma table_info(shaped)").fetchone()[1] == name
+        connection.execute("insert into shaped values(?,?,?)", (witness, "ready", "ready"))
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+    assert guard.check_expression(ddl, "\u0301ck\u00a0") == predicate
+    db_path = tmp_path / "non-ascii-identifier.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(ddl)
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute(f"select count(*) from shaped where {predicate} AND peer='ready' AND state='ready'").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("char", ["١", "\u0085", "\u00a0", "\u0301", "😀", "×", "\u2028"])
+@pytest.mark.parametrize("keyword", ["and", "or", "between", "case", "end"])
+@pytest.mark.parametrize("placement", ["{}name", "name{}", "name{}tail"])
+def test_sql_control_tokens_cannot_split_native_unicode_identifiers(char, keyword, placement):
+    name = placement.format(char + keyword)
+    expression = f"n BETWEEN 0 AND 2 AND {name} GLOB 'A' AND CASE WHEN n=0 THEN 1 ELSE 0 END"
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute(f"create table shaped({name} text,n integer,check({expression}))")
+        assert connection.execute("pragma table_info(shaped)").fetchone()[1] == name
+        connection.execute("insert into shaped values('A',0)")
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+    assert guard.sql_identifiers(name) == {guard.identifier_key(name)}
+    assert list(guard.conjunctive_terms(expression)) == [
+        "n BETWEEN 0 AND 2", f"{name} GLOB 'A'", "CASE WHEN n=0 THEN 1 ELSE 0 END",
+    ]
+
+
+@pytest.mark.parametrize("char", ["\u00a0", "\u0301", "😀", "×", "\ufeff"])
+def test_unicode_identifier_payloads_are_not_numeric_or_function_sources(char):
+    name = f"x{char}999"
+    assert list(guard.sql_matches(guard.SQL_INTEGER, f"{name}=2"))[0].group() == "2"
+    assert [match.group() for match in guard.sql_matches(guard.SQL_INTEGER, f"2={name}")] == ["2"]
+    assert guard.numeric_domains(f"n={name}", ["n"], {"n": 0}, [999, 0]) == [[0, 999]]
+    for function, arguments in [("json_extract", "a,'$.x'"), ("substr", "a,1,2")]:
+        expression = f"x{char}{function}({arguments})='bad'"
+        assert list(guard.sql_matches(guard.JSON_TERM if function == "json_extract" else guard.SUBSTRING_TERM, expression)) == []
+    assert list(guard.conjunctive_terms(f"{name}=peer")) == [f"{name}=peer"]
+
+
+def test_bom_at_token_start_is_not_part_of_a_native_identifier():
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute("create table shaped(\ufeffname text)")
+        assert connection.execute("pragma table_info(shaped)").fetchone()[1] == "name"
+    assert guard.sql_identifiers("\ufeff\ufeffname") == {"name"}
+    assert guard.sql_identifiers("a\ufeffname") == {"a\ufeffname"}
 
 
 @pytest.mark.parametrize("keyword", ["and", "or", "between", "case", "end"])

--- a/tests/test_migration_release_guard.py
+++ b/tests/test_migration_release_guard.py
@@ -1751,6 +1751,101 @@ def test_dead_invalid_json_candidate_does_not_change_opaque_document():
         assert connection.execute("select * from shaped").fetchall() == [("opaque", "ready")]
 
 
+@pytest.mark.parametrize("target", [
+    "INTEGER", "REAL", "NUMERIC", "BOOLEAN", "DECIMAL(10,2)", "DOUBLE PRECISION",
+    '"unsigned big int"', "'INTEGER'", "[INTEGER]", "/* TEXT */ INT",
+])
+@pytest.mark.parametrize("predicate", [
+    "length(a)=2", "a GLOB 'AB'", "substr(a,1,2)=b", "a=b",
+    "a='AB'", "json_extract(payload_json,'$.x') IS 'AB'",
+])
+@pytest.mark.parametrize("reverse", [False, True])
+def test_numeric_truth_casts_preserve_all_required_term_consumers(tmp_path, target, predicate, reverse):
+    checks = [f"CAST({predicate} AS {target})", "b='AB'", "state='ready'"]
+    if reverse:
+        checks.reverse()
+    ddl = "create table shaped(a text not null,b text not null,state text not null,payload_json text not null," + ",".join(
+        f"constraint ck{i} check({check})" for i, check in enumerate(checks)
+    ) + ")"
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute(ddl)
+        connection.execute("insert into shaped values('AB','AB','ready','{\"x\":\"AB\"}')")
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+    db_path = tmp_path / "cast-wrapper.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(ddl)
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute(f"select count(*) from shaped where {predicate} and b='AB' and state='ready'").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("wrapper", [
+    "+CAST({} AS INTEGER)", "-CAST({} AS REAL)", "NOT NOT CAST({} AS NUMERIC)",
+    "CAST({} AS INTEGER) IS TRUE", "CAST({} AS REAL) IS NOT FALSE",
+    "CAST({} AS INTEGER)=1", "CAST({} AS REAL)==true",
+    "1=CAST({} AS INTEGER)", "true IS CAST({} AS REAL)",
+    "CAST(CAST(({}) AS INTEGER) AS REAL)", "CAST(likely({}) AS INTEGER)",
+    "likely(CAST({} AS REAL))", "CAST(+({}) AS NUMERIC)",
+    "CAST({} /* AS TEXT */ AS INTEGER)", "CAST({} AS /* AS TEXT */ INTEGER)",
+])
+def test_numeric_casts_compose_with_whole_truth_wrappers(wrapper):
+    expression = wrapper.format("length(a)=2 AND a=b")
+    assert [guard.sql_projection(term).strip() for term in guard.conjunctive_terms(expression, ["a", "b"])] == ["length(a)=2", "a=b"]
+    ddl = f"create table shaped(a text,b text,constraint ck check({expression}))"
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute(ddl)
+        assert guard.insert_seed_row(connection, "shaped", ddl, [("a", "TEXT"), ("b", "TEXT")],
+                                     {"a": "x", "b": "x"}) == ("", True)
+        assert connection.execute("select length(a),a=b from shaped").fetchall() == [(2, 1)]
+
+
+@pytest.mark.parametrize("expression", [
+    "CAST(a=b AS INTEGER)=0", "CAST(a=b AS REAL) IS FALSE",
+    "NOT CAST(a=b AS NUMERIC)", "CAST((a=b) OR 1 AS INTEGER)",
+    "CAST(CASE WHEN 1 THEN 1 ELSE a=b END AS INTEGER)",
+    "CAST(a=b AS TEXT)", "CAST(a=b AS BLOB)", "CAST(a AS INTEGER)=b",
+    "CAST((a=b) AS INTEGER)+1", "CAST((a=b) AS INTEGER) BETWEEN 0 AND 1",
+    "-CAST(a=b AS INTEGER)=-1", "CAST(a=b AS INTEGER)=true",
+])
+def test_casts_do_not_expose_optional_or_converted_operands(expression):
+    assert guard.column_equality_groups(expression, ["a", "b"], context_columns=["true"]) == [["a"], ["b"]]
+
+
+@pytest.mark.parametrize("wrapper", [
+    "CAST(({}) OR 1 AS INTEGER)", "CAST(NOT({}) AS REAL)",
+    "CAST(({})=0 AS NUMERIC)", "CAST(CASE WHEN 1 THEN 1 ELSE {} END AS INTEGER)",
+    "CAST({} AS INTEGER)=0", "CAST({} AS REAL) IS FALSE",
+])
+@pytest.mark.parametrize("predicate", ["length(a)=2", "a GLOB 'B'", "substr(a,1,1)=b", "a=b"])
+def test_optional_casts_cannot_rewrite_valid_native_columns(wrapper, predicate):
+    ddl = "create table shaped(a text,b text,state text," + ",".join(
+        f"constraint ck{i} check({term})"
+        for i, term in enumerate([wrapper.format(predicate), "a='A'", "b='R'", "state='ready'"])
+    ) + ")"
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute(ddl)
+        connection.execute("insert into shaped values('A','R','ready')")
+        assert guard.insert_seed_row(connection, "shaped", ddl,
+                                     [("a", "TEXT"), ("b", "TEXT"), ("state", "TEXT")],
+                                     {"a": "A", "b": "R", "state": "x"}) == ("", True)
+        assert connection.execute("select a,b from shaped").fetchall() == [("A", "R"), ("A", "R")]
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("cast", ["CAST(a AS INTEGER)", "CAST(a AS REAL)", "CAST(a AS NUMERIC)"])
+def test_cast_operand_affinity_remains_native(cast):
+    ddl = f"create table shaped(a text,b text,state text,constraint ck check({cast}=b),constraint ready check(state='ready'))"
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute(ddl)
+        connection.execute("insert into shaped values('01','1','ready')")
+        assert guard.insert_seed_row(connection, "shaped", ddl,
+                                     [("a", "TEXT"), ("b", "TEXT"), ("state", "TEXT")],
+                                     {"a": "01", "b": "1", "state": "x"}) == ("", True)
+        assert connection.execute("select a,b from shaped").fetchall() == [("01", "1"), ("01", "1")]
+
+
 @pytest.mark.parametrize("wrapper", [
     "+({})", "+ + /* unary */ ({})", "+(+({}))", "+({}) IS TRUE",
     "+likely({})", "NOT NOT +({})", "+ NOT + NOT ({})",
@@ -2455,6 +2550,80 @@ def test_numeric_fallback_progress_is_scoped_to_each_check(tmp_path, reverse_che
     assert short == {}
     with sqlite3.connect(db_path) as connection:
         assert connection.execute('select count(*) from shaped where a=1 and b=2 and c=3 and d=4').fetchone()[0] >= guard.SEED_ROWS
+
+
+@pytest.mark.parametrize("accepting_source", ["numeric", "literal"])
+@pytest.mark.parametrize("competing_count", [1, 2, 9, 17, 29])
+def test_each_source_finishes_its_fitting_forward_pass(monkeypatch, accepting_source, competing_count):
+    # With both finite passes fitting the INSERT budget, restarting the shorter
+    # source cannot consume the longer source's remaining first-pass turns.
+    tail_count = guard.SEED_ATTEMPTS - competing_count - 1
+    numeric_count, literal_count = (
+        (tail_count, competing_count) if accepting_source == "numeric" else (competing_count, tail_count)
+    )
+    numeric = [(("n", value),) for value in range(1, numeric_count + 1)]
+    literals = [("state", f"value{index}") for index in range(literal_count)]
+    monkeypatch.setattr(guard, "shape_proposals", lambda *args, **kwargs: guard.ShapeProposals([], numeric))
+    monkeypatch.setattr(guard, "check_proposals", lambda *args, **kwargs: literals)
+    predicate = f"n={numeric_count}" if accepting_source == "numeric" else f"state='value{literal_count-1}'"
+    ddl = f"create table shaped(n integer,state text,constraint ck check({predicate}))"
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute(ddl)
+        attempts = []
+        connection.set_trace_callback(lambda sql: attempts.append(sql) if sql.startswith('insert into "shaped"') else None)
+        assert guard.insert_seed_row(connection, "shaped", ddl, [("n", "INTEGER"), ("state", "TEXT")],
+                                     {"n": 0, "state": "initial"}) == ("", True)
+        assert len(attempts) == len(set(attempts)) <= guard.SEED_ATTEMPTS
+        assert connection.execute(f"select {predicate} from shaped").fetchall() == [(1,)]
+
+
+@pytest.mark.parametrize("count", [30, 45, 50])
+@pytest.mark.parametrize("context", ["1", "g=0", "changes()>=0"])
+@pytest.mark.parametrize("reverse_columns,reverse_terms", itertools.product([False, True], repeat=2))
+def test_literal_tails_share_budget_with_numeric_sources(tmp_path, count, context, reverse_columns, reverse_terms):
+    names = ["state", "n"] if not reverse_columns else ["n", "state"]
+    choices = [*(f"a{index:03}" for index in range(count - 1)), "ready"]
+    terms = ["n>=0", f"state IN ({','.join(repr(value) for value in choices)})",
+             "unicode(substr(state,1,1))=114", context]
+    if reverse_terms:
+        terms.reverse()
+    expression = " AND ".join(terms)
+    columns = ",".join(name + (" TEXT" if name == "state" else " INTEGER") + " NOT NULL" for name in names)
+    ddl = f"create table shaped({columns},g integer generated always as(0),constraint ck check({expression}))"
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute(ddl)
+        connection.execute("insert into shaped(state,n) values('ready',0)")
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+    assert guard.check_proposals(expression, names) == [("state", value) for value in choices]
+    db_path = tmp_path / "source-tail.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(ddl)
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("select count(*) from shaped where state='ready' AND n>=0").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("dependency", ["state=lower(code)", "state IS code", "(state=code OR state='ready')"])
+@pytest.mark.parametrize("reverse", [False, True])
+def test_generic_literals_retain_connected_recipients_without_pollution(tmp_path, dependency, reverse):
+    terms = ["code IN ('ready')", dependency, "label=trim(state)", "n>=0", "length(payload_json)>0"]
+    if reverse:
+        terms.reverse()
+    expression = " AND ".join(terms)
+    names = ["payload_json", "n", "label", "state", "code"]
+    proposals = guard.check_proposals(expression, names)
+    assert {name for name, _ in proposals} == {"label", "state", "code"}
+    db_path = tmp_path / "literal-recipients.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table shaped(payload_json text not null,n integer not null,label text not null,state text not null,code text not null,constraint ck check({expression}))")
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("select count(*) from shaped where code='ready' and state='ready' and label='ready'").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("select count(*) from shaped where json_valid(payload_json)").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
 
 
 def test_numeric_fallback_exhaustion_stays_visible(tmp_path):

--- a/tests/test_migration_release_guard.py
+++ b/tests/test_migration_release_guard.py
@@ -1069,13 +1069,18 @@ def test_numeric_repairs_coordinate_columns_without_order_dependence(tmp_path, c
         assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
 
 
-def test_joint_numeric_evaluation_has_a_finite_budget():
+def test_joint_numeric_evaluation_has_a_finite_budget(monkeypatch):
     required = [(f"n{index}", "INTEGER") for index in range(6)]
     values = {name: 0 for name, _ in required}
     expression = " and ".join(f"{name} > 0" for name in values) + " and n5 < 0"
     statements = []
     with sqlite3.connect(":memory:") as connection:
-        connection.set_trace_callback(statements.append)
+        connect = sqlite3.connect
+        def traced_connect(*args, **kwargs):
+            candidate = connect(*args, **kwargs)
+            candidate.set_trace_callback(statements.append)
+            return candidate
+        monkeypatch.setattr(guard.sqlite3, "connect", traced_connect)
         assert guard.shape_proposals(connection, expression, required, values) == []
     evaluations = [statement for statement in statements if statement.startswith("select coalesce(cast(")]
     assert len(evaluations) == guard.SEED_ATTEMPTS
@@ -1296,10 +1301,91 @@ def test_numeric_repair_uses_sqlite_affinity_classification(tmp_path, declared, 
         assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
 
 
+@pytest.mark.parametrize("declared", ["", "DATE", "DECIMAL", "NUMERIC", "BOOLEAN", "INTEGER", "REAL", "BLOB", "TEXT"])
+@pytest.mark.parametrize("shape", ["length(value)=4", "value glob 'A???'", "length(value)=4 and value glob 'A*'", "length(value)=4 and value not glob '*[0-9]*'"])
+def test_text_shapes_are_not_restricted_by_initial_storage_class(tmp_path, declared, shape):
+    db_path = tmp_path / "flexible.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table shaped(value {declared} not null, constraint ck check({shape}))")
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("select count(*) from shaped").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("declared", ["NUMERIC", "REAL", "INTEGER"])
+@pytest.mark.parametrize("count", [15, 20])
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize("repair", ["state='ready'", "json_valid(state) and json_extract(state,'$.ready')=1"])
+def test_unvalidated_numeric_fallback_cannot_starve_other_repairs(tmp_path, declared, count, reverse, repair):
+    columns = [f'n{index} {declared} not null' for index in range(count)]
+    if reverse:
+        columns.reverse()
+    checks = ' and '.join([*(f'n{index}>=0' for index in range(count)), 'g=0', repair])
+    db_path = tmp_path / "fallback.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(f"create table shaped({','.join(columns)},state text not null,g integer generated always as (0),constraint ck check({checks}))")
+    short, _ = guard.seed_representative_rows(db_path)
+    assert short == {}
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("select count(*) from shaped").fetchone()[0] >= guard.SEED_ROWS
+        assert connection.execute("pragma integrity_check").fetchall() == [("ok",)]
+
+
+@pytest.mark.parametrize("function", ["changes()", "total_changes()", "last_insert_rowid()"])
+def test_context_sensitive_check_uses_the_real_insert_state(function):
+    with sqlite3.connect(":memory:") as connection:
+        ddl = f"create table shaped(n integer not null,constraint ck check(n>0 and n>{function}))"
+        connection.execute(ddl)
+        assert guard.insert_seed_row(connection, "shaped", ddl, [("n", "INTEGER")], {"n": 0}) == ("", True)
+        assert connection.execute("select n from shaped").fetchall() == [(1,)]
+
+
+@pytest.mark.parametrize("expression", ["n>0", "n>0 and n<0", "n>changes()", "n>0 and unregistered(n)"])
+def test_candidate_generation_does_not_mutate_fixture_connection_state(expression):
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute("create table held(n integer primary key)")
+        connection.execute("insert into held values (17)")
+        connection.execute("insert into held values (19)")
+        snapshot = "select changes(),total_changes(),last_insert_rowid()"
+        before = connection.execute(snapshot).fetchone()
+        guard.shape_proposals(connection, expression, [("n", "INTEGER")], {"n": 0})
+        assert connection.execute(snapshot).fetchone() == before
+        assert connection.execute("select n from held").fetchall() == [(17,), (19,)]
+
+
+@pytest.mark.parametrize("expression", ["n>0", "n>0 and n<0", "n>changes()", "n>0 and unregistered(n)"])
+def test_isolated_candidate_connections_are_always_closed(monkeypatch, expression):
+    connections = []
+    connect = sqlite3.connect
+    def tracked_connect(*args, **kwargs):
+        candidate = connect(*args, **kwargs)
+        connections.append(candidate)
+        return candidate
+    with connect(":memory:") as connection:
+        monkeypatch.setattr(guard.sqlite3, "connect", tracked_connect)
+        guard.shape_proposals(connection, f"n>0 and ({expression})", [("n", "INTEGER")], {"n": 0})
+        assert len(connections) == 1
+        with pytest.raises(sqlite3.ProgrammingError, match="closed"):
+            connections[0].execute("select 1")
+
+
+@pytest.mark.parametrize("function", ["changes()", "total_changes()", "last_insert_rowid()", "local_context()"])
+def test_context_functions_in_defaults_defer_to_target_insert(function):
+    with sqlite3.connect(":memory:") as connection:
+        connection.create_function("local_context", 0, lambda: 0)
+        ddl = f"create table shaped(n integer not null,tag integer default ({function}),constraint ck check(n>0 and tag=0))"
+        connection.execute(ddl)
+        assert guard.insert_seed_row(connection, "shaped", ddl, [("n", "INTEGER")], {"n": 0}) == ("", True)
+        assert connection.execute("select n,tag from shaped").fetchall() == [(1,0)]
+
+
 @pytest.mark.parametrize("equality", ["=", "==", "IS"])
 @pytest.mark.parametrize("reverse_operands,reverse_checks", itertools.product([False, True], repeat=2))
 @pytest.mark.parametrize("source", ["a glob 'R-[A-C][0-9]'", "a in ('R-A0')"])
-def test_substring_dependencies_use_normalized_equality(tmp_path, equality, reverse_operands, reverse_checks, source):
+@pytest.mark.parametrize("declared", ["TEXT", "DATE", "", "BLOB"])
+def test_substring_dependencies_use_normalized_equality(tmp_path, equality, reverse_operands, reverse_checks, source, declared):
     left, right = ('substr("C", 1, 4)', '"A"')
     if reverse_operands:
         left, right = right, left
@@ -1308,7 +1394,7 @@ def test_substring_dependencies_use_normalized_equality(tmp_path, equality, reve
         checks.reverse()
     db_path = tmp_path / "vibe.sqlite"
     with sqlite3.connect(db_path) as connection:
-        connection.execute(f"create table shaped(id integer primary key, a text not null, c text not null, {', '.join(checks)})")
+        connection.execute(f"create table shaped(id integer primary key, a {declared} not null, c {declared} not null, {', '.join(checks)})")
     short, _ = guard.seed_representative_rows(db_path)
     assert short == {}
     with sqlite3.connect(db_path) as connection:


### PR DESCRIPTION
## Current Fix Evidence

Fix commit `050c65fb10686c8322c4be552233b44a3d18a1e5` addresses the COLLATE finding on `0685075619`. The existing required-term traversal recognizes postfix COLLATE clauses immediately after a complete parenthesized/function operand, using the existing SQL projection and complete identifier/string tokens. It retains the original SQL for complete native 0/1 wrapper validation. Comparison-operand collations, negative/optional/CASE terms, converted comparison operands and nontransparent TEXT/BLOB compositions retain their boundaries. All existing required consumers share the repair; no general parser, solver, candidate family, scheduler or cursor owner was added.

Final five migration suites: **4673 passed, no skips**, 234.99 seconds, 907 existing SQLAlchemy warnings. Every tagged upgrade (including rc6), current-schema all-table minimum rows, native/STRICT storage, full-CHECK context, refusal, references and repetition are included. Added **240 cases / 105 test lines**, with **zero historical test lines changed or removed**. The unchanged focused baseline passed 858 cases; the final related run passed 1098. Ruff and diff-check pass. Independent source/test diff review confirms only the two authorized files, **113 insertions / zero deletions**, including eight guard lines.

The original named CHECK now seeds three valid rows; native first-row acceptance takes three distinct INSERTs and integrity passes. Thirteen pre-edit in-memory postfix/composition variants also seeded three valid rows each. New tests cover all required consumers, quoted/commented/chained syntax, conjunction/CHECK order and non-destructive collation/opaque boundaries. Both 60 limits, minimum two rows, int64/4096-width/16384-state limits, numeric families/order, source forward passes, held-value ownership and final persisted verification are unchanged. Local contextual wide-ranked widths 80/59 take 12.26/6.18 seconds. Fresh-head CI remains a separate gate.

Normal push is independently verified by local/remote/GitHub HEAD; the worktree is clean with no unpushed commit. Origin/master was fetched and remains `e4924db41`; merge-base remains `c570ab009`, and the main checkout was not advanced. The prior SHA-bound review `5144310302`, completed summary and withdrawn PR-body/old-trigger eyes were independently re-verified BEFORE push. Reply `3960179323` was independently fetched and matched its exact draft body and original `in_reply_to_id=3960039719` BEFORE resolving `PRRT_kwDOPbFPYs6gUsvW`. The complete PR re-fetch confirms **51/51 threads resolved**, 102 comments, 69 reviews, no nested comment pages or current-head bot finding. Bodyless owner reply-envelope review `5144507825` is not a verdict. Original #1933 remains nine resolved/five carried unresolved until corrective delivery actually merges.

The first new-head review was independently confirmed through external owner trigger `5588599232` (16:39:45Z), its bot eyes `413099526`, PR-body eyes `494786150` and summary `5578421575` naming `050c65f`. It then **FAILED** at 2026-09-08T16:41:36.009725Z. Bot issue comment `5588621490` reports an unknown error and requests trying again later; this is not a code verdict or another findings-bearing head. Complete reviews/comments and withdrawn PR-body/both old-trigger eyes were independently re-fetched, confirming no current-head verdict or pending review and unchanged HEAD.

A single bounded retry was posted by this turn on unchanged HEAD: trigger `5588742735`, created at **16:51:31Z**. Its exact body was read back, and bot eyes **`413107259`** on that exact returned comment ID were independently confirmed (16:51:46Z). Summary `5578421575` named `050c65f`, Running since 16:51:48.940260Z, Manual request. The retry also **FAILED at 16:53:18.768015Z**; bot issue comment `5588763726` reports the same unknown error. Both failures are terminal service errors, not code verdicts or findings-bearing heads.

**Delivery is blocked; no review is currently running.** Complete review/comment/thread inventories and withdrawn PR-body/retry eyes were independently checked again: 69 reviews, 102 inline comments, six issue comments, 51/51 threads resolved, and no current-head bot verdict. The only current-head review envelope is the bodyless owner reply. The public OpenAI status summary lists Codex components as operational and the reported incidents concern image generation/file uploads; it does not establish the cause of these GitHub review errors. Do not infer a code defect, quota failure or general Codex outage. The single bounded retry is exhausted: no third trigger, code change, force push, review waiver or watch replacement is justified by the same unknown error. Further progress requires review-service investigation/recovery or explicit direction. Keep the existing watch/cursor for new activity, without claiming an active review. Prefer a SHA-bound verdict when review resumes; the same unchanged-head epoch remains intact.

Sole exact-head lint `34252404014`, suite `92787224766`, attempt 1, is **completed/successful**. All **17 expected jobs AND independently fetched check-runs** are present, completed and successful, including the six shards, UI, migration-release-guard, Windows, both installer consumers and aggregates (`unit-tests` job `102153984255`, install-upgrade job `102151542715`). No old-head run is counted. The same sole-owner watch `c052cd565ea2` remains healthy/process-alive, follow-up `59413b7b5228`; command and cursor are unchanged. No local Incus E2E, remote/production DB operation, running-service change, merge or deployment was performed. CI is green but the review-service failure leaves no current-head verdict, so this is not a delivery PASS.

## Twenty-Second Findings-Head Diagnosis (Before Edits)

Orchestrator `sesssbbj4mt2y` independently re-fetched the complete paginated inventories on 2026-09-09 CST: #1933 has 14 threads/28 comments (nine resolved/five carried); #1941 has 51 threads/101 comments (50 resolved/one new unresolved). There are no nested comment pages. All 86 reviews, issue comments and PR-body/comment reactions were fetched. Bot review `5144310302` is bound to `068507561928a033e42615a150b61bde3c110176`, submitted at 2026-09-08T16:23:08Z; summary `5578421575` completed at 16:23:11.701057Z and the PR-body eyes withdrew. No review is pending. The same sole-owner watch `c052cd565ea2` is healthy/process-alive with unchanged command/cursor, current follow-up `59413b7b5228`.

There are **22 findings-bearing heads**, chronological counts **3/2/4/5/3/3/4/5/2/3/2/4/3/1/3/4/2/2/2/4/3/1**. Finding `3960039719` / `PRRT_kwDOPbFPYs6gUsvW` repeats the required-truth-traversal class: a postfix COLLATE on a whole predicate prevents existing required consumers from seeing it. Counts and rewrite boundaries do not reset. The breaker paused source/test edits for this renewed full-inventory diagnosis; green CI does not waive it.

The sole exact-head lint run `34249178899`, suite `92778249600`, attempt 1, is completed/successful. All **17 expected jobs AND independently fetched check-runs** are present, completed and successful, including all six unit shards, UI, migration-release-guard, both installer consumers and both aggregates. Local/remote/GitHub HEAD agree, the worktree is clean, and merge-base remains `c570ab009`. No old-head run is counted.

The original named CHECK `(length(a)=2) COLLATE BINARY AND state='ready'` reproduces zero rows after two distinct INSERTs, although native `('AB','ready')` succeeds and passes integrity. Thirteen native-valid variants (built-in/quoted/chained collations, unary/hint/CAST/COALESCE/boolean-comparison composition) show the same missing required operand. Inspected the previous source diff and historical consumers for required and optional truth wrappers, native CAST composition, lexical projection, collated equality/storage, shape/substring/JSON/literal consumers, and the unchanged numeric/full-CHECK/atomic-INSERT/source-progress/held/repetition boundaries.

An in-memory experiment recognizes only leading postfix COLLATE clauses immediately after the existing complete parenthesized/function operand, preserving the original SQL in the existing complete native false/true composition probe. All 13 variants then seed three valid rows. Comparison-operand collations, negative/optional terms and nontransparent TEXT/BLOB comparison compositions stay opaque. This identifies one missing path in the existing shared owner, not a need for a general parser, solver, new candidate family or scheduler.

Scope decision recorded BEFORE source/test edits: keep ONLY `scripts/migration_release_guard.py` and `tests/test_migration_release_guard.py`. Extend the existing whole-operand suffix recognition using the shared complete identifier/string tokens and offset-preserving SQL projection; preserve actual comparison collation and validate complete recognized wrapper composition through SQLite. Cover every existing required consumer, conjunction/CHECK ordering, quoted/commented/chained syntax, and native non-destructive opaque/affinity boundaries. Preserve both 60 limits, minimum two rows, int64/4096-width/16384-state bounds, all historical tests/parameters, native/STRICT storage, full-CHECK numeric context, source passes, held values and final refusal/reference/repetition verification. No schema/migration/constraint/workflow/dependency/timeout/coverage change, service operation, main fast-forward, merge or deployment is authorized. Conservatively track this required-term revision as another candidate-model rewrite.

## Previous Fix Evidence (068507561; Superseded by the Diagnosis Above)

Fix commit `068507561928a033e42615a150b61bde3c110176` addresses all three findings on `9947a9d54e`. Positive COALESCE/IFNULL guards expose only their first argument through the existing required-term traversal; complete native 0/1 wrapper evaluation retains negative/optional/CAST-affinity boundaries and never promotes fallback arguments into requirements. Existing normalized substring relationships also retain one atomic native-slice alternative from the shaped containing values, including bounded chains and equality aliases, alongside the original opposite-direction repair.

The existing table-metadata pass supplies NOT NULL columns to the JSON producer. Only speculative NULL dependent cells that cannot be stored in those columns are omitted; their current values and useful document/other-dependent assignments remain. Nullable columns retain native NULL candidates. Native non-CHECK refusal, held-column projection, final persisted non-NULL repetition, minimum two rows, both 60 limits, full-CHECK numeric evaluation, numeric families/order, source forward passes, and int64/4096-width/16384-state limits are unchanged. No parser/solver, persistent cursor owner, dependency, schema, workflow, timeout or coverage change was introduced.

Final five migration suites: **4433 passed, no skips**, 229.64 seconds, 907 existing SQLAlchemy warnings, including every tagged upgrade (rc6 included) and current-schema all-table minimum rows. Added **288 cases / 156 test lines**, with **zero historical test lines removed or changed**. Final focused validation: 288 new/boundary cases passed, followed by 1730 related cases passed. Ruff and diff-check pass. Independent source/test diff inspection confirms only the authorized two files, **200 insertions/3 deletions**. Local contextual wide-ranked widths 80/59 take 12.30/6.17 seconds; fresh-head CI remains a separate gate.

Original COALESCE, IFNULL, substring and required-JSON fixtures each seed three valid rows. First-row native traces take 3/3/3/2 distinct INSERT attempts respectively; native integrity passes. The coordinated substring refinement closes all 12 initial chain probes plus the added declaration/CHECK/equality/alias and Unicode/zero-width cases. The new nullable cases intentionally preserve the existing visible non-NULL-repetition shortfall when only NULL repetition is available; this is not a new PASS claim or a change to final verification.

Intermediate results and evidence-led refinements are recorded below, before their respective changes: 1478 historical focused tests passed before chain closure; the first new run had 192 passed/five NEW nullable expectation failures and the broader run had 1294 passed/the same failures. Unchanged-head comparison established that duplicate NULLs do not satisfy the existing proof, so only the NEW expectation was calibrated without dropping parameters or weakening historical assertions.

Before push, SHA-bound review `5143868721`, its completed summary and withdrawn PR-body/old-trigger eyes were independently re-verified; no review was pending. Original-head lint `34244803005` has all 17 jobs/checks successful, but cannot count for this new commit. Origin/master remains `e4924db41`, merge-base `c570ab009`, and the main checkout was not advanced. The same sole-owner watch/cursor remain healthy and unchanged. No local Incus E2E, remote/production DB verification, running-service change, merge or deployment was performed. New-head pickup, exact-head CI and reply/readback/resolution are still separate delivery gates.

Normal push is independently verified by local/remote/GitHub HEAD, and the worktree is clean. Replies `3959923311`, `3959923050` and `3959922930` were separately read back with exact bodies and original `in_reply_to_id` BEFORE resolution. The complete PR inventory now has **50/50 threads resolved**, 100 comments, 67 reviews, no nested comment pages and no current-head bot finding. Current-head owner reply-envelope reviews `5144168743`, `5144168881` and `5144169218` have empty bodies and are not verdicts.

Automatic pickup is independently confirmed: summary `5578421575` names `0685075`, Running since 2026-09-08T16:08:23.659850Z, “New commits”; bot PR-body eyes `494723601` was created at 16:08:28Z. No explicit trigger was posted. Sole exact-head lint `34249178899`, suite `92778249600`, attempt 1, is in progress. The latest full jobs/check-runs fetch has 15 present: four successful and 11 running; both aggregates are absent. This is NOT CI green or a review PASS. Same sole-owner watch `c052cd565ea2` remains healthy/process-alive, follow-up `3ebe41bb06d7`; command and cursor are unchanged.

## Twenty-First Findings-Head Diagnosis (Before Edits)

Orchestrator `sesssbbj4mt2y` independently fetched both complete paginated inventories on 2026-09-08: #1933 has 14 threads/28 comments (nine resolved/five carried); #1941 has 50 threads/97 comments (47 resolved/three new unresolved), with no nested comment pages. All 82 reviews, issue comments and PR-body/comment reactions were fetched. Current-head bot review `5143868721` is bound to `9947a9d54e1b835a7fcb11ee0f78e6d9aec932fe`, submitted at 15:42:21Z; summary `5578421575` completed at 15:42:25.363885Z and its PR-body eyes withdrew. No review is pending. The same sole-owner watch `c052cd565ea2` is healthy/process-alive, with unchanged command/cursor and follow-up `3ebe41bb06d7`.

There are **21 findings-bearing heads**, chronological counts **3/2/4/5/3/3/4/5/2/3/2/4/3/1/3/4/2/2/2/4/3**. The three new findings repeat required truth traversal (`3959676329`), shaped substring dependency propagation (`3959676342`), and JSON candidate/native-constraint boundaries (`3959676349`). Counts and rewrite boundaries never reset. The breaker paused source/test edits for this independent full-inventory diagnosis; green CI does not waive it.

The sole exact-head lint run `34244803005`, suite `92765860559`, attempt 1, is completed/successful. All **17 expected jobs AND independently fetched check-runs** are present, completed and successful, including the formerly timed-out unit-tests shard, migration-release-guard and both installer consumers/aggregate. Old-head runs are not counted. Local/remote/GitHub HEAD agree; the worktree is clean and merge-base remains `c570ab009`.

All original examples reproduce on unchanged HEAD while native accepted witnesses pass integrity. COALESCE and IFNULL length fixtures each seed zero rows and stop after one INSERT. The substring fixture seeds zero rows after three distinct INSERTs: the shape owner finds `b='A0'` but only splices initial `a='x'` into it; the existing functional alternative cannot turn a two-character witness into its one-character substring. The JSON fixture stops after two INSERTs because a missing member is assigned as NULL to required `state`, before the document-only candidate can be used. Inspected the preceding source diff and historical consuming tests, including optional/negative wrapper boundaries, native CAST composition, GLOB/substring equality groups, JSON populated/missing/functional alternatives, atomic INSERT, per-CHECK source progress, held-value projection and final persisted repetition.

Scope decision recorded BEFORE source/test edits: keep ONLY `scripts/migration_release_guard.py` and `tests/test_migration_release_guard.py`.

- Extend the existing whole-operand traversal to the first argument of positive COALESCE/IFNULL truth guards; do not descend into fallback arguments. Reuse the existing complete native false/true wrapper check and keep optional, negative, CASE, converted-operand and shadowed-boolean boundaries. This is not arbitrary SQL/function inversion.
- Preserve the already-computed shaped source as an atomic native-substring alternative for its existing normalized equality target (and existing equality aliases), alongside the current source-to-containing-text repair. Use SQLite's substring result, retain source witness/context and both operand directions, and verify chains/declaration/CHECK orders without adding a solver or candidate scheduler.
- Use the existing table metadata at the INSERT boundary to tell the JSON producer which supplied columns forbid NULL. Omit only impossible speculative NULL dependent cells for those columns, keeping their current native value and useful document/other-dependent cells. Nullable columns must retain real NULL candidates; populated/missing documents, candidate order, native non-CHECK refusal and held-value ownership remain intact.

Both 60 limits, minimum two rows, native/STRICT storage, full-CHECK numeric context, source forward passes, int64/4096-width/16384-state bounds, refusal/reference/repetition and all historical tests/parameters remain mandatory. No schema/migration/constraint/workflow/dependency/timeout/coverage change is authorized. Validation will include native original witnesses, positive/opaque wrapper composition across existing consumers, bidirectional substring propagation, required versus nullable JSON dependents, and all five migration suites. Conservatively track this traversal/substring/JSON-boundary revision as another candidate-model rewrite.

The first diagnostic command attempted an editable package build through `uv run` and failed before running the probe because this worktree has no `ui/dist`. No dependency or workflow edit was made; the existing worktree interpreter then ran the diagnostic successfully. No running service, local main, remote/production DB, merge or deployment operation was performed.

### Substring Chain Refinement (Recorded Before Refinement)

The initial implementation seeds all three original examples with three valid rows each, and 1478 unchanged truth/optional/substring/JSON/prefix/held/repetition tests pass. A separate native-valid chain probe (`c GLOB 'A*'`, widths 3/2/1, `substr(c,1,2)=b`, `substr(b,1,1)=a`) still fails in six declaration permutations under one CHECK order: per-edge alternatives preserve the original source for only one edge before the opposite-direction repair overwrites it. This is the same propagation class, not grounds to stop at the two-column example.

An in-memory experiment reuses the existing normalized substring list to derive one coordinated slice alternative from the shaped values before the old splice path runs. Propagate native slices and existing equality aliases until unchanged, with scans capped by the number of existing relationships; no candidate-domain search, new persistent cursor, parser or scheduler is introduced. Retain the old opposite-direction repair and emit the coordinated result through the same semantic fallback. All 12 chain declaration/CHECK-order probes then seed successfully. Apply this bounded refinement and add chain/alias/native-slice tests; historical coverage and both 60 limits remain unchanged.

### Nullable Test Contract Calibration

The first new-case run reached 192 passed/five NEW nullable-fixture assertion failures; the broader focused run reached 1294 passed/the same five NEW failures. These fixtures incorrectly expected full guard PASS after a nullable dependent was repeatedly stored as NULL. Independent execution of the unchanged `9947a9d54e` source and the working source produces identical rows and the same visible `no two rows share a state` failure for the direct `=` and `IS` examples. The documented contract proves non-NULL repetition, not duplicate NULLs. Functional `=` can preserve the original non-NULL value and passes; `IS` still requires NULL in the constructed missing-member fixture.

Keep every new parameter and assert native NULL-candidate acceptance/minimum row count separately from the unchanged non-NULL repetition proof. Retain the exact visible shortfall when that proof is absent; do not change final verification, remove NULL alternatives, or weaken any historical acceptance assertion. The required-column examples must still pass, and impossible NOT NULL plus missing-member `IS` examples must still refuse.

## Previous Fix Evidence (9947a9d54e; Superseded by the Diagnosis Above)

Fix commit `9947a9d54e1b835a7fcb11ee0f78e6d9aec932fe` addresses all four findings on `496f865742`. Malformed JSON inputs receive an existing valid document assignment before a numeric, shape or literal repair can enable JSON evaluation; already-valid documents retain the original semantic source ordering and missing-path alternatives. Recognized nonzero comparisons and TEXT/BLOB truth CASTs share the existing required-term traversal. SQLite validates the complete recognized wrapper composition using constant 0/1 predicates, preserving opaque cases such as `CAST(false AS BLOB) <> 0`; no arbitrary expression solver or Python affinity approximation was added.

Repeat and restore offers now hold their designated column at the same atomic INSERT/whole-row-deduplication boundary. Other useful cells from an assignment remain available, and the successfully repaired initial offer becomes the later offers' base; a rejected maximal offer still cannot contaminate mandatory fallback. Native final repetition verification and refusal/reference reporting remain unchanged. Identifier normalization reuses its ASCII translation table, and numeric-domain scoring binds each column's predicates once and invokes only the selected comparison operator. Numeric ranking, stable ties, candidate families/order, native full-CHECK context and per-CHECK forward source progress are unchanged.

Final five-suite migration regression: **4145 passed, no skips**, 228.56 seconds, 907 existing SQLAlchemy warnings. This includes every tagged upgrade (including rc6), current-schema all-table minimum rows, native/STRICT storage, isolation, refusal, references and repetition. Added 271 cases. No test/parameter was dropped; all historical full-seeder acceptance/minimum-row/refusal/reference/repetition assertions remain unchanged. One internal CAST-opacity assertion now treats its existing TEXT/BLOB truth-CAST parameters as positive requirements, matching native SQLite; its other parameters retain their original expectations. Ruff and diff-check pass. Independent source/test diff inspection confirms only the two authorized files: **285 insertions/43 deletions**, including 184 added/one changed test line.

The supplied guarded JSON, nonzero, TEXT-CAST and BLOB-CAST schemas each seed three valid rows, with the first accepted row reached in three distinct INSERTs. The supplied equality/functional-repeat schema seeds two valid rows and records native CHECK refusals for the bounded repeat offers instead of falsely claiming a duplicate. Native integrity checks pass. The held last-column boundary experiments now seed 51/56/57 rows at widths 50/55/56 without shortfalls, while all historical bounded-coverage assertions remain intact.

A controlled performance comparison swaps ONLY the two pure normalization/scoring functions inside the same repaired contextual-width-31 seeder. The complete **1023-statement actual INSERT traces are identical**, with 32 valid rows and 991 shape/domain calls in both runs. With cProfile enabled, elapsed time falls from 4.594 to 3.327 seconds; numeric-domain cumulative time from 1.855 to 0.930 seconds, and identifier-key calls from 1,486,056 to 471,813. This is local evidence, not a claim that CI is already green. Final full-run contextual widths 80/59 take 12.12/6.16 seconds locally. The existing 300-second CI timeout and all coverage are unchanged; old failed lint `34236524815` is not a new-head gate.

Recorded intermediate validation: 133 passed/five unchanged JSON-consumer failures prompted the recorded invalid-input-only priority refinement; then 378 historical focused and 280 new/boundary cases passed. The first full run stopped at 662 passed/three unchanged wide sparse-boundary failures, prompting the recorded held-value projection refinement. Its focused run had 44 passed/one NEW test failure: the new fixture unnecessarily demanded all-zero non-held columns although a valid negative-valued native row satisfied the property. The new assertion now checks that only the held column is positive; no historical assertion changed. All these cases are included in the final passing run.

Before commit, both complete thread inventories and all 77 reviews were independently re-fetched: #1941 has 47 threads/90 comments, 43 resolved/four awaiting replies; #1933 remains 14/28, nine resolved/five carried. Head counts remain twenty, with the current four findings bound to terminal review `5143218298`; the completed summary and withdrawn eyes were re-verified immediately before push. Origin/master remains `e4924db41`; merge-base remains `c570ab009`, and the main checkout was not fast-forwarded. Same sole-owner watch/cursor remain healthy and unchanged. No local Incus E2E, remote/production DB verification, merge/deployment or running-service operation was performed. New-head pickup, exact-head CI and reply/readback/resolution must still be verified before delivery can pass.

Normal push of `9947a9d54e1b835a7fcb11ee0f78e6d9aec932fe` is verified by local/remote refs and GitHub; the worktree is clean. Replies `3959573129`, `3959573066`, `3959577158` and `3959577081` were independently read back with exact draft bodies and original comment IDs BEFORE resolving their threads. Full re-fetch confirms **47/47 threads resolved**, 94 comments, 63 reviews and no nested comment pages or current-head bot finding. The four current-head owner reply envelopes have empty bodies and are not verdicts.

Automatic new-head review pickup is independently confirmed: summary `5578421575` names `9947a9d`, Running since 2026-09-08T15:27:11.891261Z, “New commits”; bot PR-body eyes `494636152` was created at 15:27:16Z. No explicit trigger was posted. The old review/summary/withdrawn-eyes boundary was verified before this push, and the same watch/cursor retain the unchanged-head epoch. Sole exact-head lint `34244803005`, suite `92765860559`, attempt 1, is in progress. All 16 present jobs and independently fetched check-runs were inspected: 13 successful, unit-tests (0/6), UI and migration-release-guard still running; the unit-tests aggregate is absent. Review and CI remain pending, not a delivery PASS. Same sole-owner watch `c052cd565ea2` remains healthy/process-alive, follow-up `7500884b511d`; command and cursor are unchanged.

## Twentieth Findings-Head Diagnosis (Before Edits)

Orchestrator `sesssbbj4mt2y` independently re-fetched the complete paginated inventories on 2026-09-08: #1933 has 14 threads/28 comments (nine resolved/five carried), and #1941 has 47 threads/90 comments (43 resolved/four new unresolved). All 77 reviews, issue comments, PR-body reactions and #1941 comment reactions were fetched; there are no nested comment pages. Bot review `5143218298` is bound to `496f865742a6abd606153ad0041beff3668fa565`, submitted at 14:45:09Z. Summary `5578421575` completed at 14:45:14.265696Z; current PR-body eyes and the old external-trigger eyes have withdrawn. No review is pending. The unchanged sole-owner watch `c052cd565ea2` is healthy/process-alive, follow-up `7500884b511d`; its command and cursor are untouched.

There are now **twenty findings-bearing heads**, chronological counts **3/2/4/5/3/3/4/5/2/3/2/4/3/1/3/4/2/2/2/4**. New findings repeat semantic JSON ordering (`3959135766`), required truth traversal (`3959135782`, `3959135791`), and repeat-assignment ownership (`3959135801`). Counts and rewrite boundaries do not reset. The breaker paused source/test edits pending this whole-inventory diagnosis and independently chosen scope.

All four supplied schemas reproduce the reported failures. Native witnesses insert successfully and pass integrity: the guarded JSON schema and nonzero/TEXT/BLOB truth wrappers seed zero rows; the equality/functional-repeat schema inserts three distinct triples but falsely claims a repeated `b`. Inspected the prior diff and shared lexical/required-term, JSON/member/recipient, shape/numeric, full-CHECK evaluation, atomic INSERT, whole-row/source-progress, repeat/restore and final readback owners, plus their historical consuming tests. A read-only in-memory held-assignment experiment restores the original repeat schema to two valid rows with native CHECK refusals recorded instead of a false repetition claim.

The sole exact-head lint run `34236524815`, suite `92742103084`, attempt 1, has all 17 expected jobs AND independently fetched check-runs present/completed: 15 success, `unit-tests (0/6)` and the unit-tests aggregate failed. This is not green. Its full log/annotations show the existing 300-second whole-file watchdog interrupted `test_migration_release_guard.py` after 2832 passing cases, without an assertion failure; the interrupted tmp-path frame is not proof of a hung lexical test. CI inter-result timings put 116.155 seconds in six wide-ranked cases. Local unchanged-head cProfile of contextual width 31 measured 991 shape/numeric-domain calls, 1,044,514 score calls and 1,485,606 identifier normalizations. The timeout is not another findings-bearing review head, not a flaky rerun candidate, and not permission to weaken coverage.

Scope decision recorded BEFORE source/test edits: retain ONLY `scripts/migration_release_guard.py` and `tests/test_migration_release_guard.py`.

- Let existing JSON assignments reach native INSERT before another candidate enables guarded JSON evaluation; retain populated documents before missing-path alternatives, optional-scope isolation and whole-row deduplication. The same class includes numeric/shape guards, not only generic state literals. No broad catch/retry of native malformed-JSON refusals and no new candidate family or source-cursor owner.
- Extend the existing whole-operand traversal for nonzero comparisons and all truth CAST affinities. Preserve the complete recognized wrapper composition when validating transparency: native probes show `CAST(0 AS BLOB) <> 0` and `+CAST(0 AS TEXT) <> 0` ACCEPT false, unlike direct truth CASTs. Therefore merely deleting the affinity filter or adding a suffix regex is insufficient. Use SQLite's constant 0/1 truth results at the recognized-wrapper boundary, not a second affinity evaluator or arbitrary expression solver. Optional/negative/CASE paths, shadowed boolean names and converted comparison operands remain opaque.
- Make the existing INSERT boundary honor the repeat probe's held column, including restoration after reference resolution; assignments may not silently turn a repeat into a different-value INSERT. Preserve the successfully repaired initial candidate as the base for later offers (as the caller's existing contract requires), without carrying mutations from a rejected maximal offer into the mandatory fallback. Keep final persisted repetition verification, native refusal reporting, reference checks and minimum two rows.
- Remove pure repeated work in identifier normalization and numeric-domain scoring. Bind each column's predicates once and evaluate only its actual comparison operator; stable domain/candidate ordering, native full-CHECK context, source progress and candidate families must remain unchanged. Measure again before choosing any further performance scope; do not add a cross-row cache, prune CHECK context, change workflow/timeouts, drop parameters/tests, or skip guard coverage.

Both 60 limits, minimum two rows, native/STRICT storage, int64/4096-width/16384-state bounds, refusal/reference/repetition contracts and all historical acceptance tests remain mandatory. Verify native positive and negative wrapper compositions, JSON guard ordering, held/restore behavior, exact numeric-domain order and the final five migration suites. Conservatively track the wrapper/held/JSON-priority revision as another candidate-model rewrite. No migration/schema/constraint/dependency change, merge/deployment, local-main fast-forward, remote/production DB operation, or running-service change is authorized.

### JSON Priority Refinement (Recorded Before Refinement)

Initial historical focused validation: 133 passed / five failures, all unchanged numeric-CAST JSON consumers. The native execution trace/model shows why unconditional JSON priority is too broad: after the required document is valid, its `{}` alternative can replace it while a separate literal CHECK is still pending; returning to the original JSON CHECK then finds the already-attempted good whole row and stalls. Refine the same priority boundary to **invalid JSON inputs only**, identified from existing JSON-term source columns and SQLite's `json_valid`. Existing valid documents, member alternatives and missing-path candidates retain the original semantic source ordering/progress. This still repairs guarded malformed inputs before numeric/shape/literal candidates can enable their evaluation, without broad exception handling or a new source cursor. Historical tests and assertions are unchanged.

### Held-Assignment Refinement (Recorded Before Refinement)

After the JSON boundary refinement, 378 historical focused tests and 280 new/boundary-focused cases passed. The first full run stopped at 662 passed / three unchanged wide sparse-boundary failures. The repaired base now correctly produces 50/55/56 rows, but the final held-last-column offer exhausts 60 INSERTs because rejecting an entire assignment that changes the held column also discards useful changes to every other column. This is the same held-assignment boundary, not grounds to weaken the historical shortfall assertion or alter numeric scheduling. A read-only in-memory experiment retains each existing assignment's changes to other columns while restoring the fixed held value atomically before whole-row deduplication/INSERT. It seeds 51/56/57 valid rows respectively, with no shortfalls/refusals and native integrity passing. Refine the existing INSERT owner to project each whole assignment onto the held-value contract instead of discarding the whole assignment; keep the original candidate order, both 60 budgets, full-CHECK evaluation and final repetition readback.

## Capability

Follow-up to #1933, which the owner explicitly requested merging with green CI before closing five remaining generic-seeder edge findings. The original rc6 baseline blocker is already repaired on master. This PR repairs those remaining candidate-generation and evaluation cases without changing migrations, schema constraints, workflow coverage, dependencies, or production behavior.

- Native isolated typed evaluation preserves affinity/defaults and fixture state. EXPLAIN compiles CHECK/DEFAULT value expressions without executing them; unavailable context defers to actual INSERT.
- Finite ranked/sparse/Cartesian/anchor candidates retain 60 evaluations per pass and 60 actual INSERT attempts. Wide domains keep a stable bounded anchor prefix. STRICT mode governs storage; flexible columns retain semantic seeds.
- Shared lexical boundaries preserve complete quoted and unquoted identifiers. Unconditional equality/substring relationships guide bounded GLOB/width repair; independent witnesses preserve collation alternatives and valid native storage.
- Derived repairs are atomic. Whole-row deduplication and per-CHECK forward source passes retain numeric and semantic tails before either source wraps. Literal bindings precede connected-recipient alternatives; required JSON documents and local speculative alternatives stay separate, retain native members, and mask raw paths/patterns.

## Previous Fix Evidence (Superseded By The Twentieth Diagnosis)

Fix commit `496f865742a6abd606153ad0041beff3668fa565` addresses both findings on `f734b32505`. Existing per-CHECK source cursors now finish forward passes before wrapping together, so repeated numeric vectors in changed text contexts cannot consume the other source's first-pass tail. Whole-row deduplication still allows later repairs after other columns change. Generic literals reuse existing CHECK-term connectivity, retaining transitive/functional/conditional recipients without polluting disconnected numeric/JSON columns. The shared required-term traversal recognizes whole numeric CAST wrappers, their top-level `AS` delimiter, supported unary/hint/truth-comparison compositions and either truth-comparison direction. Operand casts, optional/negative/CASE paths and nonnumeric casts remain opaque.

Final five-suite migration regression: **3874 passed, no skips**, 267.00 seconds, with 907 existing SQLAlchemy warnings. This includes every tagged upgrade (including rc6), current-schema all-table minimum rows, native/STRICT storage, isolation, refusal, references and repetition. Added 226 cases; historical tests are unchanged (169 test lines added, none removed). Expanded focused run: 2602 passed. The initial focused run had 548 passed/one NEW test failure: the assertion incorrectly expected the offset-preserving traversal to remove an original SQL comment; the new assertion now compares projected terms. No historical test or acceptance assertion was changed. Ruff and diff-check pass.

Both supplied schemas now seed three valid rows with native integrity checks passing. The source-tail schema reaches its first accepted row in **38 distinct INSERTs**, and the CAST schema in **three**; a reversed CAST truth-comparison probe also succeeds in three. The first-pass property is tested symmetrically for both finite sources whose combined distinct cost fits 60. Full-seeder tail tests cover 30/45/50 literals, both declaration and term orders, ordinary/generated/connection-state contexts. Connected literal tests retain functional and conditional chains while preserving unrelated native documents. Arbitrarily large combined sources or Cartesian products remain bounded heuristic failures, not a completeness promise.

Independent source/test diff review confirms **215 insertions/16 deletions in only the two authorized files**. The native full-CHECK evaluator, numeric ranking/families, atomic INSERT, whole-row identity, both 60 limits, minimum two rows, int64/4096-width/16384-state limits and refusal/reference/repetition contracts are unchanged. No new dependency, schema, migration, parser/solver, cache or cursor owner. Origin/master was fetched at `e4924db41`; merge-base remains `c570ab009`, and the main checkout was not fast-forwarded. No local Incus E2E, remote/production DB verification, merge/deployment or running-service operation was performed.

Before commit, both full thread inventories and head counts were independently re-fetched unchanged; #1941 still had 43 threads/84 comments with these two unresolved, #1933 14/28 with its five carried threads untouched. Current-head terminal review and withdrawn eyes were read again. The prior head's fully green lint `34231381728` is NOT a new-head gate. New-head pickup, thread reply readbacks/resolution and fresh exact-head CI must be verified after the normal push. Same watch/cursor remain in place.

Normal push of `496f865742a6abd606153ad0041beff3668fa565` is verified locally/remotely, with a clean worktree. A post-push `ls-remote` SSH connection closure was reconciled by a successful read-only retry and GitHub exact-head readback; the push was not duplicated. Replies `3958793560` and `3958793461` matched their exact drafts and original comment IDs on separate GETs BEFORE resolution. Complete re-fetch: **43/43 threads resolved**, 86 comments, 58 reviews, no nested comment pages and no current-head bot finding. Owner reply-envelope reviews `5142821318`/`5142821433` have empty bodies and are not bot verdicts.

New-head pickup is confirmed by summary `5578421575`: `496f865` Running since 2026-09-08T14:10:15.545924Z, “New commits”; bot PR-body eyes `494475166` was created at 14:10:19Z and independently fetched. No explicit trigger was posted. Prior `f734b32` review `5142438326`, summary completion and both withdrawn eyes were re-verified before push; the old external trigger `5585800027` is not a trigger for this head. Sole exact-head lint `34236524815`, suite `92742103084`, is in progress; all 15 present jobs and independently fetched check-runs were inspected, with the unit-tests and install-upgrade-regression aggregates not yet present. Review and CI remain pending, not a delivery PASS. Same sole-owner watch `c052cd565ea2` is healthy/process-alive, follow-up `41a9874fe009`; command and cursor are unchanged.

## Nineteenth Findings-Head Diagnosis (Before Edits)

Orchestrator `sesssbbj4mt2y` independently re-fetched both complete paginated inventories on 2026-09-08: #1933 has 14 threads/28 comments, nine resolved/five carried; #1941 has 43 threads/84 comments, 41 resolved/two new unresolved. No nested comment pages remain. All 74 reviews, all issue comments and PR-body/comment reactions were fetched. Bot review `5142438326` is bound to `f734b32505c23853468e99aab938ca38c5a311eb`, submitted at 13:37:43Z; summary `5578421575` records completion at 13:37:46.535423Z, and both the PR-body and external-trigger eyes have withdrawn. No review remains pending and no duplicate trigger was posted. Sole exact-head lint `34231381728`, suite `92727333420`, is successful; all 17 expected jobs and independently fetched check-runs are present/successful. Same sole-owner watch `c052cd565ea2` is healthy/process-alive, follow-up `41a9874fe009`; command/cursor are untouched.

There are now **nineteen findings-bearing heads**, chronological counts **3/2/4/5/3/3/4/5/2/3/2/4/3/1/3/4/2/2/2**. The two new roots repeat source-budget/progress (`3958476174`, `PRRT_kwDOPbFPYs6gQrdK`) and required-truth traversal (`3958476182`, `PRRT_kwDOPbFPYs6gQrdO`). Historical counts and rewrite boundaries do not reset. The breaker paused edits until this full-inventory diagnosis and scope decision.

Both supplied schemas reproduced zero full-seeder rows while native accepted witnesses passed integrity. The source case used 60 distinct actual INSERTs, ending at `a028` without reaching `ready`: the numeric source repeatedly wraps its short list as each new text value makes the same numeric vector a new whole row. Generic broadcasts also send a term's literals into disconnected numeric columns when declarations are reversed. The CAST case stopped after one INSERT because the required length term remained opaque. The previous diff, shared lexical/required-term owners, numeric evaluator/schedule, generic/semantic producers, whole-row deduplication and per-CHECK progress owner, and their consuming tests were inspected.

Scope decision, recorded BEFORE source/test edits: retain ONLY `scripts/migration_release_guard.py` and `tests/test_migration_release_guard.py`. Evolve the existing per-CHECK source positions into forward passes: a source that reaches its tail yields remaining turns to the other source; only after both passes are exhausted may existing whole-row deduplication permit another pass in the changed row context. Do not permanently deduplicate individual cells, freeze candidate lists, add a cursor owner/cache, raise limits, or merely alter weights. Reuse existing CHECK-term recipient connectivity for generic literals, retaining functional/conditional connected recipients and preferred explicit bindings without broadcasting into disconnected terms.

An in-memory experiment of that same-owner pass policy plus connected literal scope seeded three valid rows for every 30/45/50-item tail probe, both declaration orders, ordinary/generated-column/connection-state contexts. A competing partial-CHECK numeric-evaluation experiment also helped the simple example, but was rejected as the implementation choice: generated columns may hide dependencies, so pruning their context could wrongly suppress needed numeric alternatives. Native full-CHECK evaluation and all existing numeric candidate families remain unchanged.

For CAST, extend the existing offset-preserving whole-operand traversal to recognize its own top-level `AS` delimiter and reuse the existing affinity classifier for numeric target types. Only complete numeric truth wrappers may expose their body to existing required-term consumers; operand casts, negative/optional/CASE paths, boolean-name shadowing and nonnumeric conversions remain opaque. No arbitrary SQL/function inversion, new parser/solver, candidate family or schema change. Verify all existing consumers and wrapper compositions, native CAST boundaries, source-tail/order/context properties, refusal/minimum-row/repetition/reference behavior, and the final five migration suites. Both 60 limits and int64/4096-width/16384-state bounds remain mandatory. Conservatively track this source-pass/required-term revision as another candidate-model rewrite.

## Previous Fix Evidence (Superseded By The Nineteenth Diagnosis)

Fix commit `f734b32505c23853468e99aab938ca38c5a311eb` addresses both findings on `152a677ab1`. The existing whole-required-term traversal now recognizes unary signs and compositions with supported truth wrappers, retaining NOT parity, boolean-name shadowing, and the distinction between whole predicates and signed comparison operands. Existing length/substring/JSON scalar-result forms accept unary plus without erasing bare-column affinity. The shared lexical owner uses complete SQLite identifier-character boundaries, ASCII grammar whitespace/case rules, consistent keyword/numeric boundaries, and offset-preserving standalone-BOM projection; Unicode characters inside identifiers remain intact. No new parser/solver, scheduler, candidate family, cache or cursor owner.

Final five-suite migration regression: **3648 passed, no skips**, 248.54 seconds, with 907 existing SQLAlchemy warnings. This includes every tagged upgrade (including rc6), current-schema all-table minimum rows, refusal, references, repetition and isolation. Added 408 cases; historical tests are unchanged (190 test lines added, none removed). Final focused run: 834 passed. Ruff and diff-check pass. Independent source/test diff review confirms only the two authorized files, 239 insertions/28 deletions. Fetched origin/master is `e4924db41`; merge-base remains `c570ab009` and the main checkout was not moved.

Native replay of both supplied schemas now seeds three valid rows each, reaching the first row in three distinct INSERT attempts each. The same result holds for the previously accepted unary-minus/boolean-suffix/scalar-plus variants and the NBSP identifier probe. Native witnesses and seeded rows pass integrity checks. Whole-row deduplication, per-CHECK progress, both 60-attempt limits, minimum two rows, native/STRICT storage and int64/4096-width/16384-state bounds remain unchanged.

Intermediate evidence: 46 passed/five NEW JSON-fixture failures exposed CHECK's NULL acceptance, not a seeder failure; the new required-member test uses `IS` rather than `=`. Next focused run: 737 passed; first full five-suite run: 3551 passed in 245.89 seconds. Native comparison with merge-base `c570ab009` then confirmed additional released unary shapes needing the recorded scope refinement. The subsequent full run was intentionally interrupted at 1676 passed/115.50 seconds to tighten the signed-comparison boundary (`-1=(a=b)` is not a whole truth wrapper); it had no test failure. Next 834 focused tests and the final 3648-test run cover that boundary. No historical assertion was modified or weakened.

The full inventory/counts were independently re-fetched before commit: #1941 has 41 threads/80 comments, 39 resolved/two awaiting replies; #1933 remains 14/28, nine resolved/five carried. All 71 reviews retain the eighteen findings-head counts below. A PR-body refinement HTTP 400 was reconciled as unchanged before a successful JSON-input PATCH/readback; transient reaction-read EOFs were retried successfully, never counted as empty. The prior head's terminal findings and its green lint `34225180784` are NOT review/CI gates for this new commit. New-head pickup must be verified after normal push. Same watch/cursor remain unchanged. No local Incus or remote/production DB verification, merge, deployment, running-service operation, or main-checkout fast-forward.

Normal push of `f734b32505c23853468e99aab938ca38c5a311eb` is verified clean locally/remotely. Replies `3958332072` and `3958331888` were fetched and matched to their exact drafts and original-comment IDs before resolution. Complete re-fetch: 41/41 threads resolved, 82 comments, 55 reviews, no nested comment pages and no new-head bot verdict. Bodyless owner reply-envelope reviews are not verdicts. Sole exact-head lint `34231381728`, suite `92727333420`, is in progress; all 16 present jobs and independently fetched check-runs were read, with the unit-tests aggregate not yet present. Initial post-push PR-head propagation, one issue-comment TLS timeout and one check-run EOF were reconciled by successful fresh reads.

Current-head review pickup is confirmed: summary `5578421575` first reported automatic review of `f734b32` since 2026-09-08T13:20:58Z, and PR-body bot eyes `494378556` was created at 13:21:02Z. A later complete comment fetch discovered an external owner-account trigger `5585800027` created at 13:20:49Z, not posted by this turn. Its bot eyes `412951748` at 13:21:03Z was independently read; the summary now names `f734b32` Running since 13:21:06Z with trigger “Manual request”. No additional trigger was posted. Prefer the resulting SHA-bound bot verdict; if a terminal reaction-only result leaves the around-push binding ambiguous, follow the existing one-trigger-after-terminal rule, never duplicate a pending review or a current-head SHA-bound pass. Same sole-owner watch `c052cd565ea2` is healthy/process-alive, with follow-up run `3e0b293948f0`; command and cursor are unchanged. Review and CI remain pending, not a delivery PASS.

## Fourteenth Follow-Up Review: Circuit-Breaker Diagnosis

Recorded BEFORE source/test edits at `152a677ab17b4d1982151306d5d4f7e7e6f0aae3`. Terminal bot review `5141764663` submitted 2026-09-08T12:39:29Z; summary completed at 12:39:34Z. Complete paginated inventory independently fetched: 55 threads / 108 comments across #1933 (14/28, nine resolved/five carried) and #1941 (41/80, 39 resolved/two open), all 71 reviews, issue comments and reactions. Two transient reaction-read EOFs were retried successfully, never counted as empty. Sole exact-head lint `34225180784`, suite `92709820422`, and all 17 expected jobs and independently fetched check-runs are successful. EIGHTEEN findings-bearing heads have counts 3/2/4/5/3/3/4/5/2/3/2/4/3/1/3/4/2/2; counts never reset.

- `3957972533` / `PRRT_kwDOPbFPYs6gPZCk`: repeated required-term/truth-wrapper root. Full seeding of `CHECK(+(length(a)=2) AND state='ready')` produces zero rows although native `('AB','ready')` passes integrity checking. The existing traversal does not unwrap a unary-plus prefix.
- `3957972539` / `PRRT_kwDOPbFPYs6gPZCq`: repeated lexical-identity root. Full seeding of `CHECK(length(١)=2 AND state='ready')` likewise produces zero rows with an accepted native witness. Native differential probes reproduce the same class for combining marks, emoji, symbols, and non-ASCII whitespace in identifier starts/continuations. Python Unicode word/digit/space categories do not describe SQLite identifier tokens: the current traversal even trims an NBSP identifier away and splits control words after non-word Unicode characters.

Inspected the previous diff, shared projection/matcher/token definitions, required-term traversal, length/GLOB/substrings/equality/JSON consumers, numeric literal extraction/ranking, actual INSERT and per-CHECK progress, and the existing wrapper/identifier acceptance and optional-branch consumers. Native probes also confirm that `a=1` and `+a=1` differ for a TEXT value `'1'`; indiscriminately deleting unary plus would change affinity semantics. Leading U+FEFF is not a SQLite identifier starter, while an embedded U+FEFF is part of an identifier.

Orchestrator scope decision: retain ONLY `scripts/migration_release_guard.py` and `tests/test_migration_release_guard.py`. Evolve the existing shared lexical owner to use SQLite's ASCII letters/underscore plus non-ASCII identifier characters (except leading BOM), ASCII digits/dollar as continuations, consistent complete-token boundaries for keywords/numeric literals, and ASCII grammar whitespace/case matching without trimming non-ASCII identifier contents. Reuse the existing whole-operand wrapper traversal for unary-plus chains and composition with already-supported transparent truth wrappers. Do not strip plus from an operand inside a comparison or make optional/negative/compound predicates required.

Tests will assert native identifier identity and complete-token preservation across existing candidate owners, keyword-like continuations, numeric boundary provenance, required unary wrapper equivalence, and optional/affinity non-destruction. Keep all historical full-seeder acceptance/minimum-row/refusal/reference/repetition assertions. Actual INSERT remains authoritative; whole-row deduplication, per-CHECK progress, native/STRICT storage, both 60-attempt limits, minimum two rows and int64/4096-width/16384-state bounds are unchanged. No new parser, solver, candidate family, scheduler, cache, cursor owner, dependency, schema or migration change. Conservatively track this lexical/required-term boundary revision as another candidate-model rewrite. Same watch/cursor remain unchanged; no merge, deployment, running-service operation, main-checkout fast-forward, or remote database testing.

Before the next refinement: 737 focused tests passed. The first new-only run stopped at 46 passed/five JSON fixture failures: `=` permits missing-path NULL to pass a CHECK, so the new positive-required fixture now uses native `IS 'AB'`; no historical assertion changed. Independent native INSERT probes also found that `-(length(a)=2)`, `-(length(a)=2) IS TRUE`, and `+length(a)=2` still fail although the merge-base seeder at `c570ab009` accepts them. These are the same unary boundary regression, not a reason to delete released capability. Scope refinement BEFORE edits: let the existing whole-operand traversal treat unary signs as truth-preserving only where a whole CHECK/boolean suffix requires truth (never erase a minus under `=1`); retain the existing NOT parity boundary. Let the already-recognized length/substring/JSON scalar-function forms accept unary-plus prefixes on their function results, which have no column affinity to erase. Bare-column operand affinity and unsupported function inversion remain native/visible. Standalone BOM runs use the existing opaque projection to become whitespace, while embedded BOMs remain identifier contents.

## Previous Head Evidence (superseded by the review above)

Fix commit `152a677ab17b4d1982151306d5d4f7e7e6f0aae3` addresses both findings on `844cb753dc`. The existing JSON producer now constructs required whole clauses across CHECKs before separate local speculative clauses from the failing CHECK. Both scopes reuse one document/member-assignment implementation; populated documents precede missing-path alternatives. Native errors reject only the speculative document/member candidate, while actual INSERT retains the schema's visible refusal. The common conjunction traversal consumes complete `SQL_IDENTIFIER` tokens, so embedded control-keyword text cannot split a valid column name. Actual INSERT, whole-row deduplication, per-CHECK source progress, native/STRICT storage, both 60-attempt limits, minimum rows and all text/state/int64 bounds are unchanged.

Final five-suite migration regression: **3240 passed, no skips**, 212.70 seconds; 907 existing SQLAlchemy warnings. This includes every tagged upgrade (including rc6), current-schema all-table minimum rows, refusal, references, repetition and isolation. Added 178 cases; all historical tests are unchanged (147 test lines added, none removed). Expanded focused run: 2316 passed; earlier focused run: 482 passed. Ruff and diff-check pass. Independent source/test diff review confirms only the two authorized files, 223 insertions/49 deletions. Fetched origin/master remains `2bdbb05de`; merge-base remains `c570ab009` without moving the main checkout.

Native replay of the two supplied schemas now seeds two valid rows each and reaches the first accepted row in two distinct INSERT attempts each. The dead-invalid-path schema seeds three rows in three first-row attempts; the retained local-optional JSON control seeds three rows in four attempts; a joint required-path consumer seeds two rows in two attempts. All supplied native witnesses and seeded rows pass integrity checks; no trace repeats an INSERT assignment.

Intermediate evidence: the first focused run stopped at 85 passed/five NEW-fixture failures. Four reordered likelihood fixtures evaluated malformed initial JSON before any named CHECK repair; adding the fixture's own `json_valid` guard preserves the established malformed-JSON refusal contract. The fifth assumed `$[` always raises an OperationalError, but native SQLite rejects this `{}` case with a CHECK IntegrityError instead; the new test now compares the seeder's exact refusal with the native error rather than guessing its subtype. No historical assertion or actual INSERT behavior changed.

Fresh exact-head CI and Codex pickup must be verified after the normal push; neither the green `844cb753dc` CI nor its terminal findings review is a gate for this fix. The full inventory was re-fetched before commit: #1941 has 39 threads/76 comments, 37 resolved/two awaiting replies; #1933 remains 14/28, nine resolved/five carried. All 68 reviews preserve the seventeen findings-head counts recorded below. One transient inventory TLS timeout was retried successfully, never counted as an empty collection. Same watch and cursor remain unchanged. No local Incus or remote/production DB verification, merge, deployment, running-service change, or main-checkout fast-forward.

Normal push of `152a677ab17b4d1982151306d5d4f7e7e6f0aae3` verified clean locally/remotely. Replies `3957783690` and `3957783819` were fetched and matched to their exact drafts and original-comment IDs before resolving. Complete re-fetch: 39/39 threads resolved, 78 comments, 52 reviews, no nested comment pages or new-head bot verdict. Auto-review pickup is verified: summary `5578421575` Running for `152a677` since 2026-09-08T12:16:57Z; bot-authored PR-body eyes `494269241` at 12:17:03Z. No duplicate explicit trigger. Sole exact-head lint `34225180784` is running; all 15 present jobs and check-runs were independently fetched, four successful/eleven running, with both aggregate jobs not yet present. Review and CI are pending. Same sole-owner watch `c052cd565ea2` is healthy/process-alive and its command/cursor remain unchanged.

## Thirteenth Follow-Up Review: Circuit-Breaker Diagnosis

Recorded BEFORE source/test edits at `844cb753dc227d9dec003084e13632dc13947ba3`. Terminal bot review `5141275776` submitted 2026-09-08T11:47:19Z; summary completed at 11:47:23Z. Complete paginated inventory independently fetched: 53 threads / 104 comments across #1933 (14/28, nine resolved/five carried) and #1941 (39/76, 37 resolved/two open), all 68 reviews, issue comments and reactions. One transient read EOF was retried successfully, not treated as an empty collection. Sole exact-head lint `34221059784` and all 17 expected jobs and separately fetched check-runs passed. SEVENTEEN findings-bearing heads have counts 3/2/4/5/3/3/4/5/2/3/2/4/3/1/3/4/2; counts never reset.

- `3957552743` / `PRRT_kwDOPbFPYs6gOUSy`: repeated requiredness/JSON-provenance root. Aggregate scanning folds optional `json_extract(doc,'$.x')=2 OR 1` into the document required by `(json_valid(doc) AND json_extract(doc,'$.x')=1) IS TRUE`. Full seeding produces zero rows, though native `{"x":1}` passes. A CASE-dead invalid path additionally raises an uncaught `OperationalError` during candidate construction.
- `3957552747` / `PRRT_kwDOPbFPYs6gOUS1`: repeated lexical-identity root. The boolean-keyword regex splits valid `foo$and` into `foo$` and `and`; full seeding produces zero rows, though native `A` passes. Prefix/suffix probes for all five boolean-control keywords reproduce either splitting or lost conjunctions.

Inspected the previous source diff, shared SQL projection/matcher/identifier definition, required-term traversal, JSON document/member producer, recipient connectivity, actual INSERT and per-CHECK source progress, and existing optional-shape, JSON-dependency and identifier consumers. Both supplied schemas and the dead-path variant were reproduced through the full seeder; native accepted rows pass integrity checks. Existing optional JSON OR and CASE consumers also seed successfully at this head, so simply dropping all optional JSON proposals would remove real capability.

Orchestrator scope decision: retain ONLY `scripts/migration_release_guard.py` and its test file. Reuse complete `SQL_IDENTIFIER` tokens when identifying boolean-control keywords, preserving offsets, opaque tokens, parentheses, CASE and BETWEEN handling. For JSON, reuse the existing document/member construction for two distinct proposal scopes: required whole JSON comparisons across CHECKs first, then speculative comparisons from the currently failing CHECK. Optional occurrences in another CHECK cannot overwrite the required document; local optional candidates remain alternatives, not requirements. Keep source documents with dependent assignments and the existing missing-path fallback. Native errors while constructing/evaluating a speculative JSON candidate discard that candidate locally; actual INSERT remains authoritative and retains visible schema refusals. Do not introduce a path parser, solver, scheduler, cache, cursor owner, dependency, or higher budget.

Tests will assert required-document preservation under optional/negative/compound/dead clauses, valid local optional alternatives, native invalid-path refusal without helper crashes, and complete-identifier invariance across existing consumers and every boolean-control keyword. Preserve all historical full-seeder acceptance/minimum-row/refusal/reference/repetition assertions, native/STRICT storage, both 60-attempt limits and text/state/int64 bounds. Same watch/cursor remain unchanged; no merge, deployment, running-service operation, remote database testing, or main-checkout fast-forward. Conservatively track this proposal-scope/lexical-boundary revision as another candidate-model rewrite; any future repeated root still requires renewed full-inventory diagnosis.

## Previous Head Evidence (superseded by the review above)

Fix head `844cb753dc227d9dec003084e13632dc13947ba3` addresses all four findings on `53acbf758a`. Required-term traversal recognizes truth-preserving wrappers, respecting declared/omitted/generated names that shadow boolean literals. GLOB and JSON semantic alternatives retain whole assignments and propagate only through connected CHECK terms; independent columns are not broadcast recipients. Bare required equality groups retain native member alternatives without needing a GLOB. JSON candidates keep their source documents and missing-path fallback. Actual INSERT, whole-row deduplication, per-CHECK progress, both 60-attempt limits, minimum rows and all previous refusal/reference/repetition contracts remain unchanged.

Final five-suite migration regression: **3062 passed, no skips**, 203.87 seconds; 907 existing SQLAlchemy warnings. Added 267 cases. Focused class run: 2360 passed before a behavior-preserving removal of repeated identifier parsing; final full run includes that optimization. All tagged upgrades including rc6 and current-schema all-table minimum rows passed. Native traces of the four original schemas each reach the first accepted row in three distinct INSERT attempts; full seeding produces 3/3/3/2 rows with integrity intact. Ruff/diff-check pass. Only one historical internal JSON proposal-shape test was adapted to whole assignments; its value/type/opaque-token assertions and all historical full-seeder acceptance assertions remain intact.

Intermediate evidence is retained below: 2320 focused passed, then 3054 full passed before the independently found disconnected-column regression. A later full run was interrupted after 715 passing tests solely to remove repeated pure identifier parsing (201.68 seconds); it is not counted as a full pass. The final 3062-test run is the completion evidence. Scope refinements were recorded/read back before corrections. Diff self-review confirms only the two authorized files; origin/master was fetched to `2bdbb05de` without moving the main checkout, and merge-base remains `c570ab009`.

New-head CI and Codex are fresh gates, not inherited from `53acbf758a`; no passing review is claimed. No local Incus, remote/production database verification, merge, deployment, service restart, or main-checkout fast-forward. Same durable watch/cursor remain unchanged. The five carried #1933 threads remain unresolved until corrective merge actually occurs.

Normal push of `844cb753dc227d9dec003084e13632dc13947ba3` verified clean locally/remotely. Replies `3957428981`, `3957429035`, `3957429326`, `3957429063` were fetched and compared with their drafts and original-comment IDs before resolution. Whole-PR re-fetch: 37/37 threads resolved, 74 comments, 49 reviews, no extra nested pages or new-head bot verdict. Auto-review pickup is verified: summary `5578421575` Running for `844cb75` since 2026-09-08T11:30:47Z and bot-authored PR-body eyes `494199173` at 11:30:53Z. No explicit duplicate trigger. Sole exact-head lint `34221059784` is in progress; all 15 present jobs and check-runs independently fetched, four successful and eleven running; the unit-tests and install-upgrade aggregate jobs remain absent. CI and review are pending, not completion.

## Twelfth Follow-Up Review: Circuit-Breaker Diagnosis

Recorded BEFORE source/test edits at reviewed head `53acbf758a01e2b1295c629b44aba912354d03b1`. Terminal bot review `5140762342` submitted 2026-09-08T10:52:25Z; summary `5578421575` completed at 10:52:28Z, with four findings, not a PASS. Independently fetched the complete paginated inventory: 51 threads / 98 comments across #1933 (14/28, nine resolved/five carried) and #1941 (37/70, 33 resolved/four open), all 63 reviews across both PRs, issue comments/reactions, and every exact-head lint run. Sole run `34216367668` and all 17 expected jobs and independently fetched check-runs are successful. SIXTEEN findings-bearing heads have counts 3/2/4/5/3/3/4/5/2/3/2/4/3/1/3/4. Counts are not reset by a push, rewrite, or PR transfer.

- `3957107388` / `PRRT_kwDOPbFPYs6gNLmW`: required-condition normalization repeats the conditional-shape class. `(length(a)=2) IS TRUE`, `likely(length(a)=2)`, and `(length(a)=2)=1` each seed zero rows while native `('aa','ready')` succeeds.
- `3957107392` / `PRRT_kwDOPbFPYs6gNLmZ`: semantic witness composition repeats the GLOB dependency/atomic-row class. Negative-only `a` chooses an empty witness, positive `b` chooses `a`; `lower(a)=b` cannot receive both positive values atomically.
- `3957107396` / `PRRT_kwDOPbFPYs6gNLmc`: semantic provenance repeats the JSON/GLOB functional-dependent class. The constructed member `ready` is not retained outside bare dependency matching.
- `3957107398` / `PRRT_kwDOPbFPYs6gNLmd`: required equality composition repeats the grouping/value-propagation class. `b='A'` followed by `a=b` has no candidate because the group has no GLOB pattern.

All four supplied schemas (including all three reported truth wrappers) reproduced zero rows through the full seeder; native accepted witnesses and integrity checks succeeded. Traced actual INSERT stopped after only two or three distinct attempts, so these failures are candidate loss/composition defects, not exhaustion of the finite budget. Inspected the shared conjunctive extractor, shape/group and JSON producers, generic masking, atomic INSERT/source cursors, previous diff, and historical full-seeder consumers. The repeated-root breaker is active regardless of green CI.

Orchestrator scope decision: retain ONLY the guard and its test file. Extend the existing required-term traversal at its common boundary for grouping and truth-preserving wrappers (boolean true comparisons and SQLite likelihood hints), without descending into optional/negative/CASE branches. Apply the same traversal to every existing required-term consumer. Keep computed semantic values as speculative whole `SeedAssignment` alternatives, not forced aliases: GLOB alternatives can coordinate mentioned columns while preserving their individual detected shapes; bare required groups can offer existing native member values even without GLOB/width constraints. Evolve the existing JSON producer to retain constructed documents together with member/dependent alternatives, so a candidate never loses its source document and functional dependents can try native member values. Raw JSON paths/GLOB patterns remain masked. This is bounded candidate propagation, not arbitrary function evaluation or inversion.

Reuse the existing actual-INSERT authority, whole-row deduplication and per-CHECK source cursors; no new solver, cache, cursor owner, scheduler weights, or budget. Preserve native/STRICT storage, collation alternatives, both 60-attempt limits, minimum two rows, refusal/reference/repetition, lexical boundaries and width/state/int64 bounds. Tests will assert required-wrapper equivalence and optional-branch non-destruction across the existing shape consumers, atomic cross-CHECK alternatives and native value provenance, alongside unchanged historical acceptance tests and all five migration suites. Conservatively track this semantic-assignment/required-term revision as another candidate-model rewrite; future repeats still require renewed full-inventory diagnosis. No merge, deployment, running-service change, main-checkout fast-forward, or remote database testing.

Before the next refinement: the first expanded focused run passed 2320 tests. Two new-fixture mistakes were corrected without changing historical tests: native REAL representatives can still be Python integers, and reordered JSON dependencies need their own `json_valid` guard; malformed unguarded JSON still refuses. Independent head-versus-worktree probes then found a real wrapper regression when declared columns named `true` or `false` shadow SQLite's boolean literals. Both supplied native witnesses and the unchanged head seed those schemas; the initial wrapper implementation does not. Scope refinement BEFORE correction: pass the already-available declared/omitted/unavailable column names through the common required-term traversal, so only unshadowed boolean names are transparent wrappers. No schema parser or new source of column metadata. This closes the same identifier/requiredness boundary across shape, grouping and substring consumers.

The first full five-suite run passed 3054 tests (217.92 seconds, no skips), but an independent composition probe found a real source-boundary regression before commit: `code GLOB 'ready'`, `state=lower(code)`, and an unrelated `json_extract(payload_json,'$.x')=1` previously seed valid rows with the semantic `{}` document. Broadcasting a computed GLOB value to every named column instead writes `ready` into that unrelated document and causes a malformed-JSON refusal. Scope refinement recorded BEFORE correction: use one shared, bounded column-reachability calculation over the existing conjunctive/lexical view for speculative semantic values. Both GLOB and JSON values may traverse CHECK terms connecting their source to dependent columns (including chains), but cannot reach disconnected columns. These are candidate recipients, never forced equality groups or a function solver. Retain source documents for JSON assignments and individual shape filters for GLOB recipients; existing INSERT ownership and budgets remain unchanged. Add disconnected-column preservation and chained-dependent consumers for both semantic producers, then rerun all five suites. No historical assertion is weakened.

## Previous Head Evidence (superseded by the findings above)

Fix head `53acbf758a01e2b1295c629b44aba912354d03b1` implements all three eleventh-round findings and the recorded same-class refinements. Only unconditional whole length/GLOB/substring terms force shape repair. Storage-valid CHECK-rejected numeric assignments remain speculative origins through the existing INSERT loop; required prefix semantics share its existing semantic turn. Populated JSON documents/dependencies precede `{}` alternatives. No scheduler weights, budgets, parser, dependency or schema change.

Final five-suite migration regression: **2795 passed, no skips**, 197.30 seconds; 907 existing SQLAlchemy warnings. All tagged upgrades including rc6, current-schema minimum rows, refusal/reference/repetition and isolation checks passed. Added 212 cases; focused final shape/numeric/JSON suite: 2062 passed. An earlier full run passed 2747 before the adjacent shape-boundary closure. Original examples now yield 4/4/2 valid rows with integrity intact; the supplied numeric repeat succeeds in eight distinct INSERT attempts. Ruff/diff-check pass. Two internal proposal-list assumptions were explicitly updated, while historical full-seeder acceptance assertions remain unchanged. Source ownership and consuming tests were independently reviewed.

Current-head Codex review and exact-head CI remain fresh gates, not inherited from `853f86a`. No merge/deploy/service restart or main-checkout fast-forward. Local Incus was unavailable; no remote or production DB verification. Same durable watch/cursor remain live. The five carried #1933 threads stay unresolved until corrective merge.

Normal push of `53acbf758a01e2b1295c629b44aba912354d03b1` verified clean locally/remotely. Replies `3956987744`, `3957003762`, `3957004052` were read back before resolving; complete re-fetch shows 33/33 threads resolved, 66 comments, 44 reviews, no new-head bot verdict yet. Auto-review pickup: summary `5578421575` Running for `53acbf7` since 2026-09-08T10:36:49Z, bot eyes `494121093` at 10:36:53Z. No duplicate explicit trigger. Sole exact-head lint `34216367668` is in progress; all 15 present jobs and check-runs independently fetched, four successful/eleven running, two aggregate jobs absent. These are pending gates, not completion.

## Eighth Follow-Up Review: Circuit-Breaker Diagnosis

Reviewed head `3d3d2d681bb19ad308499067fabcd7cf362f33e9` received four findings in terminal review `5138799615` at 2026-09-08T07:45:47Z. This is the TWELFTH findings-bearing head across both PRs (3/2/4/5/3/3/4/5/2/3/2/4), first after the equality-group/progress-ownership rewrite. The orchestrator independently fetched all 40 threads and all 76 comments on #1933/#1941, all bot reviews and summary verdicts, and every matching exact-head lint run. Run `34199065520` and all 17 expected jobs/check-runs are successful. #1933 retains nine resolved/five carried unresolved; #1941 has 22 resolved/four new unresolved. All four roots repeat existing composition, storage-domain or evaluation-context classes; the breaker pauses edits despite green CI.

- [3955514535](https://github.com/avibe-bot/avibe/pull/1941#discussion_r3955514535): computed GLOB witnesses disappear outside bare equality groups. `code GLOB 'ready' AND state=lower(code)` seeds zero rows but native `('ready','ready')` succeeds. Semantic masking must preserve the computed witness as a bounded candidate, without returning raw wildcard patterns to generic guessing.
- [3955514548](https://github.com/avibe-bot/avibe/pull/1941#discussion_r3955514548): conditional equalities are promoted into unconditional identities. `a GLOB 'A' AND b GLOB 'B' AND (a=b OR 1)` seeds zero rows although native `('A','B')` succeeds. A lexical equality occurrence is not evidence that every accepted row must satisfy it.
- [3955514566](https://github.com/avibe-bot/avibe/pull/1941#discussion_r3955514566): a valid non-string shape loses its storage class during text promotion. `typeof(value)='blob' AND length(value)=0 AND state='ready'` rejects all generated rows after replacing `b''` with text, while native `('ready',b'')` succeeds. Existing native shape satisfaction must be checked before promotion.
- [3955514580](https://github.com/avibe-bot/avibe/pull/1941#discussion_r3955514580): function-name metadata conflates overloads. Scalar `max(n1,n2)` is deterministic, whereas aggregate `max(n)` is a different overload. The exactly-one-positive example exhausts the fallback although native `(0,2,0)` succeeds.

All four examples were reproduced through the minimum-row consumer and then accepted by native INSERT with integrity checks. The orchestrator inspected the shape/group owner, lexical boundaries, generic/semantic source selection, native evaluator, existing consuming tests and previous diffs before this record. Scope decision BEFORE source/test edits: retain the same two files and bounded contract. Keep computed GLOB witnesses in the existing speculative semantic source for mentioned text-eligible dependents; raw pattern operands remain masked. Form equality groups only from whole bare equality terms reached through unconditional conjunctions, preserving SQL precedence and opaque tokens. Preserve non-string values that already satisfy the detected native shape instead of promoting them solely because another column failed.

Replace the name-only function metadata screen with SQLite's own overload-aware deterministic-expression compilation: EXPLAIN CREATE INDEX against the empty isolated candidate table checks [SQLite's expression-index restrictions](https://www.sqlite.org/expridx.html) without creating an index or executing the expression. Check DEFAULT expressions separately before candidate DML, then the CHECK expression. Native experiments confirmed scalar min/max are admitted while aggregate min/max, state functions and keyword time functions are refused; quoted columns/literals remain data. Unknown or unsupported compilation still defers bounded assignments to authoritative target INSERT. This removes the competing name classification rather than parsing function arities or depending on unstable VM opcodes.

The first targeted run passed all four new examples and 162 related cases but exposed two unchanged default-literal tests: SQLite treats a standalone single-quoted index term as a column name. A native compile experiment confirmed that wrapping the probe in unary plus forces value-expression syntax while still rejecting nondeterministic overloads. This probe-context refinement is recorded before its correction; no existing acceptance test is weakened.

No new dependency, schema/migration/workflow change, larger budget, guard skip, or general solver claim. Preserve the 60 CHECK evaluations, 60 target INSERT attempts, minimum two valid rows, isolated connection cleanup, finite text/state/int64 limits, refusal/reference/repetition evidence, and all prior acceptance tests. Conservatively track this proposal/context-boundary change as another candidate-model rewrite; historical head and root counts remain active. The four new threads remain unresolved until fixes are pushed and verified.

## Scope And Dependencies

Only `scripts/migration_release_guard.py` and `tests/test_migration_release_guard.py`. Requires #1933, already merged as `a58644528deb8365876915904d11fb89df48db11`. Independent branch from the updated default branch; not stacked on an unmerged PR. No new dependency or public-documentation change. No matching user-facing scenario-catalog entry: this is release-check fixture construction, exercised through the seeder and tagged-release upgrade consumers.

## Carried Findings

The five threads remain unresolved on the merged PR until the follow-up is actually delivered. They are not erased or described as a passing review:

| Root | Original Finding | Follow-Up Ownership |
| --- | --- | --- |
| Insertion-context semantics (repeat) | [default affinity](https://github.com/avibe-bot/avibe/pull/1933#discussion_r3953808110) | Typed temporary candidate table; supplied/default storage differential tests |
| Constraint composition/search ordering (repeat) | [non-uniform assignments](https://github.com/avibe-bot/avibe/pull/1933#discussion_r3953808117) | Predicate-ranked finite domains; column, clause, operand and operator permutations |
| Expression normalization | [substring equality](https://github.com/avibe-bot/avibe/pull/1933#discussion_r3953808120) | Shared normalized equality extraction and consuming prefix tests |
| Affinity producer/consumer mismatch | [numeric declared types](https://github.com/avibe-bot/avibe/pull/1933#discussion_r3953808127) | Shared affinity classifier for repair eligibility/evaluation; representative-family selection preserves existing semantic seeds |
| Constraint composition (repeat) | [negative GLOB](https://github.com/avibe-bot/avibe/pull/1933#discussion_r3953808133) | Positive/negative state intersection, SQLite differential oracle |

## Circuit-Breaker Continuity

Changing the PR number does not reset the review history. Four findings-bearing heads on #1933 contained 3/2/4/5 findings, respectively:

1. `41c067bd39`: cross-CHECK order, numeric parsing/int64 bounds, identifier case.
2. `ffbf2aa360`: GLOB width and coordinated numeric columns. Repeated composition triggered orchestrator diagnosis before edits.
3. `aef3f40ca1`: positive GLOB intersection, joint-budget starvation, omitted context, closing-bracket tokenization. Repeated composition triggered another recorded diagnosis; `b2bb3b339` conservatively counts as a candidate-model rewrite.
4. `b2bb3b339`: the five linked findings above; first findings-bearing head after that rewrite. Repeated composition/context triggered a renewed full-inventory diagnosis, recorded in #1933 BEFORE reproduction-test edits.

The orchestrator verified all 14 paginated threads, reviewed-head counts and exact-head CI, reproduced each finding with SQLite plus a valid real INSERT, inspected the owner and consuming tests, and chose the same two-file scope. The owner subsequently authorized early merge of #1933 and a separate corrective PR, not deployment or automatic merge of this follow-up. This change replaces the CAST evaluator and unranked domain strategy rather than adding competing fallback layers; conservatively count it as a candidate-model rewrite. Future repeated roots still require renewed diagnosis before editing/pushing. Three findings-bearing heads after a rewrite also trip the breaker. Green tests do not waive either threshold.

## First Follow-Up Review: Circuit-Breaker Diagnosis

Reviewed head `765c35f20c71490b1b1fd0bfd2b38a7bc414c9ca` received three findings in review `5136932088`. Across both PRs this is the FIFTH findings-bearing head (3/2/4/5/3), and the first since the typed-evaluator/domain-ranking rewrite. The existing nine resolved and five carried threads on #1933 are preserved. All three #1941 findings were addressed in `5a7e60f8f9367014b79d880dfa8cac3127ba3dbe`, replied/read-back/resolved (replies `3954070289`, `3954070641`, `3954070924`). The diagnosis below was recorded before those edits; the subsequent review is recorded in the next section.

- [3953984966](https://github.com/avibe-bot/avibe/pull/1941#discussion_r3953984966): flexible-affinity text candidates. Repeats the producer/consumer candidate-domain class: current Python storage type accidentally gates shape derivation even though SQLite affinity is not a storage-class restriction.
- [3953984970](https://github.com/avibe-bot/avibe/pull/1941#discussion_r3953984970): speculative numeric fallback starves literal/JSON repairs. Repeats composition/search-budget ownership: the real INSERT loop owns the total budget, so unvalidated candidates cannot consume all of it before other repair sources.
- [3953984972](https://github.com/avibe-bot/avibe/pull/1941#discussion_r3953984972): scratch DML changes connection-state functions. Repeats evaluation-context semantics: preserving tables is insufficient when the evaluator changes `changes()`, `total_changes()` or `last_insert_rowid()` before the authoritative INSERT.

The orchestrator paused before source/test edits, fetched complete paginated inventories and bot reviews on both PRs, verified current-head terminal review and all 17 exact-head CI jobs/checks, inspected the implementation and consuming tests, and reproduced each example. Real INSERT accepts witnesses; a later integrity check of a `changes()`-dependent CHECK is itself context-dependent, so the regression must compare INSERT behavior and unchanged pre-insert connection state, not claim that such a CHECK is time-invariant.

Scope decision: keep the same two files and preserve the existing bounded-heuristic contract. Derive text eligibility from explicit length/GLOB/substring requirements instead of the current value class. Bound unvalidated numeric fallback to the first half of the real INSERT budget so literal/JSON repair retains attempts; verified numeric candidates and text shapes remain available. Move typed scratch insertion into a separate in-memory SQLite connection so candidate generation never writes to the fixture connection. Nondeterministic/context-sensitive or unavailable SQL functions cannot provide a synthetic rejection: defer those bounded candidates to the real INSERT. SQLite's function metadata supplies that context boundary, not a growing ad-hoc list of state-function names. Keep native typed/default storage checks, finite numeric domains, the 60 CHECK-evaluation and 60 real-INSERT limits, minimum rows, visible refusals and reference/repetition coverage. No schema/workflow/production changes or new dependencies. This local evaluator isolation is conservatively tracked as a candidate-model rewrite; historical root counts remain active for subsequent rounds.

## Second Follow-Up Review: Circuit-Breaker Diagnosis

Reviewed head `5a7e60f8f9367014b79d880dfa8cac3127ba3dbe` received three findings in terminal review `5137109045` at 2026-09-08T03:47:46Z. This is the SIXTH findings-bearing head across both PRs (3/2/4/5/3/3), and the first since evaluator isolation. The orchestrator fetched all 20 threads and their complete comment pages across both PRs, all bot reviews, and every matching exact-head lint run: run `34183833432` has all 17 jobs and check-runs successful. #1933 retains nine resolved/five carried unresolved threads; #1941 has three resolved/three new unresolved threads. Green CI does not waive this renewed breaker.

- [3954137128](https://github.com/avibe-bot/avibe/pull/1941#discussion_r3954137128): sparse assignments are starved by ranked full tuples and Cartesian order. Repeats constraint composition/search fairness. The five-column exactly-one-positive example refuses the seed but accepts a real `(1,0,0,0,0)` INSERT. Predicate scores are not evidence that predicates must all be true.
- [3954137132](https://github.com/avibe-bot/avibe/pull/1941#discussion_r3954137132): untyped `_json` columns lose their existing semantic seed to the affinity classifier. Repeats representative-domain compatibility. Bare `json_valid(payload_json)` refuses the empty bytes seed but accepts `{}`. Undeclared affinity does not require bytes; the regression also affects the existing untyped date/email/name defaults.
- [3954137135](https://github.com/avibe-bot/avibe/pull/1941#discussion_r3954137135): a bare `random` column is mistaken for a nondeterministic call. Repeats context classification/expression semantics. The seeder refuses `random=1 AND a=2` while a real `(1,2)` INSERT passes.

Diagnosis and scope were recorded BEFORE source/test edits after independently inspecting candidate scheduling, representative values, isolated evaluation and their consuming tests. Keep one bounded scheduler, but interleave sparse neighborhoods around both the current row and the top-ranked row with uniform and Cartesian assignments; deduplicate evaluations and retain the 60-evaluation cap. Restore semantic name defaults for undeclared columns without changing explicitly declared numeric/BLOB defaults. Replace bare-name screening with SQLite's own compile-time function authorization on the isolated evaluator, retaining the metadata-derived nondeterministic boundary. SQLite does not authorize functions embedded in DEFAULT during INSERT, as directly verified; compile each default separately with EXPLAIN SELECT before using it, without executing it. This lets SQLite distinguish calls, quoted names, strings, comments and keyword functions. Unknown/context-sensitive expressions still defer bounded proposals to actual INSERT.

The consuming minimum-row test exposes a second part of the same scheduling contract: after the first sparse row succeeds, varied rows start from dense values. Neighborhoods must therefore include the existing uniform boundary anchors as well as current/ranked anchors; one shared round-robin schedule will cover them, not a special-case retry. The two-row invariant remains unchanged. SQLite also confirms that an unquoted CURRENT_TIMESTAMP is a keyword invocation, not a column reference; name-disambiguation tests must quote keyword identifiers rather than demand different SQL semantics.

The smallest complete change remains in the same two files, with consuming sparse/dense and name-semantics invariants plus function/default parser and unchanged-connection tests. No general solver, new dependency, production/schema/workflow change, larger budget, or guard skip. Conservatively track the scheduler replacement as another candidate-model rewrite for subsequent gating; historical classes and all prior head counts remain active.

Implemented in `eb9636c44c06f86cf8a462b87856ac968b359693`. The three current findings were replied/read-back/resolved via `3954232589`, `3954233120`, and `3954233671`; the original five carried #1933 threads remain unresolved pending actual follow-up merge. Bot summary `5578421575` names `eb9636c` as Running since 2026-09-08T04:09:00Z, with bot-authored PR-body eyes `493630527` verified at 04:09:03Z. No duplicate explicit trigger was posted while auto-review is pending. Current-head review and CI are fresh gates, not inherited from `5a7e60f8f9`.

## Third Follow-Up Review: Circuit-Breaker Diagnosis

Reviewed head `eb9636c44c06f86cf8a462b87856ac968b359693` received four findings in terminal review `5137301763` at 2026-09-08T04:25:24Z. This is the SEVENTH findings-bearing head across both PRs (3/2/4/5/3/3/4), first since the preceding scheduler rewrite. The orchestrator fetched all 24 threads and full comment pages across #1933/#1941, all bot reviews, and every exact-head lint run. Run `34185954164` and all 17 expected jobs/check-runs pass. #1933 retains nine resolved/five carried unresolved threads; #1941 has six resolved/four new unresolved. Repeated composition, scheduling and storage-context roots trigger the breaker again regardless of green CI.

- [3954307205](https://github.com/avibe-bot/avibe/pull/1941#discussion_r3954307205): Cartesian scheduling starvation (repeat). For `n0 IN (0) AND n1 IN (2) AND n2 IN (4)`, the valid tuple is Cartesian candidate 27 but merged candidate 66, outside the 60-evaluation cap. Nested scheduling diluted the supposedly independent Cartesian turns.
- [3954307209](https://github.com/avibe-bot/avibe/pull/1941#discussion_r3954307209): unvalidated numeric fallback expires (repeat). A generated-column context with fifteen nonnegative columns followed by `n15=1` loses the required proposal after 30 INSERT attempts. Reserving opportunity by disabling a source is not fair scheduling.
- [3954307213](https://github.com/avibe-bot/avibe/pull/1941#discussion_r3954307213): STRICT ANY storage (repeat of producer/evaluator context). The type name alone is insufficient: SQLite STRICT ANY preserves storage instead of applying ordinary ANY's numeric affinity. The supplied lower(value)=value schema refuses the integer seed but accepts text.
- [3954307217](https://github.com/avibe-bot/avibe/pull/1941#discussion_r3954307217): generic literals overwrite one-shot JSON repairs (repeat). The supplied nullable schema does not produce zero total rows because the mandatory NULL row passes; its maximal row does fail, and the NOT NULL variant reproduces zero rows. Generic literals consume the JSON path as column data after the constructed document has already been marked tried.

All cases were checked against real SQLite INSERT and the consuming seeder; implementation, existing minimum-row/budget tests and candidate lifetimes were independently inspected BEFORE source/test edits. Scope decision: retain the bounded heuristic and existing owners in the same two files. Give Cartesian candidates two direct turns, current-row single changes one, and remaining anchors one in the shared numeric schedule, rather than burying Cartesian behind nested families. At the real-INSERT owner, round-robin shape/numeric proposals with generic-literal/semantic-JSON proposals for the entire 60-attempt lifetime; remove the half-budget expiry. Within the latter source, generic guesses precede constructed JSON so the one-shot document is not destroyed by later generic guesses from that CHECK. This replaces the conflicting cutoff/priority policy, not the schema or coverage contract.

Consuming CHECK-order permutations showed why restoring generic-before-JSON ordering alone is insufficient: JSON paths and JSON-member values are still offered as ordinary column literals, so they can leave another column at the wrong value before the one-shot semantic repair. Reuse the existing JSON_REQUIREMENT parser to remove the JSON requirements from the generic literal source; their paths/member values belong to the existing semantic JSON source. This closes the demonstrated provenance error without adding another SQL parser or changing one-shot/refusal policy. A new 30-column stress case also exceeds the 60-attempt budget on repeat probes even without the old cutoff; preserve visible exhaustion there rather than claiming all larger domains are supported or increasing the budget. The 16/25-column consuming cases establish that numeric proposals remain available beyond attempt 30.

The first full regression run caught a pre-existing shape-composition consumer regressing before any push: a raw GLOB literal was scheduled ahead of remaining derived shape repairs. Diagnosis: the old flat shape-proposal result erased whether numeric proposals were evaluated or were an unavailable-context fallback. The fair-scheduling rule must apply to speculative fallback, not promote generic guesses ahead of derived repairs. Replace that ambiguous flat result with one explicit two-part result (derived repairs and unvalidated numeric fallback). Keep derived repairs first; round-robin only unvalidated fallback with the generic/semantic literal source. Remove the obsolete allow-unvalidated cutoff switch. Update the direct helper tests and retain the existing cross-CHECK shape permutations unchanged. This is a candidate-provenance contract refinement inside the same owner and two-file scope, not another priority timer or extra retry layer.

Read STRICT mode from SQLite table metadata, not DDL text. Thread it through representative-value selection and native typed scratch-table evaluation: STRICT ANY keeps semantic text seeds and remains eligible for bounded integer repairs; ordinary ANY retains its existing numeric behavior. The isolated evaluator must retain STRICT storage/default semantics as well, and a datatype-rejected candidate is a rejected candidate, not an exception that escapes the fixture guard. Validate STRICT/ordinary ANY against real supplied/default storage and exercise both text and integer consumers.

No new dependency, parser/solver, schema/migration/workflow change, guard skip, larger budget, merge or deployment. The existing 60 CHECK evaluations, 60 real INSERT attempts, minimum rows, source-connection isolation and reference/repetition evidence remain. Conservatively count these scheduler/lifetime and table-mode changes as another candidate-model rewrite for later gating; no historical count or root is reset. Unsupported domains remain visible failures, not a completeness claim.

## Fourth Follow-Up Review: Circuit-Breaker Diagnosis

Reviewed head `2ce8a963f6b6b26badfe087f65ebd6b79e6ff57e` received five findings in terminal review `5137604060` at 2026-09-08T05:19:26Z. This is the EIGHTH findings-bearing head across #1933/#1941 (3/2/4/5/3/3/4/5), first after the candidate-provenance/table-mode change. The orchestrator fetched all 29 threads and complete comment pages, all bot reviews, and every exact-head lint run; `34188965737` and all 17 expected jobs/check-runs pass. #1941 has ten resolved/five new unresolved threads; #1933 keeps nine resolved/five carried unresolved. All five repeat existing candidate-domain, composition, or evaluation-context classes, so the breaker applies before edits despite green CI.

- [3954572541](https://github.com/avibe-bot/avibe/pull/1941#discussion_r3954572541): text promotion violates STRICT numeric storage. The real repair offers `x0` for an INTEGER requiring `length(n)=2 AND n=10`, ending on a datatype error before numeric `10` can run.
- [3954572549](https://github.com/avibe-bot/avibe/pull/1941#discussion_r3954572549): the first sparse alternative for column 17 falls beyond the interleaved evaluation budget. Rebalancing unrelated family weights is not the same as preserving one initial opportunity per mentioned column.
- [3954572552](https://github.com/avibe-bot/avibe/pull/1941#discussion_r3954572552): removing JSON-owned literals also erased the value needed by an explicit `state=json_extract(doc,'$.x')` dependency. The source document becomes valid while the dependent text column is left holding a path guess.
- [3954572556](https://github.com/avibe-bot/avibe/pull/1941#discussion_r3954572556): scratch implicit rowids differ from the target's next rowid. Direct insertion of an already-correct second row works, but the consuming seeder stores only one row for `n>=1 AND n=rowid`, because its repair evaluator keeps testing against scratch rowid 1.
- [3954572564](https://github.com/avibe-bot/avibe/pull/1941#discussion_r3954572564): raw regex extraction treats a commented reverse substring equality as an active dependency, corrupting an otherwise valid semantic email seed while repairing another CHECK. String/identifier payloads have the same lexical boundary risk.

All examples were reproduced with the current owner and valid real SQLite INSERT witnesses; the rowid example was additionally reproduced through the complete minimum-row consumer. The orchestrator inspected candidate creation, selection, typed evaluation, dependency discovery and existing consuming tests before choosing scope. No new source/test edits were made before recording this diagnosis.

Scope decision: keep the same two files and replace ambiguous boundaries in their existing owners. STRICT columns that cannot store text must not receive derived text-shape proposals; numeric evaluation stays reachable, while TEXT/ANY and flexible ordinary affinities retain their capabilities. Give the initial sparse alternative for each candidate-bearing column a first round before mixed search, then continue bounded deduplicated families without raising the 60-evaluation cap. Domains larger than the cap cannot be promised exhaustive coverage.

Keep JSON paths out of generic guesses, but derive dependent column values through explicit JSON-extraction equalities in either operand order using SQLite's existing JSON machinery and the constructed source document. Do not scatter every JSON member literal back across unrelated columns. Recognize unshadowed `rowid`, `_rowid_`, and `oid` references as unavailable target context and defer their finite proposals to actual INSERT; never approximate target allocation with scratch rowids or mutate the fixture connection to discover it.

Add one small lexical projection for the existing bounded regex grammar, shared by expression/dependency extraction: comments are opaque, string contents are not executable expressions, and quoted identifiers remain distinct from literals. Reuse it for substring, text-shape, numeric and JSON/literal extraction, and ignore quoted/commented parentheses when locating CHECK bodies. This is not a general SQL parser or solver, and does not add a dependency. SQLite remains the semantic and insertion oracle. Preserve actual INSERT authority, 60 attempts/evaluations, minimum rows, isolated connections, visible refusal, reference/repetition and all tagged upgrades. No schema, migration, workflow, dependency, production, merge or deployment changes. Conservatively track the lexical/proposal boundary and scheduler revision as a candidate-model rewrite; all historical counts remain active.

The shared JSON-dependency invariant was expanded over every member type already declared by `JSON_TYPE_MEMBERS`. It exposed an existing representation mismatch: `true`/`false` were passed as SQL integers, producing JSON integer members and dependent type `integer`. Native `json(?)` preserves the required boolean type. Keep this closure in the same existing JSON owner by supplying boolean JSON tokens through the existing semantic splice path, with no new candidate family. The original 1349-test focused regression passed; the newly added type invariant caught four boolean cases before push. REAL shape fixtures use SQLite's actual `10.0` representation (width four), not INTEGER's width two.

## Fifth Follow-Up Review: Circuit-Breaker Diagnosis

Reviewed head `93ece9fa11a7c26771e7dc46c21eee63b9dfb929` received two findings in terminal bot review `5137891863` at 2026-09-08T05:55:05Z. This is the NINTH findings-bearing head across #1933/#1941 (3/2/4/5/3/3/4/5/2), first after the lexical/proposal-boundary revision. Before source/test edits, the orchestrator fetched all 31 threads and every nested comment page, all bot reviews, and every exact-head lint run. The sole run `34191632584` has all 17 expected jobs and check-runs successful. #1941 has 15 resolved/two unresolved threads; #1933 retains nine resolved/five carried unresolved. Both roots repeat prior classes, so the circuit breaker applies despite green CI.

- [3954773891](https://github.com/avibe-bot/avibe/pull/1941#discussion_r3954773891): seed selection incorrectly equates NUMERIC affinity with an explicitly numeric representative. Native SQLite accepts the semantic JSON object in ordinary DATE, DECIMAL and ANY columns, but current representatives are `0`; the consuming seeder produces zero rows for the valid whole-document JSON CHECK. At base `c570ab009a121c10073cde3506f32d519ea268ff`, these declarations reached the existing semantic-name policy. Affinity is the evaluator's storage rule, not a replacement for that seed policy.
- [3954773897](https://github.com/avibe-bot/avibe/pull/1941#discussion_r3954773897): the lexical projection treats non-word quoted identifiers as opaque payload to avoid interpreting their contents as code. This also erases real column identity: the consuming seeder produces zero rows for `"has space"='ready'`, while native INSERT of `ready` succeeds. Retaining the identity must not expose its payload as executable SQL.

Both examples were reproduced through the real minimum-row seeder, with successful native SQLite witnesses. The orchestrator inspected the current representative policy, shared projection, every candidate extractor, CHECK-body discovery and consuming tests, and compared the seed policy with the recorded base. Scope remains the same two files. Restore the existing declared seed-family precedence independently from SQLite affinity; extend invariant coverage across ordinary flexible declarations and semantic JSON/date/email/text names. Explicit numeric/BLOB seeds and STRICT storage remain intact. Correct the prior test that mistakenly grouped ordinary ANY with explicit numeric defaults rather than preserving that regression as a contract.

Replace word-only normalization with shared quoted-identifier token recognition and decoding. Keep offsets and token boundaries: comments/literal contents remain opaque, a quoted identifier may be consumed as one identifier but never as code inside that token. Share this boundary across literal, substring, GLOB, numeric, JSON, and CHECK discovery; escape identifiers when constructing the seed owner's SQL so decoded quotes are not reinterpreted. This is a bounded lexical repair, not a general SQL parser or solver. Keep actual INSERT authority, isolated native evaluation, all attempt/state/width bounds, minimum rows, visible refusal and reference/repetition checks. No schema/migration/workflow/dependency or production changes. Conservatively count the seed-policy/token representation change as a candidate-model rewrite; historical counts are not reset.

The token-boundary spot check also reproduced `length('\"')>0 AND "has space"='ready'`: rejecting a regex match that begins inside a string is insufficient if `finditer` has already consumed the following real identifier. Keep candidate searches at lexical boundaries, advancing past the enclosing opaque token rather than past an invalid cross-token match. This is the same recorded lexical owner/scope, not an extra fallback. Add consuming tests for literal/comment delimiters preceding real identifiers and for quoted names through reference/repetition and CHECK discovery.

## Sixth Follow-Up Review: Circuit-Breaker Diagnosis

Reviewed head `93b0592e5d71428bf42d7aed7722d914fed9529d` received three findings in terminal bot review `5138161653` at 2026-09-08T06:30:13Z. This is the TENTH findings-bearing head across #1933/#1941 (3/2/4/5/3/3/4/5/2/3), first after the seed-policy/token revision. Before source/test edits, the orchestrator independently fetched all 34 threads and every comment page, bot reviews and every exact-head lint run. The sole run `34193703951` and all 17 expected jobs/checks pass. #1941 has 17 resolved/three unresolved threads; #1933 retains nine resolved/five carried unresolved. All three repeat composition, search fairness or proposal-provenance classes; the circuit breaker applies.

- [3954980312](https://github.com/avibe-bot/avibe/pull/1941#discussion_r3954980312), thread `PRRT_kwDOPbFPYs6gHtow`: target-context fallback discards joint assignments and permanently suppresses already-tried individual cells. The minimum-row consumer produces zero rows for `rowid>=1 AND a=1 AND b=2`, although native INSERT accepts `(1,2)`.
- [3954980320](https://github.com/avibe-bot/avibe/pull/1941#discussion_r3954980320), thread `PRRT_kwDOPbFPYs6gHto1`: reserving only the first sparse alternative does not reserve later local alternatives. For `abs(n0)=12 AND n1 IN (0,...,11)`, the valid `(12,0)` is emitted at position 63, beyond the 60-evaluation budget. The full seeder fails and native INSERT succeeds.
- [3954980322](https://github.com/avibe-bot/avibe/pull/1941#discussion_r3954980322), thread `PRRT_kwDOPbFPYs6gHto3`: GLOB pattern literals leak into generic guesses and overwrite a derived witness. `code NOT GLOB '*[^a]*' AND state='ready'` produces zero rows while native INSERT accepts `('', 'ready')`.

All three were reproduced before edits through full seeding and successful native witnesses/integrity checks. The orchestrator inspected candidate creation, the real INSERT owner, fallback/context exits, numeric scheduling, literal provenance and consuming budget/minimum-row tests. Scope remains these two files. The existing scalar fallback result cannot express a joint assignment, so replace it with bounded whole-numeric-column assignments from the same scheduler used by native evaluation; apply each atomically at the real INSERT boundary. Replace permanent cell-level suppression with deduplication of complete offered rows, so a repair can be reconsidered after another column changes without retrying identical rows. Derived repairs retain priority; fallback and literal/JSON sources retain their shared real-INSERT budget.

Reserve an initial half-budget of sparse alternatives (while preserving the initial opportunity for every candidate-bearing column when larger), then mix the existing Cartesian and anchor families. Keep the 60-evaluation/60-INSERT caps; do not claim exhaustive coverage outside that budget. Reuse one GLOB operand matcher in shape derivation and literal masking so semantic patterns stay out of generic guesses, just as existing JSON terms do. This is candidate representation/provenance repair, not an added solver, retry or relaxed schema.

The old 30-column fallback fixture asserted an incidental failure of scalar proposals. Coordinated row proposals may correctly seed that valid shape; retain it as a successful minimum-row regression and verify visible exhaustion with an actually incompatible CHECK over the same bounded search instead. Preserve native storage/context isolation, all lexical/JSON/GLOB bounds and previous acceptance invariants. No migration/schema/workflow/dependency, production, merge or deployment changes. Conservatively count this row-assignment/provenance revision as a candidate-model rewrite; historical counts remain active.

The first targeted run passed 647 cases but exposed five existing nonnumeric-starvation failures before stopping: whole-row deduplication correctly permits context-dependent repairs, but restarting each generic source at its first cell on every changed numeric row repeatedly reoffers early literals. A two-column SQL trace shows the mechanism; larger existing 15/20-column consumers exceed the budget. Keep complete-row deduplication and add advancing positions within the existing guess sources, so each source's candidates get turns as well as the sources themselves. This is the same recorded provenance/fairness owner; old acceptance tests remain unchanged. Record this diagnosis before refining selection, not as a claim that the partial run passed.

## Seventh Follow-Up Review: Circuit-Breaker Diagnosis

Reviewed head `8912f334aa4e9d6d080e1502b8f92c67b161937d` received two findings in terminal bot review `5138460065` at 2026-09-08T07:07:15Z. This is the ELEVENTH findings-bearing head across #1933/#1941 (3/2/4/5/3/3/4/5/2/3/2), first after the atomic-row/provenance revision. Before edits, the orchestrator fetched all 36 threads and every nested comment page, all bot reviews and every exact-head lint run. The sole run `34196571691` and all 17 expected jobs/check-runs pass. #1941 has 20 resolved/two unresolved threads; #1933 retains nine resolved/five carried unresolved. Both repeat dependency composition or search-state ownership; green CI does not waive the circuit breaker.

- [3955231282](https://github.com/avibe-bot/avibe/pull/1941#discussion_r3955231282), thread `PRRT_kwDOPbFPYs6gIXMV`: `code GLOB 'ready' AND state=code` derives a valid source witness but never supplies it to the explicitly equal dependent column. Removing patterns from generic guesses is correct provenance; the missing capability is propagation of the computed value, not reintroducing raw pattern literals.
- [3955231290](https://github.com/avibe-bot/avibe/pull/1941#discussion_r3955231290), thread `PRRT_kwDOPbFPYs6gIXMa`: generic/numeric source positions belong to one rejected CHECK's candidate list, but are currently shared across every named CHECK. A 41-member kind list reaching its middle `target` transfers that offset into a different 61-member state list, skipping its first valid `ready` and exhausting the shared 60 attempts.

Both were reproduced before edits through the complete minimum-row seeder (zero rows), followed by successful native INSERT witnesses and integrity checks. The orchestrator inspected the lexical/equality extractors, GLOB witness owner, JSON dependency precedent, source selection and consuming tests. The smallest complete action remains in these two files. Group explicitly equal text-eligible columns in the existing shape owner, combine their positive/negative GLOB and width requirements before deriving a common witness, and preserve valid common values. This closes reversed equalities, transitive chains/cycles and declaration ordering without adding a parallel pattern fallback. Use the existing bounded lexical grammar, identifier identity and storage restrictions; SQLite still decides actual admissibility. Do not turn arbitrary expressions into column aliases or claim a general solver.

Scope candidate progress by the rejected CHECK expression, retaining advancing per-source positions when revisiting that expression and complete-row deduplication across the whole insertion attempt. An unrelated CHECK starts its own candidate list at zero; do not reset progress merely because the offered row changes, which would reintroduce the preceding starvation failure. Preserve derived priority, the 60 evaluation/INSERT caps, all state/width bounds, minimum rows, native storage/context isolation, reference/repetition and tagged-upgrade checks. No migration/schema/workflow/dependency or production changes. Conservatively count the equality-group/progress-ownership revision as a candidate-model rewrite; historical counts remain active.

The orchestrator's consuming-path spot check combined the new equality group with the existing substring owner: `source GLOB 'AB' AND code GLOB 'A*' AND state=code AND substr(code,1,2)=source`. The first local change left `state='A'` while substring repaired `code='AB'`; native INSERT of three `AB` values succeeds. Record this before refining the shared ownership: existing substring updates must update the same equality group rather than detaching one member after GLOB construction. This does not add another search family or change substring semantics; it preserves the group's value through the already-supported shape operations. Add full minimum-row tests over dependency/operand/declaration orders, while retaining all existing tests.

## Last Pushed Evidence (Superseded By The Eleventh Diagnosis)

`853f86a27473e82a5545adca619cb2508e96f8b0`: 2583 passed, no skips, 169.96s; 187 new cases, focused 869 passed, Ruff/diff-check passed, 907 existing warnings. All tagged upgrades/current-schema minimum rows and refusal/reference/repetition checks passed. Wide-domain anchors precede the first sparse wave; small-domain ordering is unchanged. Varied 31/59/80-column all-ones traces take three INSERT attempts. Larger 50/55/56-column sparse repetition probes can still stop at one row and visibly fail; this is not full-domain completeness.

Reply `3956505250` was read back before resolving the tenth-round thread. Pickup through summary `5578421575` and eyes `494036825` was verified. Terminal review `5140224363` now has three findings, not a PASS; exact-head lint `34211247099` and all 17 jobs/check-runs succeeded. No local Incus/remote/production DB verification, merge, deployment or service restart. Same watch/cursor remain live; #1933 carried threads await corrective merge.

## Ninth Follow-Up Review: Circuit-Breaker Diagnosis

Recorded by the orchestrator before source/test edits for reviewed head `fd547404a54e70960e036cafdad63b59c8126c33`. Terminal bot review `5139272209` at 2026-09-08T08:32:07Z has three findings; summary `5578421575` completed at 08:32:11Z, not a PASS. The full paginated inventory contains 43 threads / 83 comments across #1933 (14/28) and #1941 (29/55), with no additional comment pages. All bot reviews were re-fetched. Thirteen findings-bearing heads now have counts 3/2/4/5/3/3/4/5/2/3/2/4/3; the historical classes and rewrite ledger above remain in force. Sole exact-head lint `34203664467` and all 17 expected jobs and check-runs are independently verified successful. Green tests and CI do not waive the repeated-class breaker.

All three supplied schemas reproduced zero rows through the full minimum-row seeder, despite accepted native INSERT witnesses and `integrity_check=ok`:

- `3955908650` / `PRRT_kwDOPbFPYs6gKFtq`: equal BLOB columns already satisfy `a NOT GLOB 'x'`, but repairing `state='ready'` promotes both to text. The storage-preservation boundary covers singletons only, while equality composition owns the whole group. This repeats native-storage/composition roots.
- `3955908666` / `PRRT_kwDOPbFPYs6gKFtw`: NOCASE equality accepts `('A','a')` with separate case-sensitive GLOBs. The common-witness optimization incorrectly treats its failed intersection as absence of any valid assignment. This repeats equality/context composition roots.
- `3955908675` / `PRRT_kwDOPbFPYs6gKFt4`: 59 integer columns constrained by a sum of `abs(n-1)` require a uniform tuple, but the initial reservation consumes all 60 candidates before joint families. This repeats budget starvation.

Independent scope decision: keep the existing shape owner and numeric scheduler in the same two files. Preserve native common values for entire groups when SQLite confirms the detected requirements. If a group has no common text witness, derive its members independently through the same bounded search and keep those members independent for subsequent substring repair; actual INSERT decides collation/affinity equality. This avoids adding a schema-collation parser or claiming byte identity from SQLite equality. Cap the initial sparse prefix at half the existing budget regardless of column count, then retain the current mixed local/Cartesian/anchor families. No candidate family may consume the entire budget before the others become eligible. Existing small-domain sparse coverage and old Cartesian consumers must remain green; arbitrary large-domain completeness is not promised.

The orchestrator inspected the prior diff, shape/equality/substrings and authoritative INSERT owners, numeric scheduler, native-storage consumers, all 17 sparse-position cases and the reserved-budget property tests. Expected result: the three supplied schemas seed at least two valid rows without changing source schema/constraints, guard coverage, 60 CHECK evaluations/60 INSERT attempts, int64/text/state bounds, or existing acceptance tests. This proposal/group and budget boundary change is conservatively tracked as another candidate-model rewrite for future gating; counts and classes are not reset.

The first expanded run passed 80 cases but failed four 60/80-column consumers. A direct proposal/INSERT trace showed that the scheduler now finds all ones, but the INSERT owner splits the verified derived assignment into individual cell retries (60 attempts end with only 59 cells changed). This repeats the atomic-assignment boundary already fixed for unvalidated numeric fallback. Scope refinement before further code edits: apply the shape owner's derived row together, using the existing `SeedAssignment`/whole-row dedup contract, rather than introducing a second representation for verified numeric cells. This keeps derived priority and the same limits; all historical acceptance tests must pass unchanged. The 59-column reported example already passes the initial scheduler fix, but the class-level 60/80-column cases expose why stopping there is incomplete.

The expanded focused run now passes 477 cases, including all prior sparse/equality/substring consumers. A declaration-order spot check found the same BLOB example still fails when BLOB columns precede `state`: generic broadcast offers the storage-label or state literal to BLOBs before the explicit `state='ready'` binding. This is another provenance path into the same storage loss, not a new schema requirement. Before correcting it, the scope is refined to rank whole unconditional column/string-literal equality bindings first in the existing generic source, including reversed operators and quoted names. They remain proposals checked by INSERT; fallback broadcasts remain available. Test every column position rather than making the storage-preservation consumer depend on `state` being declared first.

## Tenth Follow-Up Review: Circuit-Breaker Diagnosis

Recorded by the orchestrator before source/test edits for `8010ad1f3d52da681b2625fa4255c4fa0bbceec5`. Bot review `5139638966` submitted at 2026-09-08T09:06:32Z has one finding; summary `5578421575` completed at 09:06:36Z, not a PASS. The independently fetched, fully paginated inventory has 44 threads / 87 comments across #1933 (14/28, nine resolved and five carried) and #1941 (30/59, 29 resolved and one open), without additional comment pages. All bot reviews were re-fetched. Fourteen findings-bearing heads have counts 3/2/4/5/3/3/4/5/2/3/2/4/3/1. The sole exact-head lint run `34206752592`, all 17 jobs and all 17 check-runs passed; this does not waive the repeated budget/fairness breaker.

Finding `3956204475` / `PRRT_kwDOPbFPYs6gK10i` repeats numeric-family starvation. The complete seeder reproduces zero rows for the supplied 39-column CHECK and its 40/50/59-column variants, while native INSERT of a row changing only the final column succeeds with integrity intact. The first 30 sparse proposals are followed by four-way mixing; the first 60 proposals only reach sparse position 37. The prior opposite failure was dense 59-column search losing all joint opportunities to a complete sparse prefix. Merely moving the fixed cutoff recreates the same competition.

Independent scope decision: change only the existing scheduler and its consuming tests. Preserve the current small-domain schedule, including its reserved later sparse alternatives and direct Cartesian turns. When the first per-column sparse wave crosses the half-budget boundary, offer the existing uniform joint anchors at that boundary, then finish the first sparse wave before mixing later alternatives/products/neighborhoods. This gives both first-wave sparse repairs and the existing dense anchors an explicit opportunity whenever their distinct combined cost fits the same 60-candidate cap, instead of diluting the incomplete sparse wave among deeper searches. It does not promise that more than 60 distinct candidates fit 60 evaluations, or that every large Cartesian domain is exhausted. No new solver, predicate parser, search family, limit increase, or fallback owner is introduced.

The orchestrator inspected the preceding diff, numeric ranking/scheduling, isolated evaluation and atomic target INSERT owners, plus consuming sparse-position, later-alternative, Cartesian, large dense and target-context tests. Expected evidence: all 39 target positions, boundary sizes above 30, native positive/negative dense witnesses, and the existing small-domain consumers succeed together; a direct scheduler property checks coverage when the combined first-wave/anchor cost fits the budget. Existing 60 CHECK evaluations/60 INSERT attempts, minimum rows, signed-int64/text/state bounds, native storage, visible refusal, reference and repetition contracts remain unchanged. The scheduler boundary revision is conservatively tracked as a candidate-model rewrite; history and repeated-root counts are not reset. Same durable watch and cursor remain live and untouched.

The initial targeted run passed 10 cases and failed three unchanged large target-context consumers before stopping. A native INSERT trace starting with one held `1` and thirty `2`s reproduced 60 failed attempts: rebuilding the middle anchor block after sparse mutations changes deduplicated offsets, so the cursor skips the all-ones anchor. Scope refinement before further edits: for wide domains, emit a stable prefix of uniform anchors before row-dependent ranking/sparse proposals, bounded to half the existing budget so a nonuniform ranked assignment remains reachable. Then finish the first sparse wave and reuse the existing mixed tail. Small-domain ordering stays unchanged. This is still a scheduler-only change: no cached second candidate model or INSERT-cursor rewrite. Add direct varied-row target-context traces and wide heterogeneous ranked consumers; preserve the unchanged failing tests. The conditional coverage property includes the cost of distinct anchors and the ranked row, rather than claiming arbitrary-width completeness.

The refined targeted run passed 153 cases before three newly introduced 50/55/56-column minimum-row expectations failed: each now inserts the first valid sparse row, but later varied repetition offers need a different sparse anchor neighborhood that does not fit the same first-wave budget. The reported 39-column case passes at every target position, and the unchanged large target-context tests recover. Scope calibration: do not promote first-wave coverage into an unlimited full-seeder claim or add another solver to meet an unrequested stress expectation. Keep the 31–56-column direct first-wave property, full minimum-row acceptance through the tested 39/40-column boundary, and preserve the larger probes as visible-shortfall checks (a result under two rows must still fail the guard). These are new exploratory expectations, not changes to historical acceptance tests. All first-row, repeat/reference and minimum-row enforcement code stays unchanged. Larger anchor-neighborhood exhaustion remains an explicit residual limitation, not a guard skip.

## Eleventh Follow-Up Review: Circuit-Breaker Diagnosis

Recorded before source/test edits for `853f86a27473e82a5545adca619cb2508e96f8b0`. Bot review `5140224363` submitted 2026-09-08T09:57:50Z; summary `5578421575` completed 09:57:54Z with three findings, not a PASS. The orchestrator independently fetched the complete paginated inventory: 47 threads / 91 comments across #1933 (14/28, nine resolved/five carried) and #1941 (33/63, thirty resolved/three open), plus all bot reviews. FIFTEEN findings-bearing heads have counts 3/2/4/5/3/3/4/5/2/3/2/4/3/1/3. Exact-head lint `34211247099` and all 17 jobs/check-runs passed. Repeated composition/provenance/budget roots trip the breaker regardless.

The full minimum-row consumer reproduced every report; native witnesses passed INSERT and integrity checks. Optional `b=substr(a,1,1) OR 1` incorrectly rewrites required `a='A'` to `R` while repairing state (zero rows). `abs(b)=4 AND (a>0)+(b>0)+(c>0)=1` inserts `(0,4,0)` once but discards all candidates for varied repeat offers (one row); from `(0,1,1)`, the first accepted assignment is number 157. Conflicting JSON extraction/type comparisons omit the valid missing-path document (zero rows, while `{}` inserts). Owners inspected: unconditional-term extraction, substring discovery/repair, JSON construction/dependencies, ranking/scheduling, isolated evaluator, atomic INSERT/source progress, prior diff and consuming tests.

Scope decision: retain only the two assigned files. Require a whole substring equality reached through the existing unconditional conjunctive extractor in both consumers. Preserve populated JSON documents/dependencies first, then offer `{}` through the same JSON proposal source. A numeric candidate rejected by the complete CHECK is not a valid derived row, but may be a useful next search origin: retain storage-admissible rejected assignments in the existing numeric fallback when native search finds no complete witness. Actual INSERT, whole-row deduplication and the existing per-CHECK cursor remain the only outer progress owner. An in-memory experiment reusing that fallback seeded all repeat probes of the reported numeric case; merely restricting numeric ranking still failed reordered variants. No new scheduler weights, parser, score solver, cache, family or cursor owner.

Two internal test assumptions must evolve explicitly: the budget test must verify retained rejected assignments instead of assuming their deletion, while still counting exactly 60 evaluations and rejecting every row; the JSON-list test must inspect the preferred populated proposal without flattening alternate documents into a last-value dictionary. Historical full-seeder acceptance, minimum-row, refusal/reference/repetition and isolation assertions will not be weakened. Add branch/operand/CHECK-order regressions, repeat-row and native trace permutations, missing/present-path JSON alternatives and incompatible-constraint exhaustion. STRICT-invalid assignments remain excluded from evaluated fallback; unsupported context retains the existing path. Both 60-attempt limits, signed-int64/4096-width/16384-state bounds and visible failure remain mandatory. Conservatively track this proposal-retention revision as another candidate-model rewrite; no historical count is reset. Same watch/cursor stay live and untouched.

The first expanded run passed 190 cases before four NEW negated/functional fixtures failed: initial `x/x` violates their negative relation before any binding repair exists. Calibration: full-seeder fixtures keep an accepting optional branch; separate actual-INSERT probes start from valid `A/R` and test that repairing state preserves them under pure negation/compound expressions. This tests non-destruction without claiming inverse-function solving. No historical acceptance assertion changes.

The next expanded run passed 1192 cases before four UNCHANGED DATE/enum-prefix consumers failed. Native trace confirmed all 60 attempts stayed in numeric/shape candidates; the existing related-prefix semantic source was unreachable because it ran only after every other source exhausted. Refinement recorded before correction: include that already-filtered source in the existing semantic turn, after the current CHECK's literal/JSON proposals, and remove its separate last-resort path. Numeric and semantic candidates still share one per-CHECK cursor owner and one 60-INSERT limit; no new family or general cross-CHECK broadcast. Preserve those historical tests unchanged and add a trace proving the required enum source gets a turn.

Independent class-closure spot-check: `length(a)=2 OR 1` with required `a='A'`/state reproduces zero rows despite native acceptance. Before further edits, extend the same required-whole-term boundary to length and GLOB shape derivation, using existing conjunctive extraction rather than another parser. Optional/negated/function-wrapped shape occurrences must not force values during unrelated repair. Add native non-destruction and minimum-row consumers for all three shape owners; retain speculative sources and existing bounds. Substring-only closure would leave this demonstrated member of the same class unfixed.

## Previous-Head Evidence

- `8010ad1f3d52da681b2625fa4255c4fa0bbceec5`: 2396 passed, no skips, 168.07 seconds; 150 cases added, focused 162 passed. Replies `3956088497`/`3956094632`/`3956100573` were read back before resolution. Pickup through summary `5578421575` and eyes `493961721` was verified. Terminal review `5139638966` yielded the tenth-follow-up finding, not a PASS. Sole exact-head lint `34206752592` and all 17 jobs/check-runs passed.

- `fd547404a54e70960e036cafdad63b59c8126c33`: 2246 tests passed without skips in 131.26 seconds, 118 new proposal/context cases. Replies `3955808891`, `3955810021`, `3955810777`, `3955811837` were read back before resolution; pickup through summary `5578421575` and eyes `493912643` was verified. Terminal review `5139272209` produced the three ninth-follow-up findings, not a PASS. Sole exact-head lint `34203664467` and all 17 expected jobs/check-runs passed. An initial targeted run had 166 passes and two unchanged default-literal failures; the unary-plus compiler refinement was recorded before correction and the final 2246-test run passed.

- `3d3d2d681bb19ad308499067fabcd7cf362f33e9`: 2128 tests passed without skips in 130.07 seconds; 171 equality/progress cases. Replies `3955361462` and `3955366758` were read back before resolution. Pickup through summary `5578421575` and eyes `493838252` was verified. Terminal review `5138799615` produced the four eighth-follow-up findings above, not a PASS. Sole exact-head lint `34199065520` and all 17 jobs/check-runs passed.

- `8912f334aa4e9d6d080e1502b8f92c67b161937d`: 1957 tests passed without skips in 123.40 seconds, with 134 atomic-row/provenance/sparse cases. Replies `3955138593`, `3955141983`, `3955147785` were read back before resolution. Bot pickup was verified through summary `5578421575` and eyes `493798394`; terminal review `5138460065` produced the two seventh-follow-up findings above, not a PASS. Sole exact-head lint `34196571691` and all 17 jobs/check-runs passed.

- `93b0592e5d71428bf42d7aed7722d914fed9529d`: 1823 tests passed without skips in 123.64 seconds, with 213 semantic-seed/quoted-identifier cases. Replies `3954890795` and `3954893549` were read back before resolution. Pickup was verified through summary `5578421575` and eyes `493754170`. Its terminal review `5138161653` produced the three sixth-follow-up findings above, not a PASS. Sole exact-head lint run `34193703951` and all 17 jobs/check-runs passed.

- `93ece9fa11a7c26771e7dc46c21eee63b9dfb929`: 1610 tests passed with no skips, 123.90 seconds; 196 cases added for STRICT shapes, all 17 sparse positions, JSON dependencies/types/escaping, rowid and opaque SQL boundaries. The five replies `3954709662`, `3954710164`, `3954710886`, `3954717313`, `3954717788` were read back before resolution. Bot pickup was verified with summary `5578421575` and eyes `493721651`; its terminal review produced the two fifth-follow-up findings above, not a PASS. All 17 checks in run `34191632584` passed.

- Head `2ce8a963f`: 1414 passed, no skips (123.09 seconds), including 72 candidate-provenance/STRICT/fallback cases. Exact-head lint `34188965737` passed all 17 jobs/check-runs but review `5137604060` had five findings. Its preceding four threads were fixed/replied/resolved via `3954472593`, `3954475669`, `3954475970`, and `3954476516`; no passing verdict is claimed.
- Head `eb9636c44c`: 1342 passed, no skips (146.41 seconds), adding 86 sparse/dense, undeclared-seed and SQLite function/default parsing cases. Exact-head lint `34185954164` passed all 17 jobs/check-runs; terminal review still had the four findings recorded above.
- Head `5a7e60f8f9`: 1256 passed, no skips (124.88 seconds); exact-head lint `34183833432` passed all 17 jobs/check-runs. An interim run while developing the subsequent scheduler passed 1310 tests; the final validation of `eb9636c44c` was 1342 tests, not that interim result.
- Targeted candidate/shape/substring suite: 746 passed.
- Full five-suite migration regression: **1109 passed, no skips**, 125.15 seconds. Includes every tagged-release upgrade, including `gh-v3.0.15rc6`, and the current-schema all-table minimum-row invariant. The final branch also incorporates the subsequently merged cursor-only #1932; those four UI-only files do not change the validated Python surface and are not part of this PR diff.
- 3,136 finite-domain GLOB polarity/pattern/width comparisons against SQLite; default and supplied-value storage differential tests; temporary-state/data-preservation checks; 2/6/16-column numeric permutations and previous signed-int64/JSON/case/refusal/reference/repetition invariants.
- Ruff and diff-check pass. Existing SQLAlchemy expression-index reflection warnings only.
- Residual: local Incus unavailable; no remote regression environment or production database was used. No deployment or local Avibe restart.

## Known By Design

This remains a bounded fixture heuristic, not a general SQL constraint solver. Candidates must survive actual target INSERT; unsupported domains fail visibly without reducing coverage. Numeric ranking only orders finite signed-int64 boundary candidates, with sparse and joint families interleaved rather than assuming each local predicate is required to be true. Supported CHECKs are evaluated by SQLite, with at most 60 distinct evaluations per proposal pass and the existing 60 real INSERT attempts. The scheduler does not exhaust every Cartesian combination. Scratch INSERT/DELETE statements establish context on an isolated in-memory connection, not extra candidate evaluations or mutations to the fixture connection. Generated columns/implicit keys, functions rejected by SQLite's deterministic-expression compiler, or unavailable context defer to bounded real-INSERT proposals. Derived repairs retain priority; unvalidated numeric fallback and generic/semantic guesses share turns throughout the existing attempt budget, with source progress scoped to each rejected CHECK expression. Exhaustion remains visible for incompatible CHECKs or candidate domains not reached within the cap; the valid 30-column target-context regression is now seedable. Only named CHECK failures enter repair; errors such as unguarded malformed JSON remain visible refusals. CHECK and DEFAULT expressions are separately compiled as value expressions with EXPLAIN CREATE INDEX on the empty isolated table. SQLite's [expression-index restrictions](https://www.sqlite.org/expridx.html) resolve overloads and reject nondeterministic calls without creating an index or executing the expression; unsupported constructs and unavailable custom functions defer to actual INSERT. The previous name-only authorizer screen is removed. STRICT mode comes from [table_list](https://www.sqlite.org/pragma.html#pragma_table_list) and preserves native [STRICT ANY semantics](https://www.sqlite.org/stricttables.html). No source constraints are removed or disabled.

GLOB search keeps the finite printable-plus-pattern alphabet, 4096 text-width/combined-pattern bound, 16384-state cap, SQLite class membership and final validation. A negative pattern's dead state is allowed; a positive dead state cannot yield a witness. Only unconditional whole bare equalities group text-eligible columns for shared witnesses and substring updates. Functional dependents receive computed witnesses through the existing speculative source, not a claim to invert arbitrary functions. Raw wildcard patterns remain masked. Existing non-string values satisfying detected native shapes are preserved. Missing witnesses remain visible refusals. Minimum two valid rows per current table, restored references, repetition evidence and all tagged-release checks remain mandatory.

The lexical projection supports the existing bounded identifier/expression grammar, not arbitrary SQL algebra. It excludes [comments](https://www.sqlite.org/lang_comment.html) and literal payloads from active extraction while retaining their original offsets for CHECK slicing. Explicit JSON dependencies propagate values from the document assembled by existing requirements; they do not turn generic literals into a general relational solver. Unshadowed [rowid aliases](https://www.sqlite.org/rowidtable.html) depend on the target INSERT and cannot be validated against an isolated table's allocation. The reserved sparse prefix still obeys the same total 60-evaluation cap; larger domains remain bounded, not exhaustively covered.
