### PR TITLE
fix(model-hub): separate route status from Agent configuration

### DIFF
--- a/docs/plans/model-hub-gateway-status.md
+++ b/docs/plans/model-hub-gateway-status.md
@@ -1,0 +1,21 @@
+# Gateway Route Status and Agent Attribution
+
+The Model Hub backend header summarizes the routes of the displayed model
+catalog, not the configured model of an enabled named Agent. Changing an Agent
+selection or enabling/disabling an Agent must not change this route summary.
+
+- Complete per-model supply determines available, partially unavailable,
+  unavailable, or unconfigured routes. An empty catalog and an incomplete
+  supply read have distinct neutral states.
+- Named Agent supply issues retain their own attribution in a collapsible
+  footer below the model list. Its collapsed label contains only a count;
+  expanded rows display the Agent name, model, and reason separately.
+- Long identifiers wrap inside the expanded footer. They never enter the
+  compact mode-switch trigger or change the header's dimensions.
+- This is a read-only presentation change. It does not select a different
+  model, modify routes, or change runtime lifecycle behavior.
+
+Verification covers route-summary invariance, absent/incomplete supply,
+localized disclosure behavior, keyboard/touch interaction, and actual
+desktop/mobile layout with long identifiers. The existing Model Hub surface
+tokens and typography remain unchanged.

--- a/docs/plans/model-hub-gateway-status.md
+++ b/docs/plans/model-hub-gateway-status.md
@@ -1,5 +1,7 @@
 # Gateway Route Status and Agent Attribution
 
+Scenario: `MH-GATEWAY-STATUS-001` in the Model Hub scenario catalog.
+
 The Model Hub backend header summarizes the routes of the displayed model
 catalog, not the configured model of an enabled named Agent. Changing an Agent
 selection or enabling/disabling an Agent must not change this route summary.
@@ -17,5 +19,6 @@ selection or enabling/disabling an Agent must not change this route summary.
 
 Verification covers route-summary invariance, absent/incomplete supply,
 localized disclosure behavior, keyboard/touch interaction, and actual
-desktop/mobile layout with long identifiers. The existing Model Hub surface
+desktop/mobile layout with long identifiers and all localized route statuses
+under platform and wider fallback fonts. The existing Model Hub surface
 tokens and typography remain unchanged.

--- a/tests/scenarios/INDEX.yaml
+++ b/tests/scenarios/INDEX.yaml
@@ -158,6 +158,7 @@ capabilities:
       - ui/src/components/settings/models/SettingsModelsPage.render.test.tsx
       - ui/src/components/settings/models/RouteChainDialog.test.tsx
       - ui/src/components/settings/models/BackendModelCatalogDialog.test.tsx
+      - ui/src/components/settings/models/AgentCard.test.tsx
       - ui/scripts/scenarioCatalog.test.mjs
   - id: harness_failure_recovery
     name: Harness per-Session failure recovery

--- a/tests/scenarios/model_hub/catalog.yaml
+++ b/tests/scenarios/model_hub/catalog.yaml
@@ -19,6 +19,7 @@ capability:
     - ui/src/components/settings/models/SettingsModelsPage.render.test.tsx
     - ui/src/components/settings/models/RouteChainDialog.test.tsx
     - ui/src/components/settings/models/BackendModelCatalogDialog.test.tsx
+    - ui/src/components/settings/models/AgentCard.test.tsx
     # The gate that resolves those rows against vitest's own collection, and
     # its own evidence.
     - ui/scripts/scenarioCatalog.test.mjs
@@ -137,6 +138,15 @@ scenarios:
     related_tests:
       - ui/src/components/settings/models/BackendModelPickerDialog.test.tsx::finds an already-added model by its supplier and shows it as already added
       - ui/src/components/settings/models/BackendModelCatalogDialog.test.tsx::asks which row a typed ID names as the ID it would be saved as
+  - id: MH-GATEWAY-STATUS-001
+    name: Gateway route coverage stays independent of Agent selections and attributes Agent issues below the catalog
+    status: covered
+    kind: presentation
+    layer: unit
+    test: "ui/src/components/settings/models/AgentCard.test.tsx::MH-GATEWAY-STATUS-001: keeps Agent issues in an expandable footer, outside the mode trigger in en"
+    related_tests:
+      - ui/src/components/settings/models/supply.test.ts
+      - ui/e2e/model-catalog/gateway-status.spec.ts
   - id: MH-SRC-DELETE-001
     name: Source deletion removes every reference while preserving survivor order
     status: covered

--- a/ui/e2e/model-catalog/README.md
+++ b/ui/e2e/model-catalog/README.md
@@ -20,5 +20,13 @@ contracts remain covered by their existing tests; this is not live acceptance.
 
 The live `playwright.config.ts` excludes this fixture directory. The consuming
 `scripts/modelCatalogDiscovery.test.mjs` checks both real configs with `--list`:
-live discovery excludes the fixture, while isolated discovery retains all 36
-scenario-labelled cases. Collection starts no browser, web server or fixture.
+live discovery excludes the fixture, while isolated discovery retains the original
+36 catalog scenarios and discovers every fixture spec on desktop and mobile.
+Collection starts no browser, web server or fixture.
+
+`gateway-status.spec.ts` consumes `MH-GATEWAY-STATUS-001`. It renders the real
+Agent card with isolated catalog and Agent supply data. The route summary and
+collapsible Agent footer remain separate, and long identifiers wrap inside the
+footer. Every localized route status fits the existing compact control, including
+a wider fallback-font check. These are browser layout contracts, not live routing
+or backend acceptance.

--- a/ui/e2e/model-catalog/fixture.tsx
+++ b/ui/e2e/model-catalog/fixture.tsx
@@ -10,6 +10,7 @@ import { BackendModelCatalogDialog } from '../../src/components/settings/models/
 import { blankBackendModel } from '../../src/components/settings/models/backendCatalog';
 import { modelsApi } from '../../src/components/settings/models/modelsApi';
 import type { AgentBackend, AgentSupply, BackendModel, BackendModelsPut } from '../../src/components/settings/models/types';
+import { GatewayFixture } from './gatewayFixture';
 
 const params = new URLSearchParams(location.search);
 const backend = params.get('backend') as AgentBackend;
