### PR TITLE
docs(skill): offer PR merge and local regression quick replies

### DIFF
--- a/.agents/skills/pr-delivery-loop/SKILL.md
+++ b/.agents/skills/pr-delivery-loop/SKILL.md
@@ -349,9 +349,10 @@ turn ends because you armed a watch and are waiting, say exactly that.
    on which each thread was opened;
 4. Post the final report: PR URL, what shipped, evidence layers, residual
    manual checks (state what end-to-end verification is deferred to the
-   orchestrator's integration pass). Include the applicable user-facing
-   next-action buttons from §5a. Deliver it by §4's delivery rule, or
-   finish the run the orchestrator dispatched with it as the result; ending a
+   orchestrator's integration pass). Only the orchestrator's final user-facing
+   response includes the applicable next-action buttons from §5a; internal
+   lane reports never include a button block. Deliver it by §4's delivery rule,
+   or finish the run the orchestrator dispatched with it as the result; ending a
    watch-triggered round without that send means the orchestrator never learns
    you finished.
    **Tripwire:** the round where the clean pass finally lands is exactly the
@@ -380,23 +381,44 @@ turn ends because you armed a watch and are waiting, say exactly that.
 
 ## 5a. User-facing next-action buttons
 
-Offer the next authorized choice as a real quick-reply button, not merely a
-sentence suggesting it. In Avibe replies, use the existing trailing `---` and
-`[label]` syntax from `core/prompts/quick-replies.md`. Put the block at the very
-end of the final user-facing message, outside code fences; do not append it to
-GitHub comments or internal lane reports. Name the target PR and reviewed head
-in the preceding report so the choice is unambiguous. If several PRs are in the
-conversation, identify exactly which one the following button concerns.
+In the orchestrator's final user-facing response, offer the next choice as a
+real quick-reply button. Use Avibe's existing trailing `---` and `[label]`
+syntax from `core/prompts/quick-replies.md`, at the very end of the message and
+outside code fences. Never append this block to GitHub comments or internal
+lane reports. Name the repository, target PR, and reviewed head in the report.
+
+Use the user's conversation language, defaulting to English when unknown, and
+honor explicitly requested labels. These are the exact Chinese labels; English
+labels remain within the same 20-character button limit:
+
+| Action | Chinese | English |
+| --- | --- | --- |
+| Merge the reported PR | 合并PR | Merge PR |
+| Update local master regression | 更新master到回归环境 | Update master |
+| Update and verify end to end | 更新回归环境并进行端到端验证 | Update + E2E |
+
+**Bind the target before acting, for every button below.** The current format
+submits the label, not a target payload; Markdown links cannot add a hidden
+payload. Adjacent prose does not bind a click to that report. Resolve the source
+report from source-message metadata only when it is actually available to the
+agent. If it is unavailable or the report does not identify one repository/PR,
+ask the user for the PR URL before any merge or regression mutation. Never pick
+the latest-mentioned PR, the current worktree, or the only PR still open: an
+older button may refer to a different or already-closed PR. A label-only reply
+expresses action intent, not authority over an inferred target. An explicit
+target supplied by the user resolves this ambiguity; explicit merge requests
+then follow §5.6 without an extra confirmation. Do not invent payload syntax
+or change the requested labels to work around this transport limitation.
 
 - **Ready, awaiting merge authorization:** only after verifying §5.1–§5.3 on
   the current head and `mergeStateStatus == CLEAN` for an open, non-draft PR,
-  append the exact button `合并PR`. Do not show it while review/CI is pending,
-  findings remain unresolved, or the PR is conflicted, closed, or already merged.
-  Offering the button is not merge authorization; the user's click is the
-  scoped merge request. Re-fetch the PR/head and all merge gates when handling
-  that reply. If the head changed or readiness was lost, report the change and
-  refresh the offer instead of executing a stale approval. Existing explicit
-  merge authorization still follows §5.6 without an extra confirmation.
+  append the merge button from the language table. Do not show it while
+  review/CI is pending, findings remain unresolved, or the PR is conflicted,
+  closed, or already merged.
+  Offering the button is not merge authorization. After binding a click to its
+  report, re-fetch the PR/head and all merge gates. If the head differs from the
+  offered head or readiness was lost, report the change and refresh the offer
+  instead of executing a stale approval. Chinese example:
 
   ```text
   ---
@@ -404,23 +426,41 @@ conversation, identify exactly which one the following button concerns.
   ```
 
 - **Merged, next local regression action:** for Avibe, after GitHub confirms
-  the named PR is `MERGED`, replace the merge offer with both exact choices
-  below. The first updates the local regression environment from `master`;
-  the second performs that same update and then the relevant end-to-end
-  verification. Do not present a closed-but-unmerged PR as merged.
+  the named PR is `MERGED`, replace the merge offer with both regression choices
+  from the language table. The first updates local master regression from
+  `master`; the second performs that same update and then the relevant end-to-end
+  verification. Name the local target in the report. Do not present a
+  closed-but-unmerged PR as merged. Chinese example:
 
   ```text
   ---
   [更新master到回归环境] | [更新回归环境并进行端到端验证]
   ```
 
-  These are separate opt-in actions, not implied by a merge request. On a click,
-  fetch current `master`, preserve local changes, and use the repository's
-  established local Incus regression workflow. Identify the environment and
-  deployed commit in the result. Never reinterpret either choice as permission
-  to update production, a remote tenant, or the running local Avibe. Other
-  repositories offer regression actions only when their own documented local
-  workflow applies; do not invent a deployment target to make a button work.
+  These are separate opt-in actions, not implied by a merge request. After
+  binding the click and rechecking `MERGED`, follow `docs/regression/README.md`:
+  fetch `origin`, fast-forward the **primary default-branch checkout** with
+  `--ff-only`, and verify it is on `master` at the fetched `origin/master` SHA.
+  Its tracked and untracked source files must be clean before deployment. Never
+  discard, stash, or commit unrelated user edits to achieve this; report the
+  blocker instead. Fetching alone does not update a task worktree, and the
+  runner synchronizes its invoking checkout, including dirty source files.
+
+  Run `python3 scripts/incus_regression.py up --target master --reset-mode none`
+  with the working directory set to that verified primary checkout, targeting
+  the persistent **local** master environment (`avr-master` / `avibe-master`
+  by default), not a temporary worktree environment. Use the documented local
+  Lima route on macOS. Preserve the environment's product state, credentials,
+  pairing, and sessions; neither button authorizes a state reset. Verify the
+  deployment receipt and served source commit match the intended master SHA
+  before reporting success or starting the second choice's end-to-end checks.
+  Report the environment, deployed commit, and actual verification results;
+  a healthy service alone is not an end-to-end pass.
+
+  Never reinterpret either choice as permission to update production, a remote
+  tenant, or the running local Avibe. Other repositories offer regression
+  actions only when their own documented local workflow applies; do not invent
+  a deployment target to make a button work.
 
 ## 6. While waiting, don't idle
 

--- a/.agents/skills/pr-delivery-loop/SKILL.md
+++ b/.agents/skills/pr-delivery-loop/SKILL.md
@@ -349,7 +349,8 @@ turn ends because you armed a watch and are waiting, say exactly that.
    on which each thread was opened;
 4. Post the final report: PR URL, what shipped, evidence layers, residual
    manual checks (state what end-to-end verification is deferred to the
-   orchestrator's integration pass). Deliver it by §4's delivery rule, or
+   orchestrator's integration pass). Include the applicable user-facing
+   next-action buttons from §5a. Deliver it by §4's delivery rule, or
    finish the run the orchestrator dispatched with it as the result; ending a
    watch-triggered round without that send means the orchestrator never learns
    you finished.
@@ -376,6 +377,50 @@ turn ends because you armed a watch and are waiting, say exactly that.
    noninteractive even when the orchestrator is running outside the PR's
    worktree. If the gate is not CLEAN, report exactly what's missing instead
    of refusing by role.
+
+## 5a. User-facing next-action buttons
+
+Offer the next authorized choice as a real quick-reply button, not merely a
+sentence suggesting it. In Avibe replies, use the existing trailing `---` and
+`[label]` syntax from `core/prompts/quick-replies.md`. Put the block at the very
+end of the final user-facing message, outside code fences; do not append it to
+GitHub comments or internal lane reports. Name the target PR and reviewed head
+in the preceding report so the choice is unambiguous. If several PRs are in the
+conversation, identify exactly which one the following button concerns.
+
+- **Ready, awaiting merge authorization:** only after verifying §5.1–§5.3 on
+  the current head and `mergeStateStatus == CLEAN` for an open, non-draft PR,
+  append the exact button `合并PR`. Do not show it while review/CI is pending,
+  findings remain unresolved, or the PR is conflicted, closed, or already merged.
+  Offering the button is not merge authorization; the user's click is the
+  scoped merge request. Re-fetch the PR/head and all merge gates when handling
+  that reply. If the head changed or readiness was lost, report the change and
+  refresh the offer instead of executing a stale approval. Existing explicit
+  merge authorization still follows §5.6 without an extra confirmation.
+
+  ```text
+  ---
+  [合并PR]
+  ```
+
+- **Merged, next local regression action:** for Avibe, after GitHub confirms
+  the named PR is `MERGED`, replace the merge offer with both exact choices
+  below. The first updates the local regression environment from `master`;
+  the second performs that same update and then the relevant end-to-end
+  verification. Do not present a closed-but-unmerged PR as merged.
+
+  ```text
+  ---
+  [更新master到回归环境] | [更新回归环境并进行端到端验证]
+  ```
+
+  These are separate opt-in actions, not implied by a merge request. On a click,
+  fetch current `master`, preserve local changes, and use the repository's
+  established local Incus regression workflow. Identify the environment and
+  deployed commit in the result. Never reinterpret either choice as permission
+  to update production, a remote tenant, or the running local Avibe. Other
+  repositories offer regression actions only when their own documented local
+  workflow applies; do not invent a deployment target to make a button work.
 
 ## 6. While waiting, don't idle
 

--- a/.agents/skills/pr-delivery-loop/SKILL.md
+++ b/.agents/skills/pr-delivery-loop/SKILL.md
@@ -456,17 +456,37 @@ or change the requested labels to work around this transport limitation.
   actually excluded by the runner are outside this source check. If the input
   differs or the match cannot be established, stop and report the blocker.
   Never discard, stash, or commit unrelated user edits to make it pass.
+  Keep that verified input unchanged throughout the update.
   Fetching alone does not update a task worktree, and the runner synchronizes
   its invoking checkout, including local source overrides.
 
-  Run `python3 scripts/incus_regression.py up --target master --reset-mode none`
-  with the working directory set to that verified primary checkout, targeting
-  the persistent **local** master environment (`avr-master` / `avibe-master`
-  by default), not a temporary worktree environment. Use the documented local
-  Lima route on macOS. Preserve the environment's product state, credentials,
-  pairing, and sessions; neither button authorizes a state reset. Verify the
-  deployment receipt and served source commit match the intended master SHA
-  before reporting success or starting the second choice's end-to-end checks.
+  Confirm the persistent **local** master environment (`avr-master` /
+  `avibe-master` by default), its product config, and its runtime environment
+  file already exist. Missing or unreadable state is a blocker, not permission
+  to provision or re-seed it. From the verified primary checkout, use:
+
+  ```bash
+  python3 scripts/incus_regression.py up --target master --reset-mode none --clean --env-file /dev/null
+  ```
+
+  Use the documented local Lima route on macOS. Preserve the existing local
+  bind/port settings explicitly when they differ from the runner defaults.
+  For this existing-target path, `--env-file /dev/null` suppresses automatic
+  `.env.regression` discovery and leaves `/etc/avibe-regression.env` untouched.
+  `--reset-mode none` alone does not prevent that file from being rewritten;
+  an empty regular env file still triggers a rewrite and is not a substitute.
+  If the checked-out runner cannot preserve the runtime environment this way,
+  stop before mutation. Neither button authorizes credential changes or a
+  product-state reset. Preserve pairing, agent homes, and persistent sessions.
+
+  `--clean` replaces the disposable synced source and generated build tree,
+  not product state or the runtime environment. It forces receiver content
+  reconciliation even when stale bytes have the same size and mtime; a normal
+  rsync quick check plus a commit receipt cannot establish that property.
+  Let the runner rebuild its assets, then verify the deployment receipt and
+  served source commit match the intended master SHA, and that the runtime
+  environment is unchanged without exposing its values, before reporting
+  success or starting the second choice's end-to-end checks.
   Report the environment, deployed commit, and actual verification results;
   a healthy service alone is not an end-to-end pass.
 

--- a/.agents/skills/pr-delivery-loop/SKILL.md
+++ b/.agents/skills/pr-delivery-loop/SKILL.md
@@ -381,11 +381,18 @@ turn ends because you armed a watch and are waiting, say exactly that.
 
 ## 5a. User-facing next-action buttons
 
-In the orchestrator's final user-facing response, offer the next choice as a
-real quick-reply button. Use Avibe's existing trailing `---` and `[label]`
-syntax from `core/prompts/quick-replies.md`, at the very end of the message and
-outside code fences. Never append this block to GitHub comments or internal
-lane reports. Name the repository, target PR, and reviewed head in the report.
+In the orchestrator's final user-facing response, offer the next choice using
+the destination's actual delivery capability and reply-enhancement settings.
+When quick replies are supported and enabled, use Avibe's existing trailing
+`---` and `[label]` syntax from `core/prompts/quick-replies.md`, at the very end
+of the message and outside code fences. If support is absent, disabled, or
+unknown, provide the same choices as ordinary visible prose, including the PR
+URL in each suggested reply. Do not use a trailing bracket row or separator in
+that fallback: the parser can remove a button block even when the destination
+cannot render it. Apply this capability check to every action below, using
+the existing delivery configuration rather than a list of platform names.
+Never append these action offers to GitHub comments or internal lane reports.
+Name the repository, target PR, and reviewed head in the user-facing report.
 
 Use the user's conversation language, defaulting to English when unknown, and
 honor explicitly requested labels. These are the exact Chinese labels; English
@@ -441,10 +448,16 @@ or change the requested labels to work around this transport limitation.
   binding the click and rechecking `MERGED`, follow `docs/regression/README.md`:
   fetch `origin`, fast-forward the **primary default-branch checkout** with
   `--ff-only`, and verify it is on `master` at the fetched `origin/master` SHA.
-  Its tracked and untracked source files must be clean before deployment. Never
-  discard, stash, or commit unrelated user edits to achieve this; report the
-  blocker instead. Fetching alone does not update a task worktree, and the
-  runner synchronizes its invoking checkout, including dirty source files.
+  Before any environment mutation, verify that the actual deployable input of
+  `sync_source()` matches that selected Git tree under the runner's sender
+  exclusions. This includes ignored deployable files: Git ignore rules do not
+  govern rsync. Inspect the real input set, not just tracked/untracked status;
+  a clean `git status` or a receipt with `dirty=false` is not proof. Only paths
+  actually excluded by the runner are outside this source check. If the input
+  differs or the match cannot be established, stop and report the blocker.
+  Never discard, stash, or commit unrelated user edits to make it pass.
+  Fetching alone does not update a task worktree, and the runner synchronizes
+  its invoking checkout, including local source overrides.
 
   Run `python3 scripts/incus_regression.py up --target master --reset-mode none`
   with the working directory set to that verified primary checkout, targeting


### PR DESCRIPTION
## Summary

Add stage-specific quick-reply guidance to the canonical `pr-delivery-loop` skill using Avibe's existing reply format, without changing runtime code.

- The orchestrator offers a merge choice only after current-head review, CI, thread, and merge-state gates pass; regression choices appear only after an actual merge.
- Capable, enabled destinations receive buttons; unsupported, disabled, or unknown destinations receive visible prose with the same action labels and explicit PR targets.
- Preserve the requested Chinese labels `合并PR`, `更新master到回归环境`, and `更新回归环境并进行端到端验证`; use conversation-appropriate labels with English as the fallback.
- Resolve the actual source report or obtain an explicit user-supplied PR target before any action. A label alone never grants authority over an inferred PR.
- Regression actions verify the actual synchronization input, including ignored deployable files, against the selected primary `master` tree before touching the persistent local master environment. Product state is preserved. Production, remote tenants, and running local Avibe remain out of scope.
- Both regression choices use the same existing-target update: suppress automatic runtime-environment replacement and fully reconcile disposable source/build content, preserving the configured local target and persistent state.

## Evidence

- Current revision: 170 focused tests passed with 46 subtests, including parser/callback consumers and three isolated regression-runner contracts. The four Chinese/English button-block and two label-only callback contracts remain unchanged.
- This round: four existing environment/source/state consuming tests passed, plus four temporary contract checks. The actual CLI parser, environment loader, and `cmd_up()` orchestration were exercised behind a recording runner: default discovery rewrites the environment, while `--env-file /dev/null` suppresses it for an existing target. A separate check proves an empty regular file is not equivalent. Real local rsync reproduced equal-size/equal-mtime stale content and proved `--clean` replaces it. No live Incus was contacted; temporary probes are not new repository tests.
- 18 dispatcher-output checks with stub IM delivery passed across unsupported WeChat and disabled-enhancement destinations, covering all Chinese/English action labels. The ordinary prose and explicit PR target survive intact without a keyboard.
- A temporary fixture repository reproduced the source-identity gap with real local rsync through the existing test helper: `is_dirty()` returned false before and after sync while both ignored source files were copied. Incus transport was replaced by the helper's local transport; no daemon was contacted. This verifies the need for the documented input check, not a runtime fix to the runner.
- `git diff --check` passed. Only the canonical skill file changed.
- No live Incus, production change, merge, deployment, or service restart is part of this documentation task.
- Scenario IDs: not applicable to delivery-skill guidance. Runtime presentation and deployment retain their existing implementation contracts.

## Full Review Inventory

All review, thread, and comment pages and every matching exact-head lint Actions run were fetched by the orchestrator. One transient GraphQL EOF was retried; an empty failed fetch was not counted as an empty inventory.

| Reviewed head | Findings / classes | Evidence |
| --- | --- | --- |
| `a4a81acf30ef0ffa7c6eb6143da75cba87b4b536` | 4 threads: deployment source/target identity, delivery audience, action target binding, locale selection | [source](https://github.com/avibe-bot/avibe/pull/1943#discussion_r3954246946), [audience](https://github.com/avibe-bot/avibe/pull/1943#discussion_r3954246951), [binding](https://github.com/avibe-bot/avibe/pull/1943#discussion_r3954246956), [locale](https://github.com/avibe-bot/avibe/pull/1943#discussion_r3954246959); all addressed in `522d2201bb472134a819b61f0fbee8584e123cbf`. |
| `522d2201bb472134a819b61f0fbee8584e123cbf` | 5 threads, only 2 distinct classes: deployment input identity (3 duplicate reports), capability-aware delivery (2 duplicate reports) | Input identity: [3954352664](https://github.com/avibe-bot/avibe/pull/1943#discussion_r3954352664), [3954352666](https://github.com/avibe-bot/avibe/pull/1943#discussion_r3954352666), [3954352675](https://github.com/avibe-bot/avibe/pull/1943#discussion_r3954352675). Delivery capability: [3954352671](https://github.com/avibe-bot/avibe/pull/1943#discussion_r3954352671), [3954352678](https://github.com/avibe-bot/avibe/pull/1943#discussion_r3954352678). |
| `37650132150864e70b2de410b4bc2b4189d0afc2` | 2 threads: deployment identity on the receiver (repeated class), runtime credential preservation (new class) | [credential preservation](https://github.com/avibe-bot/avibe/pull/1943#discussion_r3954467922), [receiver reconciliation](https://github.com/avibe-bot/avibe/pull/1943#discussion_r3954467926). Exact-head lint run [34188434519](https://github.com/avibe-bot/avibe/actions/runs/34188434519) and all 17 checks succeeded; review 5137480575 has findings, not a pass. Both addressed in `5b54a8fe5958cb164b7a9ba6f9a190622bb1c94c`. |

## Two-Head Circuit Breaker and Orchestrator Decision

The deployment-identity class repeated on the second reviewed head. The orchestrator stopped before the next skill edit or push, inspected all nine threads, and diagnosed the whole boundary. There has been no architecture or data-model rewrite. Both reviewed heads have successful exact-head lint runs; green CI does not waive this breaker.

At `522d2201bb472134a819b61f0fbee8584e123cbf`, `is_dirty()` observes Git porcelain while `sync_source()` uses a separate exclusion set. The ignored `vibe/_version.py` and `config/local_settings.py` are admitted by that set, so branch/SHA/dirty receipts cannot establish source integrity. Independently, the registry and callback-consuming WeChat test show that explicit button blocks are parsed out even when the destination cannot render them. These are two boundary policies missing from the guidance, not evidence that this task needs a new deployment engine or callback protocol.

Scope decision, recorded before the next skill edit:

1. State the deployment invariant against the actual synchronization input and selected commit, including ignored deployable paths. Keep the verified primary checkout and local master target rules. Treat receipts as identity reports, not proof of byte integrity. Stop rather than discard user files or deploy uncertain input.
2. Select buttons versus visible text from the actual delivery capability and configuration for every action. Unsupported or unknown destinations use ordinary text containing an explicit target, not syntax that the parser removes. Keep the user-requested labels on capable destinations.
3. Preserve the already-fixed audience, target-binding, language, stale-head, and opt-in rules. Keep the change in the canonical skill; do not rewrite runtime code or sync mirrors before a clean canonical review.

## Recurrence on Head 3765013: Orchestrator Diagnosis Before Further Edits

The orchestrator independently fetched all 11 threads and their full bot comments, all three findings-bearing review heads, the exact-head bot summary/reactions, and every matching lint run. Deployment identity repeated on the third head, so editing and pushing paused again before this decision. Nine older threads remain resolved; the two current threads are actionable. No architecture or data-model rewrite has occurred.

The whole update path was read at `37650132150864e70b2de410b4bc2b4189d0afc2`: environment discovery, instance/state preflight, service stop, runtime-environment write, source sync, dependency/UI build, state seeding, config normalization, metadata, runtime preparation, and restart verification. These runner and regression-document files are unchanged against the fetched `origin/master`.

The missed distinction is three independent inputs: the selected source tree, the receiver's disposable source/build tree, and persistent runtime configuration. Sender integrity plus a commit receipt does not constrain either of the other two. `--reset-mode none` skips an existing state seed but does not suppress an environment-file rewrite; normal rsync may retain different bytes with the same size and mtime. Four existing consuming tests passed in isolation, including both runtime-environment branches, clean-source removal, and existing-state preservation. No Incus daemon was contacted.

Scope decision, recorded and read back before the next canonical skill edit:

1. Keep one shared, code-only update procedure for both regression choices. Require the persistent local target, product config, and runtime environment to exist before mutation; initial provisioning or credential changes need separate authority.
2. Use the existing `--env-file /dev/null` selector, verified against `load_env_file()`: it suppresses default discovery and returns no loaded file because this is not a regular file. Together with an existing target and `--reset-mode none`, the current runner does not rewrite runtime credentials. An empty regular file is not equivalent. Stop if the runner no longer supports this preservation path.
3. Add the documented `--clean` source reconciliation so receiver bytes cannot be skipped by the size/mtime quick check. Its scope is the disposable synced source and generated build tree, not product state, agent homes, or the runtime environment. Require source integrity to remain true through the update, then check receipt and served identity.
4. Prove the command's environment behavior with the actual loader and command orchestration behind a recording boundary, and the receiver behavior using real local rsync. Keep all task changes in the canonical skill; no new runner, callback protocol, live regression operations, or premature mirror sync.

## Known by Design: Label-Only Transport

The existing quick-reply API sends label text. Markdown links cannot add a hidden PR payload, and source-message metadata is not guaranteed in agent input. Exact labels are an explicit user requirement. If the clicked source report cannot actually be recovered, the agent must ask for the PR URL before acting, even when one PR was mentioned most recently or only one remains open. This applies to merge and both regression actions. The guidance intentionally fails closed; payload protocol changes are outside this PR.

## Dependencies and Scope

- No runtime or merge dependency on gateway PR #1939; its reviewed branch remains untouched.
- Companion repository skill mirrors follow only after the canonical change passes review.
- No implicit merge, deployment, production access, or regression state reset authorization.
