### PR TITLE
fix(search): focus mobile search within the entry tap

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -54,10 +54,11 @@ jobs:
       - name: Test browser interactions
         working-directory: ui
         run: |
-          npx playwright install --with-deps chromium
+          npx playwright install --with-deps chromium webkit
           npm run test:model-catalog
           npm run test:model-provider
           npm run test:project-order
+          npm run test:inbox-return
 
   build-linux-artifacts:
     runs-on: ubuntu-latest

--- a/ui/e2e/inbox-return/README.md
+++ b/ui/e2e/inbox-return/README.md
@@ -1,9 +1,11 @@
 # Inbox Return Regression
 
-Run `npm run test:inbox-return` from `ui/`.
+Install the browser engines with `npx playwright install --with-deps chromium webkit`,
+then run `npm run test:inbox-return` from `ui/`.
 
-This backend-free suite renders the production `InboxPage` with an in-memory
-Inbox provider and a routed Chat placeholder. Its shell mirrors the production
+This backend-free suite renders the production `InboxPage` and `SearchPage` with
+an in-memory Inbox provider and a routed Chat placeholder. Like production, a
+data router hosts descendant declarative routes. Its shell mirrors the production
 mobile internal scroll owner and desktop document scrolling. Browser history
 and the Chat Back button both return to the original Inbox entry.
 
@@ -21,6 +23,12 @@ renders, all visible rows disappearing, every supported input cancellation,
 expiration, and Strict Mode lifecycle replay. Consumption and cancellation both
 prevent the shared snapshot from leaking into a later Inbox remount, while the
 current visit retains its local copy for delayed layout corrections.
+
+Search-entry taps must mount and focus the search input before the click finishes
+bubbling, so focus stays inside the user gesture required by mobile keyboards.
+Chromium and mobile WebKit checks cover this timing, typing without another tap,
+clearing, repeat visits, and query restoration from a direct URL. Browser automation
+does not prove that the native iOS soft keyboard appears; that remains a device check.
 
 All API requests are blocked. No Avibe instance, credentials, or persisted
 messages are used. Screenshots and failure traces are written under

--- a/ui/e2e/inbox-return/fixture.tsx
+++ b/ui/e2e/inbox-return/fixture.tsx
@@ -1,8 +1,9 @@
 import { StrictMode, useCallback, useEffect, useState } from 'react';
 import { createRoot } from 'react-dom/client';
-import { HashRouter, Route, Routes, useLocation, useNavigate, useParams } from 'react-router-dom';
+import { createHashRouter, Route, RouterProvider, Routes, useLocation, useNavigate, useParams } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
 import { InboxPage } from '../../src/components/workbench/InboxPage';
+import { SearchPage } from '../../src/components/workbench/SearchPage';
 import { ApiProvider, type InboxSession } from '../../src/context/ApiContext';
 import { WorkbenchInboxContext } from '../../src/context/WorkbenchInboxContext';
 import { InstanceAuthorizationContext } from '../../src/context/InstanceAuthorizationContext';