@@ -52,4 +53,6 @@ export function Fixture() {
   </I18nextProvider>;
 }
 
-createRoot(document.getElementById('root')!).render(<Fixture />);
+createRoot(document.getElementById('root')!).render(params.get('view') === 'gateway'
+  ? <I18nextProvider i18n={language}><GatewayFixture /></I18nextProvider>
+  : <Fixture />);

--- a/ui/e2e/model-catalog/gateway-status.spec.ts
+++ b/ui/e2e/model-catalog/gateway-status.spec.ts
@@ -1,12 +1,13 @@
 import { expect, test } from '@playwright/test';
+import { hub } from '../support/copy';
 
-for (const lang of ['en', 'zh']) {
+for (const lang of ['en', 'zh'] as const) {
   for (const long of [false, true]) {
-    test(`gateway status and Agent details remain separate without overflow (${lang}, long=${long})`, async ({ page }) => {
+    test(`MH-GATEWAY-STATUS-001: gateway status and Agent details remain separate without overflow (${lang}, long=${long})`, async ({ page }) => {
       await page.goto(`/e2e/model-catalog/fixture.html?view=gateway&backend=opencode&lang=${lang}${long ? '&long=1' : ''}`);
       const card = page.locator('[data-agent-backend="opencode"]');
       const head = card.locator('[data-agent-group-head]');
-      await expect(head).toContainText(lang === 'zh' ? '网关 · 路由可用' : 'Gateway · Routes ready');
+      await expect(head).toContainText(lang === 'zh' ? '网关 · 路由可用' : 'Gateway · Ready');
       await expect(head).not.toContainText('grok');
       await expect(card.locator('[data-route-model]')).toHaveCount(5);
       const issues = card.locator('[data-agent-supply-issues]');
@@ -34,4 +35,23 @@ for (const lang of ['en', 'zh']) {
       await expect(issues.locator('ul')).toBeHidden();
     });
   }
+
+  test(`MH-GATEWAY-STATUS-001: every route status fits the compact mode trigger (${lang})`, async ({ page }) => {
+    for (const status of ['empty', 'unknown', 'unconfigured', 'available', 'partial', 'unavailable']) {
+      await test.step(status, async () => {
+        await page.goto(`/e2e/model-catalog/fixture.html?view=gateway&backend=opencode&lang=${lang}&status=${status}`);
+        const trigger = page.locator('.model-hub-agent-mode-trigger');
+        await expect(trigger).toContainText(hub(`gateway.routeStatus.${status}`, {}, lang));
+        // Platform fallback fonts have different widths; reserve room for a wider fallback too.
+        for (const font of ['inherit', 'monospace']) {
+          await trigger.evaluate((element, family) => { element.style.fontFamily = family; }, font);
+          const label = trigger.locator('span').last();
+          const size = await label.evaluate((element) => ({ available: element.clientWidth, text: element.scrollWidth }));
+          expect(size.text, `${status}/${font}`).toBeLessThanOrEqual(size.available + 1);
+          expect((await trigger.boundingBox())!.width).toBeLessThanOrEqual(190);
+          expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true);
+        }
+      });
+    }
+  });
 }

--- a/ui/e2e/model-catalog/gateway-status.spec.ts
+++ b/ui/e2e/model-catalog/gateway-status.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from '@playwright/test';
+
+for (const lang of ['en', 'zh']) {
+  for (const long of [false, true]) {
+    test(`gateway status and Agent details remain separate without overflow (${lang}, long=${long})`, async ({ page }) => {
+      await page.goto(`/e2e/model-catalog/fixture.html?view=gateway&backend=opencode&lang=${lang}${long ? '&long=1' : ''}`);
+      const card = page.locator('[data-agent-backend="opencode"]');
+      const head = card.locator('[data-agent-group-head]');
+      await expect(head).toContainText(lang === 'zh' ? '网关 · 路由可用' : 'Gateway · Routes ready');
+      await expect(head).not.toContainText('grok');
+      await expect(card.locator('[data-route-model]')).toHaveCount(5);
+      const issues = card.locator('[data-agent-supply-issues]');
+      const toggle = issues.getByRole('button');
+      await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+      await expect(issues.locator('ul')).toBeHidden();
+      const headBefore = await head.boundingBox();
+      await toggle.click();
+      await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+      await expect(issues.locator('ul')).toBeVisible();
+      await expect(issues).toContainText(long ? 'long-model-id-' : 'grok/grok-4.6');
+      await expect(issues).toContainText(lang === 'zh' ? '此模型未配置路由' : 'No route configured for this model');
+      expect(await head.boundingBox()).toEqual(headBefore);
+      const overflow = await card.evaluate((element) => {
+        const box = element.getBoundingClientRect();
+        return [...element.querySelectorAll<HTMLElement>('[data-agent-supply-issue] p, [data-agent-supply-issues] button > span, .model-hub-agent-mode-trigger > span')]
+          .filter((node) => node.scrollWidth > node.clientWidth + 1 || node.getBoundingClientRect().right > box.right + 1)
+          .map((node) => node.textContent);
+      });
+      expect(overflow).toEqual([]);
+      expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true);
+      await page.screenshot({ path: test.info().outputPath('gateway-expanded.png'), fullPage: true, scale: 'css' });
+      await toggle.focus();
+      await page.keyboard.press('Enter');
+      await expect(issues.locator('ul')).toBeHidden();
+    });
+  }
+}

--- a/ui/e2e/model-catalog/gatewayFixture.tsx
+++ b/ui/e2e/model-catalog/gatewayFixture.tsx
@@ -1,0 +1,44 @@
+import { AgentCard } from '../../src/components/settings/models/AgentCard';
+import { blankBackendModel } from '../../src/components/settings/models/backendCatalog';
+import { modelChainKey } from '../../src/components/settings/models/modelRows';
+import { readyRegion } from '../../src/components/settings/models/regionRead';
+import { freshRuntimeProjection } from '../../src/components/settings/models/runtimeLifecycle';
+import type { AgentChain, AgentSupply, Source } from '../../src/components/settings/models/types';
+
+export function GatewayFixture() {
+  const long = new URLSearchParams(location.search).has('long');
+  const ids = ['claude-fable-5', 'claude-opus-4-8', 'claude-fable-5-1', 'claude-opus-5', 'claude-sonnet-5'];
+  const source: Source = {
+    id: 'src_fixture', display_name: 'Primary', kind: 'api_key', vendor: 'anthropic',
+    protocol: 'anthropic', supply_channel: 'hub', billing: 'metered', last_discovered_at: null,
+    state: { status: 'active', retry_at: null, detail_key: null },
+    models: ids.map((id) => ({ id, origin: 'discovered', reasoning_efforts: [], reasoning_efforts_source: null })),
+  };
+  const agent: AgentSupply = {
+    backend: 'opencode', cli_present: true, mode: 'hub', menu_kind: 'open',
+    catalog_models: ids.map((id) => ({ ...blankBackendModel(), id })),
+    sources: { order: [source.id], eligibility: [{ source_id: source.id, eligible: true }] },
+    model_supply: ids.map((model_id) => ({ model_id, route_origin: 'automatic', chain_length: 1, has_runnable_hop: true })),
+    named_agents: [{
+      name: long ? `opencode-${'long-agent-name-'.repeat(16)}` : 'opencode',
+      effective_model_id: long ? `grok/${'long-model-id-'.repeat(20)}grok-4.6` : 'grok/grok-4.6',
+      route_reason: 'route_unconfigured', supply_status: 'interrupted',
+    }],
+  };
+  const chains = Object.fromEntries(ids.map((model_id) => [modelChainKey('opencode', model_id), readyRegion<AgentChain>({
+    contract_version: 10, backend: 'opencode', model_id, route_origin: 'automatic', manual_override: null,
+    current: { source_id: source.id, model_id }, supply_state: 'ok',
+    chain: [{ source_id: source.id, model_id, channel: 'hub', health: 'healthy', runnable: true, reason: null, retry_at: null }],
+  })]));
+  const runtime = freshRuntimeProjection(readyRegion({
+    contract_version: 10,
+    manifest: { name: 'cliproxyapi', resolution: 'resolved', version: '1.0.0', source_sha: 'fixture', assets: [] },
+    status: { installed_version: '1.0.0', verified: true, listening: null, health: 'ok', last_check: null },
+  }));
+  return <main className="model-hub-shell mx-auto min-w-0 max-w-3xl p-4">
+    <AgentCard agents={[agent]} sources={[source]} chains={chains} runtime={runtime}
+      pendingBackends={new Set()} switchFailures={new Set()} connectingBackend={null}
+      onConnectHub={() => {}} onSwitchDirect={() => {}} onOpenModels={() => {}}
+      onOpenOrder={() => {}} onOpenRoute={() => {}} onProbeSettled={() => {}} />
+  </main>;
+}

--- a/ui/e2e/model-catalog/gatewayFixture.tsx
+++ b/ui/e2e/model-catalog/gatewayFixture.tsx
@@ -6,7 +6,9 @@ import { freshRuntimeProjection } from '../../src/components/settings/models/run
 import type { AgentChain, AgentSupply, Source } from '../../src/components/settings/models/types';
 
 export function GatewayFixture() {
-  const long = new URLSearchParams(location.search).has('long');
+  const params = new URLSearchParams(location.search);
+  const long = params.has('long');
+  const status = params.get('status') ?? 'available';
   const ids = ['claude-fable-5', 'claude-opus-4-8', 'claude-fable-5-1', 'claude-opus-5', 'claude-sonnet-5'];
   const source: Source = {
     id: 'src_fixture', display_name: 'Primary', kind: 'api_key', vendor: 'anthropic',
@@ -16,9 +18,12 @@ export function GatewayFixture() {
   };
   const agent: AgentSupply = {
     backend: 'opencode', cli_present: true, mode: 'hub', menu_kind: 'open',
-    catalog_models: ids.map((id) => ({ ...blankBackendModel(), id })),
+    catalog_models: status === 'empty' ? [] : ids.map((id) => ({ ...blankBackendModel(), id })),
     sources: { order: [source.id], eligibility: [{ source_id: source.id, eligible: true }] },
-    model_supply: ids.map((model_id) => ({ model_id, route_origin: 'automatic', chain_length: 1, has_runnable_hop: true })),
+    model_supply: status === 'unknown' ? [] : ids.map((model_id, index) => ({
+      model_id, route_origin: 'automatic', chain_length: status === 'unconfigured' ? 0 : 1,
+      has_runnable_hop: status === 'available' || (status === 'partial' && index === 0),
+    })),
     named_agents: [{
       name: long ? `opencode-${'long-agent-name-'.repeat(16)}` : 'opencode',
       effective_model_id: long ? `grok/${'long-model-id-'.repeat(20)}grok-4.6` : 'grok/grok-4.6',

--- a/ui/scripts/modelCatalogDiscovery.test.mjs
+++ b/ui/scripts/modelCatalogDiscovery.test.mjs
@@ -1,4 +1,5 @@
 import { execFileSync } from 'node:child_process';
+import { readdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { expect, test } from 'vitest';
 
@@ -35,10 +36,23 @@ test('live E2E discovery never collects the model catalog fixture', () => {
 }, 35_000);
 
 test('isolated catalog discovery retains all scenario-labelled browser cases', () => {
-  const specs = collect('playwright.model-catalog.config.ts');
+  const specs = collect('playwright.model-catalog.config.ts')
+    .filter((spec) => spec.file === 'catalog.spec.ts');
   expect(specs.flatMap((spec) => spec.tests)).toHaveLength(36);
   for (const spec of specs) {
     expect(spec.title).toContain('MH-MENU-COMPOSE-001');
-    expect(spec.file).toBe('catalog.spec.ts');
+  }
+}, 35_000);
+
+test('isolated discovery includes every fixture spec on both viewports', () => {
+  const specs = collect('playwright.model-catalog.config.ts');
+  const files = readdirSync(new URL('../e2e/model-catalog/', import.meta.url))
+    .filter((file) => file.endsWith('.spec.ts')).sort();
+  expect(files.length).toBeGreaterThan(0);
+  for (const project of ['desktop', 'mobile']) {
+    const discovered = specs
+      .filter((spec) => spec.tests.some((entry) => entry.projectName === project))
+      .map((spec) => spec.file);
+    expect([...new Set(discovered)].sort()).toEqual(files);
   }
 }, 35_000);

--- a/ui/src/components/settings/models/AgentCard.test.tsx
+++ b/ui/src/components/settings/models/AgentCard.test.tsx
@@ -292,7 +292,7 @@ describe('AgentCard', () => {
   });
 
   it.each([
-    ['en', 'Gateway · Routes down'],
+    ['en', 'Gateway · Unavailable'],
     ['zh', '网关 · 路由不可用'],
   ] as const)('summarizes unavailable model routes in %s', (lng, copy) => {
     render(<I18nextProvider i18n={localeInstance(lng)}><AgentCard agents={[{ ...hubAgent, model_supply: hubAgent.model_supply!.map((row) => ({ ...row, has_runnable_hop: false })), named_agents: [{ name: 'claude', effective_model_id: 'claude-opus-4-6', supply_status: 'waiting' }] }]} sources={[]} chains={{}} pendingBackends={new Set()} switchFailures={new Set()} connectingBackend={null} onConnectHub={vi.fn()} onSwitchDirect={vi.fn()} onOpenOrder={vi.fn()} onOpenRoute={vi.fn()} onProbeSettled={vi.fn()} /></I18nextProvider>);
@@ -301,7 +301,7 @@ describe('AgentCard', () => {
   });
 
   it.each([
-    ['en', 'Gateway · Routes ready'],
+    ['en', 'Gateway · Ready'],
     ['zh', '网关 · 路由可用'],
   ] as const)('summarizes catalog routes without requiring a selected Agent model in %s', (lng, copy) => {
     render(<I18nextProvider i18n={localeInstance(lng)}><AgentCard agents={[{
@@ -316,7 +316,7 @@ describe('AgentCard', () => {
   });
 
   it.each([
-    ['en', 'Gateway · Routes ready'],
+    ['en', 'Gateway · Ready'],
     ['zh', '网关 · 路由可用'],
   ] as const)('keeps available routes independent of Agent usage in %s', (lng, copy) => {
     render(<I18nextProvider i18n={localeInstance(lng)}><AgentCard agents={[{ ...hubAgent, named_agents: [] }]} sources={[]} chains={{}} pendingBackends={new Set()} switchFailures={new Set()} connectingBackend={null} onConnectHub={vi.fn()} onSwitchDirect={vi.fn()} onOpenOrder={vi.fn()} onOpenRoute={vi.fn()} onProbeSettled={vi.fn()} /></I18nextProvider>);
@@ -324,7 +324,7 @@ describe('AgentCard', () => {
     expect(screen.getByText(copy)).toBeTruthy();
   });
 
-  it.each(['en', 'zh'] as const)('keeps Agent issues in an expandable footer, outside the mode trigger in %s', async (lng) => {
+  it.each(['en', 'zh'] as const)('MH-GATEWAY-STATUS-001: keeps Agent issues in an expandable footer, outside the mode trigger in %s', async (lng) => {
     const instance = localeInstance(lng);
     const agent = {
       ...openCodeAgent,

--- a/ui/src/components/settings/models/AgentCard.test.tsx
+++ b/ui/src/components/settings/models/AgentCard.test.tsx
@@ -229,7 +229,7 @@ describe('AgentCard', () => {
     };
     render(<I18nextProvider i18n={localeInstance('zh')}><AgentCard agents={[agentWithRetainedRoute]} sources={[]} chains={{}} pendingBackends={new Set()} switchFailures={new Set()} connectingBackend={null} onConnectHub={vi.fn()} onSwitchDirect={vi.fn()} onOpenModels={onOpenModels} onOpenOrder={vi.fn()} onOpenRoute={vi.fn()} onProbeSettled={vi.fn()} /></I18nextProvider>);
 
-    expect(screen.getByText('网关 · 未配置模型路由')).toBeTruthy();
+    expect(screen.getByText('网关 · 未配置模型')).toBeTruthy();
     expect(screen.getByText('0 个模型')).toBeTruthy();
     // The card offers the catalog instead of reporting missing supply: an empty
     // list is something the user can fix from here, not a broken backend.
@@ -292,18 +292,18 @@ describe('AgentCard', () => {
   });
 
   it.each([
-    ['en', 'Gateway · Supply unavailable for now'],
-    ['zh', '网关 · 等待供应商恢复'],
-  ] as const)('renders the waiting umbrella in %s', (lng, copy) => {
-    render(<I18nextProvider i18n={localeInstance(lng)}><AgentCard agents={[{ ...hubAgent, named_agents: [{ name: 'claude', effective_model_id: 'claude-opus-4-6', supply_status: 'waiting' }] }]} sources={[]} chains={{}} pendingBackends={new Set()} switchFailures={new Set()} connectingBackend={null} onConnectHub={vi.fn()} onSwitchDirect={vi.fn()} onOpenOrder={vi.fn()} onOpenRoute={vi.fn()} onProbeSettled={vi.fn()} /></I18nextProvider>);
+    ['en', 'Gateway · Routes down'],
+    ['zh', '网关 · 路由不可用'],
+  ] as const)('summarizes unavailable model routes in %s', (lng, copy) => {
+    render(<I18nextProvider i18n={localeInstance(lng)}><AgentCard agents={[{ ...hubAgent, model_supply: hubAgent.model_supply!.map((row) => ({ ...row, has_runnable_hop: false })), named_agents: [{ name: 'claude', effective_model_id: 'claude-opus-4-6', supply_status: 'waiting' }] }]} sources={[]} chains={{}} pendingBackends={new Set()} switchFailures={new Set()} connectingBackend={null} onConnectHub={vi.fn()} onSwitchDirect={vi.fn()} onOpenOrder={vi.fn()} onOpenRoute={vi.fn()} onProbeSettled={vi.fn()} /></I18nextProvider>);
 
     expect(screen.getByText(copy)).toBeTruthy();
   });
 
   it.each([
-    ['en', 'Gateway · Healthy'],
-    ['zh', '网关 · 正常'],
-  ] as const)('summarizes the backend Agents instead of the unrelated default-Agent selection in %s', (lng, copy) => {
+    ['en', 'Gateway · Routes ready'],
+    ['zh', '网关 · 路由可用'],
+  ] as const)('summarizes catalog routes without requiring a selected Agent model in %s', (lng, copy) => {
     render(<I18nextProvider i18n={localeInstance(lng)}><AgentCard agents={[{
       ...hubAgent,
       selected_model_id: null,
@@ -316,12 +316,38 @@ describe('AgentCard', () => {
   });
 
   it.each([
-    ['en', 'Gateway · No Agent uses this backend'],
-    ['zh', '网关 · 暂无 Agent 使用'],
-  ] as const)('states when no enabled Agent uses the backend in %s', (lng, copy) => {
+    ['en', 'Gateway · Routes ready'],
+    ['zh', '网关 · 路由可用'],
+  ] as const)('keeps available routes independent of Agent usage in %s', (lng, copy) => {
     render(<I18nextProvider i18n={localeInstance(lng)}><AgentCard agents={[{ ...hubAgent, named_agents: [] }]} sources={[]} chains={{}} pendingBackends={new Set()} switchFailures={new Set()} connectingBackend={null} onConnectHub={vi.fn()} onSwitchDirect={vi.fn()} onOpenOrder={vi.fn()} onOpenRoute={vi.fn()} onProbeSettled={vi.fn()} /></I18nextProvider>);
 
     expect(screen.getByText(copy)).toBeTruthy();
+  });
+
+  it.each(['en', 'zh'] as const)('keeps Agent issues in an expandable footer, outside the mode trigger in %s', async (lng) => {
+    const instance = localeInstance(lng);
+    const agent = {
+      ...openCodeAgent,
+      menu: { view: 'featured' as const, checked: ['listed-model'] },
+      model_supply: [{ model_id: 'listed-model', route_origin: 'automatic' as const, chain_length: 1, has_runnable_hop: true }],
+      named_agents: [{ name: 'opencode', effective_model_id: 'grok/grok-4.6', supply_status: 'interrupted' as const, route_reason: 'route_unconfigured' as const }],
+    };
+    const view = render(<I18nextProvider i18n={instance}><AgentCard agents={[agent]} sources={[]} chains={{}} pendingBackends={new Set()} switchFailures={new Set()} connectingBackend={null} onConnectHub={vi.fn()} onSwitchDirect={vi.fn()} onOpenOrder={vi.fn()} onOpenRoute={vi.fn()} onProbeSettled={vi.fn()} /></I18nextProvider>);
+    const mode = view.container.querySelector('.model-hub-agent-mode-trigger')!;
+    expect(mode.textContent).toContain(instance.t('settings.models.gateway.routeStatus.available'));
+    expect(mode.textContent).not.toContain('grok');
+    const toggle = screen.getByRole('button', { name: instance.t('settings.models.gateway.agentIssues.summary', { count: 1 }) });
+    const details = document.getElementById(toggle.getAttribute('aria-controls')!)!;
+    expect(details.hidden).toBe(true);
+    expect(details.closest('[data-agent-group-head]')).toBeNull();
+    await userEvent.click(toggle);
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+    expect(details.hidden).toBe(false);
+    expect(within(details).getByText('opencode')).toBeTruthy();
+    expect(within(details).getByText('grok/grok-4.6')).toBeTruthy();
+    expect(within(details).getByText(instance.t('settings.models.gateway.agentIssues.routeMissing'))).toBeTruthy();
+    await userEvent.click(toggle);
+    expect(details.hidden).toBe(true);
   });
 
   it.each([

--- a/ui/src/components/settings/models/AgentCard.tsx
+++ b/ui/src/components/settings/models/AgentCard.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ArrowDownUp, Check, ChevronDown, ChevronRight, ChevronUp, ListChecks, PlugZap, Power, RefreshCw, Route } from 'lucide-react';
+import { ArrowDownUp, Check, ChevronDown, ChevronRight, ChevronUp, ListChecks, PlugZap, Power, RefreshCw, Route, TriangleAlert } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import { Badge } from '@/components/ui/badge';
@@ -11,7 +11,7 @@ import { cn } from '@/lib/utils';
 import { catalogModelIds } from './backendCatalog';
 import { COLLAPSED_MODEL_LIMIT, collapsedModelRows, modelChainKey, modelSupplyState, type ModelChainIndex, type ModelChainRead } from './modelRows';
 import { foldRegionRead } from './regionRead';
-import { agentGroupStatus } from './supply';
+import { gatewayRouteStatus } from './supply';
 import { agentHasLiveChainProjection, type FreshRuntimeProjection } from './runtimeLifecycle';
 import { currentChainLink, isTakeoverChain } from './takeover';
 import { ACCENT_ICON, ACCENT_TILE, backendVisual } from './vendorMeta';
@@ -118,6 +118,46 @@ const ModelRow: React.FC<{
   );
 };
 
+const AgentSupplyIssues: React.FC<{ agent: AgentSupply }> = ({ agent }) => {
+  const { t } = useTranslation();
+  const [open, setOpen] = React.useState(false);
+  const detailsId = React.useId();
+  const issues = (agent.named_agents ?? []).filter((named) =>
+    named.effective_model_id === null || named.route_reason === 'route_unconfigured'
+    || (named.supply_status !== null && named.supply_status !== 'ok')
+  );
+  if (issues.length === 0) return null;
+  return (
+    <div className="min-w-0 border-t border-border px-3.5 py-2" data-agent-supply-issues>
+      <button
+        type="button"
+        className="model-hub-ink-gold flex min-h-7 w-full min-w-0 items-center gap-2 text-left text-[11px] font-semibold"
+        aria-expanded={open}
+        aria-controls={detailsId}
+        onClick={() => setOpen((value) => !value)}
+      >
+        <TriangleAlert className="size-3.5 shrink-0" aria-hidden="true" />
+        <span className="min-w-0 flex-1 break-words">{t('settings.models.gateway.agentIssues.summary', { count: issues.length })}</span>
+        <ChevronDown className={cn('size-3.5 shrink-0 transition-transform', open && 'rotate-180')} aria-hidden="true" />
+      </button>
+      <ul id={detailsId} hidden={!open} className="min-w-0 space-y-3 pb-1 pt-2">
+        {issues.map((named) => {
+          const reason = named.effective_model_id === null ? 'modelMissing'
+            : named.route_reason === 'route_unconfigured' ? 'routeMissing'
+              : named.supply_status;
+          return (
+            <li key={named.name} className="min-w-0 text-[11px] leading-4" data-agent-supply-issue>
+              <p className="min-w-0 font-semibold text-foreground [overflow-wrap:anywhere]">{named.name}</p>
+              {named.effective_model_id !== null && <p className="min-w-0 font-mono text-muted [overflow-wrap:anywhere]">{named.effective_model_id}</p>}
+              <p className="model-hub-ink-gold mt-1 [overflow-wrap:anywhere]">{t(`settings.models.gateway.agentIssues.${reason}`)}</p>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};
+
 const AgentModelCard: React.FC<{
   agent: AgentSupply;
   runtime: FreshRuntimeProjection | null;
@@ -161,10 +201,10 @@ const AgentModelCard: React.FC<{
   const hasTakeover = chainProjectionLive
     && allModels.some((modelId) => isTakeoverRead(chains[modelChainKey(agent.backend, modelId)]));
   const modeWord = t(`settings.models.gateway.group.mode.${agent.mode === 'hub' ? 'gateway' : 'direct'}`) as string;
-  const health = agent.mode === 'hub' ? agentGroupStatus(agent.named_agents ?? []) : 'unused';
+  const health = gatewayRouteStatus(agent);
   const subtitle = agent.mode === 'direct'
     ? t('settings.models.gateway.group.subtitle.direct', { mode: modeWord }) as string
-    : t('settings.models.gateway.group.subtitle.gateway', { mode: modeWord, health: t(`settings.models.gateway.group.status.${health}`) }) as string;
+    : t('settings.models.gateway.group.subtitle.gateway', { mode: modeWord, health: t(`settings.models.gateway.routeStatus.${health}`) }) as string;
   const toggleCollapsed = () => {
     setExpanded((value) => !value);
     onProbeSettled(agent);
@@ -173,16 +213,16 @@ const AgentModelCard: React.FC<{
   const noUsableSource = agent.mode === 'hub'
     && Boolean(agent.model_supply?.length)
     && agent.model_supply?.every((entry) => entry.chain_length > 0 && !entry.has_runnable_hop);
-  const statusClass = switchFailed || health === 'interrupted'
+  const statusClass = switchFailed || health === 'unavailable'
     ? 'text-destructive-ink'
-    : hasTakeover || health === 'degraded' || health === 'waiting'
+    : hasTakeover || health === 'partial'
       ? 'model-hub-ink-gold'
       : 'text-muted';
-  const statusDot = switchFailed || health === 'interrupted'
+  const statusDot = switchFailed || health === 'unavailable'
     ? 'bg-destructive'
-    : hasTakeover || health === 'degraded' || health === 'waiting'
+    : hasTakeover || health === 'partial'
       ? 'bg-gold'
-      : health === 'ok' && agent.mode === 'hub'
+      : health === 'available' && agent.mode === 'hub'
         ? 'bg-mint'
         : 'bg-muted';
   const modeStatus = switchFailed
@@ -219,7 +259,7 @@ const AgentModelCard: React.FC<{
                     type="button"
                     disabled={pending}
                     aria-label={`${t('settings.models.gateway.modeMenu.title')}: ${modeStatus}`}
-                    className={cn('model-hub-agent-mode-trigger flex min-w-0 items-center gap-1.5 rounded-md px-2.5 text-[11px] font-semibold transition-colors hover:text-foreground disabled:opacity-50', statusClass)}
+                    className={cn('model-hub-agent-mode-trigger flex max-w-full min-w-0 items-center gap-1.5 rounded-md px-2.5 text-[11px] font-semibold transition-colors hover:text-foreground disabled:opacity-50', statusClass)}
                   >
                     <span className={cn('size-[5px] shrink-0 rounded-full', statusDot)} />
                     <span className="truncate">{modeStatus}</span>
@@ -262,6 +302,7 @@ const AgentModelCard: React.FC<{
         </div>
       </div>
       {agent.mode === 'hub' && (models.length === 0 ? <div className="flex flex-col items-center gap-3 px-4 py-10 text-center sm:px-5"><p className="text-[12.5px] text-muted">{t('settings.models.gateway.group.emptyModels')}</p><ManageModelsButton disabled={pending} onClick={() => onOpenModels(agent)} /></div> : <div className="space-y-2 p-2">{noUsableSource && <p className="px-3 py-1 text-[11px] font-semibold text-muted">{t('settings.models.gateway.supply.none')}</p>}{models.map((modelId) => <ModelRow key={modelId} agent={agent} modelId={modelId} sources={sources} read={chainProjectionLive ? chains[modelChainKey(agent.backend, modelId)] : undefined} originHelpOpen={activeOriginHelp === modelChainKey(agent.backend, modelId)} onOriginHelpChange={onOriginHelpChange} onOpenRoute={onOpenRoute} />)}{canCollapse ? <button type="button" onClick={toggleCollapsed} className="model-hub-model-collapse flex h-6 w-full items-center gap-1.5 hover:text-foreground">{expanded ? <ChevronUp /> : <ChevronDown />}{expanded ? t('settings.models.gateway.collapse') : t('settings.models.gateway.moreModels', { count: collapsed.hidden.length })}</button> : needsChainRepair ? <button type="button" onClick={retryChains} className="model-hub-model-collapse flex h-6 w-full items-center gap-1.5 hover:text-foreground"><RefreshCw />{t('settings.models.gateway.retry')}</button> : null}</div>)}
+      {agent.mode === 'hub' && <AgentSupplyIssues agent={agent} />}
     </section>
   );
 };

--- a/ui/src/components/settings/models/supply.test.ts
+++ b/ui/src/components/settings/models/supply.test.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import {
-  agentGroupStatus,
+  gatewayRouteStatus,
   attribution,
   hasAttribution,
   healthyButUnrunnable,
@@ -85,56 +85,41 @@ const cannotLaunch = (...ids: string[]) =>
     process_availability_reason: 'native_cli_unavailable' as const,
   }));
 
-describe('agentGroupStatus', () => {
-  const statuses = (...values: Array<'ok' | 'degraded' | 'waiting' | 'interrupted' | null>) =>
-    values.map((supplyStatus, index) => ({
-      name: `agent-${index}`,
-      effective_model_id: supplyStatus === null ? null : `model-${index}`,
-      supply_status: supplyStatus,
-    }));
-
-  it('reports an unused backend only when no enabled Agent uses it', () => {
-    expect(agentGroupStatus([])).toBe('unused');
+describe('gatewayRouteStatus', () => {
+  const model = (model_id: string, chain_length: number, has_runnable_hop: boolean) => ({
+    model_id, chain_length, has_runnable_hop, route_origin: 'automatic' as const,
   });
+  const covered = hubAgent({ selected_model_id: null, model_supply: [model('listed', 1, true)] });
 
-  it('reports a configuration gap separately from unavailable configured sources', () => {
-    expect(agentGroupStatus([
-      {
-        name: 'opencode',
-        effective_model_id: 'gpt-5.6-terra',
-        supply_status: 'interrupted',
+  it('is independent of named Agent selections and statuses', () => {
+    for (const status of ['ok', 'degraded', 'waiting', 'interrupted', null] as const) {
+      expect(gatewayRouteStatus({ ...covered, named_agents: [{
+        name: 'opencode', effective_model_id: 'grok/grok-4.6', supply_status: status,
         route_reason: 'route_unconfigured',
-      },
-    ])).toBe('unconfigured');
-    expect(agentGroupStatus([
-      {
-        name: 'opencode',
-        effective_model_id: 'gpt-5.6-terra',
-        supply_status: 'interrupted',
-        route_reason: null,
-      },
-    ])).toBe('interrupted');
+      }] })).toBe('available');
+    }
+    expect(gatewayRouteStatus({ ...covered, named_agents: [] })).toBe('available');
   });
 
-  it('reports an Agent without a model as unconfigured', () => {
-    expect(agentGroupStatus(statuses(null))).toBe('unconfigured');
+  it.each([
+    [[], 'empty'],
+    [[model('one', 0, false)], 'unconfigured'],
+    [[model('one', 1, true), model('two', 2, true)], 'available'],
+    [[model('one', 1, true), model('two', 0, false)], 'partial'],
+    [[model('one', 1, true), model('two', 2, false)], 'partial'],
+    [[model('one', 1, false), model('two', 0, false)], 'unavailable'],
+  ] as const)('summarizes complete catalog supply %j as %s', (supply, expected) => {
+    expect(gatewayRouteStatus(hubAgent({ selected_model_id: null, model_supply: [...supply] }))).toBe(expected);
   });
 
-  it('reports healthy only when every enabled Agent is healthy', () => {
-    expect(agentGroupStatus(statuses('ok', 'ok'))).toBe('ok');
+  it('does not mistake an incomplete supply read for missing routes or success', () => {
+    for (const model_supply of [null, [], [model('other', 1, true)]]) {
+      expect(gatewayRouteStatus(hubAgent({ builtin_models: ['unread'], model_supply }))).toBe('unknown');
+    }
   });
 
-  it('reports degraded while at least one Agent remains usable but the group is not fully healthy', () => {
-    expect(agentGroupStatus(statuses('ok', 'interrupted'))).toBe('degraded');
-    expect(agentGroupStatus(statuses('degraded', 'waiting'))).toBe('degraded');
-  });
-
-  it('reports waiting when no Agent is usable and at least one can recover without action', () => {
-    expect(agentGroupStatus(statuses('waiting', 'interrupted'))).toBe('waiting');
-  });
-
-  it('reports interrupted when no Agent is usable or self-healing', () => {
-    expect(agentGroupStatus(statuses('interrupted', null))).toBe('interrupted');
+  it('ignores supply entries outside an authoritative catalog', () => {
+    expect(gatewayRouteStatus({ ...covered, catalog_models: [] })).toBe('empty');
   });
 });
 

--- a/ui/src/components/settings/models/supply.ts
+++ b/ui/src/components/settings/models/supply.ts
@@ -4,10 +4,10 @@
 // deserve unit tests, and this repo's vitest setup has no DOM, so they are plain
 // functions over the contract types and nothing else.
 import { processAvailabilityOf } from './eligibility';
+import { catalogModelIds } from './backendCatalog';
 import type {
   AgentSupply,
   ModelSupply,
-  NamedAgentSupply,
   Source,
   SourceState,
   SupplyStatus,
@@ -69,20 +69,19 @@ export const needsAttention = (state: SourceState): boolean =>
 export const healthyButUnrunnable = (agent: Pick<AgentSupply, 'sources'>, source: Source): boolean =>
   !isUnhealthy(source.state) && !processAvailabilityOf(agent, source.id).runnable;
 
-export type AgentGroupStatus = SupplyStatus | 'unconfigured' | 'unused';
+export type GatewayRouteStatus = 'empty' | 'unknown' | 'unconfigured' | 'available' | 'partial' | 'unavailable';
 
-/** Summarize the enabled Agents using one backend without inventing a backend selection. */
-export const agentGroupStatus = (agents: NamedAgentSupply[]): AgentGroupStatus => {
-  if (agents.length === 0) return 'unused';
-  if (agents.every((agent) =>
-    agent.effective_model_id === null || agent.route_reason === 'route_unconfigured'
-  )) return 'unconfigured';
-
-  const statuses = agents.map((agent) => agent.supply_status);
-  if (statuses.every((status) => status === 'ok')) return 'ok';
-  if (statuses.some((status) => status === 'ok' || status === 'degraded')) return 'degraded';
-  if (statuses.some((status) => status === 'waiting')) return 'waiting';
-  return 'interrupted';
+/** Gateway coverage is about the catalog, independent of any Agent's selection. */
+export const gatewayRouteStatus = (agent: AgentSupply): GatewayRouteStatus => {
+  const models = catalogModelIds(agent);
+  if (models.length === 0) return 'empty';
+  const byId = new Map((agent.model_supply ?? []).map((row) => [row.model_id, row]));
+  const supply = models.map((id) => byId.get(id));
+  if (supply.some((row) => !row)) return 'unknown';
+  if (supply.every((row) => row?.chain_length === 0)) return 'unconfigured';
+  const available = supply.filter((row) => row && row.chain_length > 0 && row.has_runnable_hop).length;
+  if (available === models.length) return 'available';
+  return available > 0 ? 'partial' : 'unavailable';
 };
 
 // ── AC-9: who a supply problem is about ─────────────────────────────────

--- a/ui/src/components/settings/models/types.ts
+++ b/ui/src/components/settings/models/types.ts
@@ -417,7 +417,7 @@ export type AgentSupply = {
   routes?: Record<string, AgentRoute> | null;
   /** Rollup over `sources.order` for the current selection. null in direct mode
    *  and whenever `selected_model_id` is null. This is not a backend-wide
-   *  rollup; group summaries derive from `named_agents`. */
+   *  rollup; gateway coverage derives from the catalog's `model_supply`. */
   supply_status?: SupplyStatus | null;
   /** Supply depth per selectable model. null when mode=direct. */
   model_supply?: ModelSupply[] | null;

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -933,6 +933,23 @@
         "moreModels_other": "{{count}} more models",
         "collapse": "Collapse",
         "retry": "Retry",
+        "routeStatus": {
+          "empty": "No models",
+          "unknown": "Routes unknown",
+          "unconfigured": "No routes",
+          "available": "Routes ready",
+          "partial": "Partial routes",
+          "unavailable": "Routes down"
+        },
+        "agentIssues": {
+          "summary_one": "{{count}} Agent needs attention",
+          "summary_other": "{{count}} Agents need attention",
+          "modelMissing": "No model selected",
+          "routeMissing": "No route configured for this model",
+          "degraded": "Model supply degraded",
+          "waiting": "Waiting for a source to recover",
+          "interrupted": "No source is available for this model"
+        },
         "supply": {
           "none": "No usable source",
           "unread": "Could not read this backend's supply · the gateway itself is fine"

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -935,11 +935,11 @@
         "retry": "Retry",
         "routeStatus": {
           "empty": "No models",
-          "unknown": "Routes unknown",
+          "unknown": "Unknown",
           "unconfigured": "No routes",
-          "available": "Routes ready",
-          "partial": "Partial routes",
-          "unavailable": "Routes down"
+          "available": "Ready",
+          "partial": "Partial",
+          "unavailable": "Unavailable"
         },
         "agentIssues": {
           "summary_one": "{{count}} Agent needs attention",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -933,6 +933,23 @@
         "moreModels_other": "还有 {{count}} 个模型",
         "collapse": "收起",
         "retry": "重试",
+        "routeStatus": {
+          "empty": "未配置模型",
+          "unknown": "路由状态待确认",
+          "unconfigured": "未配置模型路由",
+          "available": "路由可用",
+          "partial": "部分路由不可用",
+          "unavailable": "路由不可用"
+        },
+        "agentIssues": {
+          "summary_one": "{{count}} 个 Agent 需关注",
+          "summary_other": "{{count}} 个 Agent 需关注",
+          "modelMissing": "未选择模型",
+          "routeMissing": "此模型未配置路由",
+          "degraded": "模型供应已降级",
+          "waiting": "等待供应商恢复",
+          "interrupted": "此模型没有可用供应商"
+        },
         "supply": {
           "none": "没有可用供应商",
           "unread": "路由状态暂时不可用 · 模型网关本身正常"


### PR DESCRIPTION
## Summary

Separate Model Hub gateway route coverage from the configuration of named Avibe Agents. A listed model with runnable upstream routes remains available even when an Agent selects an unrelated, unrouted model such as `grok/grok-4.6`.

- Derive the compact backend header status from the displayed catalog and its per-model supply, not from named Agent defaults.
- Keep named Agent issues in a separate, initially collapsed footer below the model list. Expanded entries show the Agent name, model, and reason on distinct wrapping lines.
- Preserve the existing compact status control dimensions, with short localized labels. Missing supply data is unknown, not healthy or unconfigured.

Behavior contract: `docs/plans/model-hub-gateway-status.md`.
Scenario: `MH-GATEWAY-STATUS-001`, registered in the Model Hub catalog and project scenario index, with ID-labelled unit and browser evidence.

## Evidence

- Unit/contract/render: all 3,975 UI tests passed across 295 files, including the 1,304 Model Hub tests covering catalog-state invariance and localized disclosure behavior.
- Browser: all 48 model-catalog tests passed. The 12 gateway cases cover English/Chinese, desktop/mobile, normal/long identifiers, and every route status with platform and wider fallback fonts. Existing MH-MENU-COMPOSE-001 scenarios remain green.
- Catalog integrity: Python Model Hub catalog test passed; all 27 UI citations resolve to exactly one collected Vitest case each.
- Discovery contract: original catalog scenario coverage remains enforced, and every fixture spec must be discovered on both desktop and mobile without a fixed total test count.
- Layout: reproduced the old English label overflowing its 141px text area by 5px under a wider fallback font. Shorter status copy fits without widening the 190px control or weakening the overflow assertions. Inspected desktop/mobile screenshots and a 320px viewport; long identifiers wrap in the separate footer.
- UI lint baseline, theme validation, test typecheck, browser fixture typecheck, production build, and whitespace checks passed. No new dependencies. Run lint after the test suite rather than concurrently: lint integrity tests temporarily create intentional policy-violation probes.
- Residual: Pencil document reads failed through its MCP interface, so no design-canvas comparison was possible. Existing Model Hub typography, spacing, palette, and control styles are reused. Production Avibe and local user configuration were not changed; the preview uses isolated fixture data with no production API connection. Live backend and local Incus acceptance remain deferred to integration.

## Dependencies

None. Based on current `master`; this UI fix is independent of the backend-native default-model change in #1942.

## Known By Design

- Gateway coverage and named Agent readiness are different facts. A gateway may have available catalog routes while one Agent still has an unrouted selection; both are displayed without changing the selection.
- A named Agent issue does not appear in the mode-switch trigger. Its footer remains collapsed until expanded, and identifiers wrap rather than widening that trigger.
- This is a read-only presentation change. It does not alter routing, select another model, start a runtime, deploy, or restart Avibe.
