### PR TITLE
docs(model-hub): sync first-wave catalog table with api_key_vendors.json

### DIFF
--- a/docs/plans/model-hub-vendor-preset-protocol.md
+++ b/docs/plans/model-hub-vendor-preset-protocol.md
@@ -62,29 +62,36 @@ where one is replayed.
 
 ## First-wave catalog
 
-Authoritative table, shipped as `vibe/data/api_key_vendors.json`. Vendor
-ids reuse the `Source.vendor` pattern already named in
-`source.schema.json` (`anthropic|openai|zhipuai|kimi|xai|…`). Model-id
-prefix map in `vibe/data/model_vendors.json` is a different document
-(family → vendor for catalog backfill) and is not this picker.
+Mirror of `vibe/data/api_key_vendors.json`, which is the shipped artifact
+and the authority: on any drift — a cell, a missing row, or the row order —
+the JSON wins and this table is what gets corrected (last synced 2026-09-08,
+#1938). A data change belongs in the same PR as its row here. Vendor ids
+reuse the `Source.vendor` pattern already named in `source.schema.json`
+(`anthropic|openai|zhipuai|kimi|xai|…`). Model-id prefix map in
+`vibe/data/model_vendors.json` is a different document (family → vendor for
+catalog backfill) and is not this picker.
 
 | id | Label | Official Base URL | Pinned protocol |
 | --- | --- | --- | --- |
+| `openai` | OpenAI | `https://api.openai.com/v1` | `openai_responses` |
+| `anthropic` | Anthropic | `https://api.anthropic.com` | `anthropic` |
+| `xai` | xAI | `https://api.x.ai/v1` | `openai_responses` |
+| `gemini` | Gemini | `https://generativelanguage.googleapis.com/v1beta/openai` | `openai_chat` |
 | `deepseek` | DeepSeek | `https://api.deepseek.com` | `openai_chat` |
 | `qwen` | Qwen | `https://dashscope.aliyuncs.com/compatible-mode/v1` | `openai_chat` |
 | `kimi` | Kimi | `https://api.moonshot.cn/v1` | `openai_chat` |
-| `zhipuai` | Zhipu AI | `https://open.bigmodel.cn/api/paas/v4` | `openai_chat` |
-| `openai` | OpenAI | `https://api.openai.com/v1` | `openai_responses` |
-| `anthropic` | Anthropic | `https://api.anthropic.com` | `anthropic` |
 | `openrouter` | OpenRouter | `https://openrouter.ai/api/v1` | `openai_chat` |
-| `groq` | Groq | `https://api.groq.com/openai/v1` | `openai_chat` |
+| `zhipuai` | Zhipu AI | `https://open.bigmodel.cn/api/paas/v4` | `openai_chat` |
 | `mistral` | Mistral | `https://api.mistral.ai/v1` | `openai_chat` |
-| `xai` | xAI | `https://api.x.ai/v1` | `openai_responses` |
+| `groq` | Groq | `https://api.groq.com/openai/v1` | `openai_chat` |
 | `together` | Together | `https://api.together.xyz/v1` | `openai_chat` |
 | `fireworks` | Fireworks | `https://api.fireworks.ai/inference/v1` | `openai_chat` |
 
-`custom` is the dropdown default, not a catalog row. Gemini native is
-deferred (not in the three-protocol vocabulary).
+`custom` is the dropdown default, not a catalog row. The `gemini` row is
+Gemini's OpenAI-compatible surface, reached on that vendor's own
+`/v1beta/openai` base URL; Gemini **native** stays deferred (not in the
+three-protocol vocabulary, and still Out of scope below). The row and the
+deferral are about different wire formats, not a contradiction.
 
 Engine `_OFFICIAL_BASE_URLS` today only lists anthropic/openai/codex.
 This table is the replacement for api-key observation: look up by


### PR DESCRIPTION
Fixes #1938.

Documentation only — one file, `docs/plans/model-hub-vendor-preset-protocol.md`. No code, no schema, no data, no i18n.

## What changes

The First-wave catalog table drifted from `vibe/data/api_key_vendors.json` when #1926 changed the data without touching the doc. Two corrections, both taken from the JSON:

- **The missing `gemini` row is added** — `https://generativelanguage.googleapis.com/v1beta/openai`, pinned `openai_chat`.
- **The row order is restored to the shipped curated order** — `openai, anthropic, xai, gemini, deepseek, qwen, kimi, openrouter, zhipuai, mistral, groq, together, fireworks`. The order is load-bearing rather than cosmetic: the same document says the 服务商 select renders "the first-wave rows in the table order above", and `docs/plans/model-hub-ui-spec.md` says one option per shipped catalog row **in file order** — so a doc order that is not the file order describes a picker that does not exist.

The `xai` cell already reads `openai_responses` on master (#1937) and is left alone.

## Why the header paragraph changed too

The paragraph above the table called it the "authoritative table, shipped as `vibe/data/api_key_vendors.json`" — one sentence naming both the doc and the file as the authority. That is the sentence that made this drift possible to write and hard to notice, so adding a "the data wins" line under it would have contradicted the line above it. It now says the table is a mirror of the JSON, that the JSON wins on any drift including row order, that a data change belongs in the same PR as its row here, and when it was last synced (2026-09-08, #1938).

## Gemini: the row and the deferral are not in conflict

The document says elsewhere that Gemini native is deferred and lists "Gemini native / a fourth protocol value" under Out of scope. Both statements stay true: the shipped row is Gemini's **OpenAI-compatible** surface, reached on that vendor's own `/v1beta/openai` base URL, so it needs no fourth protocol value. The paragraph under the table now says that explicitly instead of leaving the two statements to look like a contradiction.

## Evidence

- **Mechanical cell-by-cell check**: parsed the markdown table out of the committed doc and compared it to `vibe/data/api_key_vendors.json` as ordered tuples of `(id, label, official_base_url, protocol)` — 13 rows vs 13 rows, exact match on order and every cell, empty symmetric difference on ids. Not eyeballed.
- **No other surface reproduces the table**: nothing in the repository parses this markdown, and the only other documents that reference the catalog (`model-hub-ui-spec.md`, `model-hub.md`, `model-hub-add-key-confirmation-flow.md`) point at the JSON rather than restating rows, so no sibling doc needs the same edit. `model-hub-ui-spec.md` already says "in file order" and needed no change.
- No vendor count, row count, or per-vendor claim elsewhere in the changed document depends on the old order.
- No test, build, or lint surface is touched: the change is prose and a table in `docs/plans/`.

## Known by design

- **No automated guard is added.** This class of drift recurs because nothing enforces doc-vs-JSON agreement, and a ~15-line test parsing the table would make it impossible rather than merely documented. That is code, and this lane was scoped documentation-only; the dated "the JSON wins" line is the mitigation that was asked for. Worth a follow-up decision rather than a silent scope expansion.
- **The dated line will itself age.** It records the last sync (2026-09-08), not a guarantee of freshness; it exists so a future reader can tell how old the mirror is instead of trusting it.