@@ -40,14 +41,8 @@ function Chat({ markRead, addActivity }: { markRead: (id: string) => Promise<voi
   </div>;
 }
 
-function Search() {
-  const navigate = useNavigate();
-  return <div data-testid="search-detail">
-    <button type="button" aria-label="Back" onClick={() => navigate(-1)}><ArrowLeft /></button>
-  </div>;
-}
-
 export function Fixture() {
+  const navigate = useNavigate();
   const location = useLocation();
   const chat = location.pathname.startsWith('/chat/');
   const [sessions, setSessions] = useState(history.slice(0, 60));
@@ -78,9 +73,9 @@ export function Fixture() {
         : 'min-h-0 flex-1 overflow-y-auto pb-[88px] md:overflow-visible md:pb-0'}>
         <div className={chat ? 'h-full' : 'px-4 py-5 md:px-10 md:py-8'}>
           <Routes>
-            <Route path="/inbox" element={<InboxPage />} />
+            <Route path="/inbox" element={<InboxPage onOpenSearch={() => { void navigate('/search', { flushSync: true }); }} />} />
             <Route path="/chat/:sessionId" element={<Chat markRead={markRead} addActivity={addActivity} />} />
-            <Route path="/search" element={<Search />} />
+            <Route path="/search" element={<SearchPage />} />
           </Routes>
         </div>
       </main>
@@ -88,17 +83,20 @@ export function Fixture() {
   </WorkbenchInboxContext.Provider>;
 }
 
+// Match production: a data router hosting descendant declarative routes.
+const router = createHashRouter([{ path: '*', element: <Fixture /> }]);
+
 createRoot(document.getElementById('root')!).render(
-  <StrictMode><HashRouter>
+  <StrictMode>
     <InstanceAuthorizationContext.Provider value={{
       remote: false, instanceKind: null, instanceRole: 'owner',
       capabilities: { ...OWNER_INSTANCE_CAPABILITIES, can_read_instance: false },
     }}>
       <ToastContext.Provider value={{ showToast: noop }}><ApiProvider>
         <WindowManagerContext.Provider value={{ focusedId: null, focusCanvas: noop } as WindowManagerValue}>
-          <Fixture />
+          <RouterProvider router={router} />
         </WindowManagerContext.Provider>
       </ApiProvider></ToastContext.Provider>
     </InstanceAuthorizationContext.Provider>
-  </HashRouter></StrictMode>,
+  </StrictMode>,
 );

--- a/ui/e2e/inbox-return/return.spec.ts
+++ b/ui/e2e/inbox-return/return.spec.ts
@@ -127,7 +127,7 @@ test('does not reuse an old Chat position when a later Search visit returns', as
   await scrollTo(page, 0);
   if (isMobile) await page.getByText(copy('workbench.search.entry'), { exact: true }).click();
   else await page.evaluate(() => { window.location.hash = '/search'; });
-  await expect(page.getByTestId('search-detail')).toBeVisible();
+  await expect(page.getByRole('textbox', { name: copy('workbench.search.placeholder') })).toBeVisible();
   await page.goBack();
   await expect(rows(page)).toHaveCount(60);
   await expect.poll(async () => (await position(page)).top).toBe(0);

--- a/ui/e2e/inbox-return/search-focus.spec.ts
+++ b/ui/e2e/inbox-return/search-focus.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from '@playwright/test';
+import { copy } from '../support/copy';
+
+test.beforeEach(async ({ page }) => {
+  await page.route('**/api/**', (route) => route.fulfill({ status: 503, json: { error: 'No backend in this fixture' } }));
+  await page.route('**/api/show-pages', (route) => route.fulfill({ json: { pages: [] } }));
+  await page.route('**/api/search/messages?*', (route) => route.fulfill({ json: { sessions: [], total: 0, session_count: 0 } }));
+});
+
+test('a search-entry tap focuses the input within the same gesture and accepts typing', async ({ page, isMobile }, testInfo) => {
+  test.skip(!isMobile, 'The Inbox search entry is mobile-only.');
+  await page.goto('/e2e/inbox-return/fixture.html#/inbox');
+  const entry = page.getByText(copy('workbench.search.entry'), { exact: true });
+  const input = page.getByRole('textbox', { name: copy('workbench.search.placeholder') });
+
+  for (let visit = 0; visit < 2; visit += 1) {
+    await expect(entry).toBeVisible();
+    await page.evaluate(() => {
+      // React handles the click at the root before it bubbles to document.
+      // Focus must already be set here, not in a timer after user activation.
+      document.addEventListener('click', () => {
+        document.body.dataset.searchFocusedDuringClick = String(document.activeElement?.tagName === 'INPUT');
+      }, { once: true });
+    });
+    await entry.tap();
+    await expect(page.locator('body')).toHaveAttribute('data-search-focused-during-click', 'true');
+    await expect(input).toBeFocused();
+    await page.keyboard.type('focus check');
+    await expect(input).toHaveValue('focus check');
+    await expect(page).toHaveURL(/#\/search\?q=focus\+check$/);
+    await page.getByRole('button', { name: copy('common.clear'), exact: true }).tap();
+    await expect(input).toBeFocused();
+    await expect(input).toHaveValue('');
+    await page.keyboard.type('second query');
+    await expect(input).toHaveValue('second query');
+    await page.screenshot({ path: testInfo.outputPath(`search-focused-${visit}.png`), scale: 'css' });
+    await page.getByRole('button', { name: copy('common.back'), exact: true }).tap();
+    await expect(page).toHaveURL(/#\/inbox$/);
+  }
+});
+
+test('opening a search URL preserves its query and focuses the input', async ({ page }) => {
+  await page.goto('/e2e/inbox-return/fixture.html#/search?q=existing&archived=1');
+  const input = page.getByRole('textbox', { name: copy('workbench.search.placeholder') });
+  await expect(input).toBeFocused();
+  await expect(input).toHaveValue('existing');
+  await page.keyboard.type(' query');
+  await expect(input).toHaveValue('existing query');
+  await expect(page).toHaveURL(/#\/search\?q=existing\+query&archived=1$/);
+});

--- a/ui/playwright.inbox-return.config.ts
+++ b/ui/playwright.inbox-return.config.ts
@@ -14,5 +14,6 @@ export default defineConfig({
   projects: [
     { name: 'desktop', use: { ...devices['Desktop Chrome'] } },
     { name: 'mobile', use: { ...devices['iPhone 13'], browserName: 'chromium' } },
+    { name: 'mobile-webkit', testMatch: 'search-focus.spec.ts', use: { ...devices['iPhone 13'] } },
   ],
 });

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -706,8 +706,12 @@ const settingsRoute = () => (
   </Route>
 );
 
-const WorkbenchRouteSurface = () => (
-  <SettingsOverlayRouteSurface
+const WorkbenchRouteSurface = () => {
+  const navigate = useNavigate();
+  // Keep mounting/focusing Search inside the tap so mobile keyboards can open.
+  // This must use the data-route navigate: descendant <Routes> drop flushSync.
+  const openSearch = () => { void navigate('/search', { flushSync: true }); };
+  return <SettingsOverlayRouteSurface
     fallbackElement={<Navigate to="/" replace />}
   >
     <Route path="/setup" element={<Wizard />} />
@@ -715,7 +719,7 @@ const WorkbenchRouteSurface = () => (
     {/* Workbench mode — `/` is the canvas root, the five capability
         entries (Inbox + Agents/Skills/Harness/Vaults) live alongside it. */}
     <Route path="/" element={<Workbench />} />
-    <Route path="/inbox" element={<InboxPage />} />
+    <Route path="/inbox" element={<InboxPage onOpenSearch={openSearch} />} />
     <Route path="/search" element={<SearchPage />} />
     <Route path="/agents" element={<AgentsPage />} />
     <Route path="/skills" element={<SkillsPage />} />
@@ -765,8 +769,8 @@ const WorkbenchRouteSurface = () => (
     {LEGACY_SETTINGS_REDIRECTS.map(({ from, to }) => (
       <Route key={from} path={from} element={<LegacySettingsRedirectRoute to={to} />} />
     ))}
-  </SettingsOverlayRouteSurface>
-);
+  </SettingsOverlayRouteSurface>;
+};
 
 function RouterRoot() {
   return (

--- a/ui/src/components/workbench/InboxPage.test.tsx
+++ b/ui/src/components/workbench/InboxPage.test.tsx
@@ -54,9 +54,13 @@ function Chat() {
 
 function mount() {
   const key = `inbox-${++entry}`;
+  function InboxRoute() {
+    const navigate = useNavigate();
+    return <InboxPage onOpenSearch={() => navigate('/search')} />;
+  }
   const app = () => <StrictMode><MemoryRouter initialEntries={[{ pathname: '/inbox', key }]}>
     <Routes>
-      <Route path="/inbox" element={<InboxPage />} />
+      <Route path="/inbox" element={<InboxRoute />} />
       <Route path="/chat/:sessionId" element={<Chat />} />
       <Route path="/search" element={<Chat />} />
     </Routes>

--- a/ui/src/components/workbench/InboxPage.tsx
+++ b/ui/src/components/workbench/InboxPage.tsx
@@ -20,7 +20,7 @@ import {
   type InboxFilter as FilterMode,
 } from '../../lib/inboxFilterMemory';
 
-export const InboxPage: React.FC = () => {
+export const InboxPage: React.FC<{ onOpenSearch: () => void }> = ({ onOpenSearch }) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const location = useLocation();
@@ -163,7 +163,7 @@ export const InboxPage: React.FC = () => {
       <Button
         type="button"
         variant="ghost"
-        onClick={() => navigate('/search')}
+        onClick={onOpenSearch}
         className="h-auto w-full justify-start gap-2.5 rounded-xl border border-border-strong bg-foreground/[0.04] px-3.5 py-2.5 text-left font-normal transition hover:bg-foreground/[0.06] md:hidden"
       >
         <Search className="size-4 shrink-0 text-muted" />

--- a/ui/src/components/workbench/SearchPage.tsx
+++ b/ui/src/components/workbench/SearchPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { AlertCircle, ChevronLeft, Loader2, Search, X } from 'lucide-react';
@@ -70,14 +70,6 @@ export const SearchPage: React.FC = () => {
     );
   };
 
-  // Autofocus the field on mount so typing flows straight in (the search page
-  // exists only to search). iOS sometimes needs the focus deferred a tick past
-  // the route transition for the soft keyboard to come up.
-  useEffect(() => {
-    const id = window.setTimeout(() => inputRef.current?.focus(), 0);
-    return () => window.clearTimeout(id);
-  }, []);
-
   // Back returns to where the user came from (usually the inbox field); a deep
   // link / refresh has nothing to pop, so fall back to /inbox. Mirrors
   // ChatPage's goBack.
@@ -125,6 +117,7 @@ export const SearchPage: React.FC = () => {
           <Search className="size-4 shrink-0 text-mint-ink" />
           <Input
             ref={inputRef}
+            autoFocus
             variant="bare"
             value={query}
             onChange={(e) => updateQuery(e.target.value)}


### PR DESCRIPTION
## Summary

- Focus the mobile Search input while the Inbox search-entry tap is still being handled, so typing can begin without a second tap.
- Replace the delayed focus timer with mount-time autofocus. Perform this navigation through the outer data route with `flushSync`, since descendant declarative routes do not forward that option.
- Preserve search URL state, clearing, back navigation, and Inbox scroll restoration. No layout, backend, or dependency changes.

## Verification

- Regression reproduced before the fix: the input was not focused when the entry click reached the document listener. The same assertion passes after the fix.
- Unit: 23 focused Inbox/search tests passed.
- Browser: 19 checks passed across desktop/mobile Chromium and mobile WebKit; one mobile-only check is intentionally skipped on desktop. Covers same-gesture focus, direct typing, clearing, repeat entry, deep-link query preservation, and existing Inbox return-position behavior.
- UI lint baseline, focused ESLint, Ruff 0.4.9, test TypeScript check, and production UI build passed. Mobile and desktop screenshots inspected.
- Add the hermetic Inbox/Search browser suite to the existing CI job, including the WebKit browser engine.
- Scenario catalog: no existing scenario ID covers this mobile focus interaction; executable coverage lives in `ui/e2e/inbox-return/search-focus.spec.ts`.
- Residual manual checks: native iOS Safari/PWA soft-keyboard appearance and full-service local Incus acceptance remain deferred. Browser automation verifies focus timing, not the OS keyboard.

## Dependencies

None. Based on the current default branch; no merge or deployment is requested by this PR.
