### PR TITLE
fix(memory): unify runtime management and installation guidance

### DIFF
--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -103,6 +103,16 @@ installs do not trigger that convergence. A disabled published install may expos
 an explicit companion-package bootstrap so the user can install the optional
 package before enabling Memory; it never runs automatically.
 
+Settings > Dependencies presents the companion package and managed artifact as
+one **Memory runtime** entry. Its status and action follow the prerequisite that
+needs attention, while installation still uses the existing package or artifact
+owner. When a dependency inspection proves Memory runtime is missing, Settings >
+Memory shows only an installation banner linking to that entry; tabs, configuration,
+and runtime actions stay hidden. An active runtime whose artifact is missing can
+use **Retry startup** from Dependencies, through the existing non-destructive Wake
+path. A disabled runtime's `not_required` inspection is not proof of absence and
+does not prevent configuration of an already-installed companion package.
+
 Package resolution, installation, upgrade, or restart failures leave core
 Avibe running and are reported as structured terminal results; a later startup
 may retry within that version's budget, while an explicit attempt remains

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -106,12 +106,15 @@ package before enabling Memory; it never runs automatically.
 Settings > Dependencies presents the companion package and managed artifact as
 one **Memory runtime** entry. Its status and action follow the prerequisite that
 needs attention, while installation still uses the existing package or artifact
-owner. When a dependency inspection proves Memory runtime is missing, Settings >
+owner. When a dependency inspection proves Memory runtime is missing and admits
+an installation or recovery action, Settings >
 Memory shows only an installation banner linking to that entry; tabs, configuration,
 and runtime actions stay hidden. An active runtime whose artifact is missing can
 use **Retry startup** from Dependencies, through the existing non-destructive Wake
 path. A disabled runtime's `not_required` inspection is not proof of absence and
 does not prevent configuration of an already-installed companion package.
+Unsupported or operator-only failures retain administration, since an installation
+banner cannot resolve them.
 
 Package resolution, installation, upgrade, or restart failures leave core
 Avibe running and are reported as structured terminal results; a later startup

--- a/ui/src/components/settings/SettingsDependenciesPage.logic.ts
+++ b/ui/src/components/settings/SettingsDependenciesPage.logic.ts
@@ -20,6 +20,21 @@ export const memoryPackageIsSourceManaged = (
   && dependency.reason === 'memory_package_source_build'
 );
 
+/** One Memory entry surfaces the prerequisite that currently needs attention. */
+export const memoryDependencyForDisplay = (
+  memoryPackage: DependencyItem | null,
+  memoryRuntime: DependencyItem | null,
+): DependencyItem | null => {
+  if (memoryPackage && !memoryPackageIsSourceManaged(memoryPackage)
+    && !['ready', 'not_required'].includes(memoryPackage.status)) {
+    return memoryPackage;
+  }
+  if (memoryRuntime && !['not_required', 'unknown'].includes(memoryRuntime.status)) {
+    return memoryRuntime;
+  }
+  return memoryPackage ?? memoryRuntime;
+};
+
 export const dependencyHasInstallAction = (
   dependency: Pick<DependencyItem, 'id' | 'status' | 'action_class'>,
 ): boolean => {

--- a/ui/src/components/settings/SettingsDependenciesPage.test.tsx
+++ b/ui/src/components/settings/SettingsDependenciesPage.test.tsx
@@ -12,6 +12,7 @@ const api = vi.hoisted(() => ({
   getMemoryStatus: vi.fn(),
   installDependency: vi.fn(),
   listDependencies: vi.fn(),
+  wakeMemory: vi.fn(),
 }));
 const showToast = vi.hoisted(() => vi.fn());
 
@@ -53,7 +54,9 @@ const stubDependencies = (response: DependenciesResult) => {
     ...response,
     deps: (ids ?? response.deps.map((dep) => dep.id)).map((id) => (
       response.deps.find((dep) => dep.id === id)
-      ?? { id, kind: 'runtime', required: null, installed: null, version: null, status: 'unknown', action_class: 'none' }
+      ?? (id === 'memory-package' && response.deps.some((dep) => dep.id === 'memory-runtime')
+        ? dependency({ id, action_class: 'none' })
+        : { id, kind: 'runtime', required: null, installed: null, version: null, status: 'unknown', action_class: 'none' })
     )),
   }));
 };
@@ -74,6 +77,7 @@ beforeEach(() => {
     health: null,
   });
   api.installDependency.mockResolvedValue({ ok: true });
+  api.wakeMemory.mockResolvedValue({ ok: true, state: 'running' });
 });
 
 afterEach(() => {
@@ -214,6 +218,20 @@ describe('SettingsDependenciesPage independent checks', () => {
 });
 
 describe('SettingsDependenciesPage Memory runtime', () => {
+  it('presents both installed components as one Memory runtime entry', async () => {
+    stubDependencies({ ok: true, deps: [
+      dependency({ id: 'memory-package', version: '3.0.15', action_class: 'none' }),
+      dependency({ version: '1.2.3', action_class: 'none' }),
+    ] });
+    renderPage();
+
+    expect(await screen.findByText('settings.dependencies.statusReady · v1.2.3')).toBeTruthy();
+    expect(screen.getAllByText('settings.dependencies.items.memory-runtime.label')).toHaveLength(1);
+    expect(screen.queryByText('settings.dependencies.items.memory-package.label')).toBeNull();
+    expect(screen.queryByText(/v3\.0\.15/)).toBeNull();
+    expect(screen.getByRole('link', { name: /common.configure/ }).getAttribute('href')).toBe('/settings/memory');
+  });
+
   it('does not let an older sidecar read override the current repair guard', async () => {
     let finish!: (value: MemoryStatusResult) => void;
     api.getMemoryStatus.mockImplementationOnce(() => new Promise((resolve) => { finish = resolve; }));
@@ -285,7 +303,7 @@ describe('SettingsDependenciesPage Memory runtime', () => {
     });
     renderPage();
 
-    expect(await screen.findByText('settings.dependencies.statusSourceManaged')).toBeTruthy();
+    await screen.findByText('settings.dependencies.memoryPackageSourceManaged');
     expect(screen.getByText('settings.dependencies.statusError').className).toContain('destructive');
     expect(screen.getByRole('alert').textContent).toBe(`errors.${reason}`);
     expect(api.installDependency).not.toHaveBeenCalled();
@@ -315,7 +333,7 @@ describe('SettingsDependenciesPage Memory runtime', () => {
     expect(api.installDependency).not.toHaveBeenCalled();
   });
 
-  it('routes repairable Python package bootstrap through its own dependency action', async () => {
+  it('routes the single Memory entry to package bootstrap before runtime installation', async () => {
     stubDependencies({
       ok: true,
       deps: [dependency({
@@ -332,6 +350,9 @@ describe('SettingsDependenciesPage Memory runtime', () => {
 
     await waitFor(() => expect(api.installDependency).toHaveBeenCalledWith('memory-package'));
     expect(api.installDependency).not.toHaveBeenCalledWith('memory-runtime');
+    expect(screen.getAllByText('settings.dependencies.items.memory-runtime.label')).toHaveLength(1);
+    expect(screen.queryByText('settings.dependencies.items.memory-package.label')).toBeNull();
+    expect(screen.queryByRole('link', { name: /common.configure/ })).toBeNull();
   });
 
   it('hides package bootstrap while Memory is not required', async () => {
@@ -363,7 +384,7 @@ describe('SettingsDependenciesPage Memory runtime', () => {
     });
     renderPage();
 
-    await userEvent.click(await screen.findByRole('button', { name: 'settings.dependencies.reinstall' }));
+    await userEvent.click(await screen.findByRole('button', { name: 'settings.dependencies.repair' }));
 
     await waitFor(() => expect(api.installDependency).toHaveBeenCalledWith('memory-package'));
   });
@@ -402,8 +423,24 @@ describe('SettingsDependenciesPage Memory runtime', () => {
       'getMemoryStatus',
       'installDependency',
       'listDependencies',
+      'wakeMemory',
     ]);
   });
+
+  it.each(['starting', 'running', 'degraded'] as const)(
+    'keeps missing-runtime recovery reachable from Dependencies while Memory is %s',
+    async (state) => {
+      stubDependencies({ ok: true, deps: [dependency({ installed: false, status: 'missing', action_class: 'repairable' })] });
+      api.getMemoryStatus.mockResolvedValue({ status: 'ok', state });
+      renderPage();
+
+      await userEvent.click(await screen.findByRole('button', { name: 'memory.runtimeAction.retryButton' }));
+
+      await waitFor(() => expect(api.wakeMemory).toHaveBeenCalledOnce());
+      expect(api.installDependency).not.toHaveBeenCalled();
+      expect(screen.queryByText('settings.dependencies.memoryRuntimeDisableBeforeRepair')).toBeNull();
+    },
+  );
 
   it('renders a persisted preparation reason on initial page load', async () => {
     stubDependencies({

--- a/ui/src/components/settings/SettingsDependenciesPage.tsx
+++ b/ui/src/components/settings/SettingsDependenciesPage.tsx
@@ -27,10 +27,12 @@ import type { DependencyItem, InstallResult, MemoryStatusResult } from '@/contex
 import { useToast } from '@/context/ToastContext';
 import {
   dependencyHasInstallAction,
+  memoryDependencyForDisplay,
   memoryPackageIsSourceManaged,
   memoryRuntimeSidecarRunning,
 } from './SettingsDependenciesPage.logic';
 import { errorMessage } from '@/lib/errorMessage';
+import { memoryErrorMessage } from '@/lib/memoryRead';
 import { useDependencyChecks } from './useDependencyChecks';
 
 // Mirrors design.pen "vibe-remote — Settings · Dependencies": one card per
@@ -47,7 +49,6 @@ const DEP_META: Record<string, DepMeta> = {
   avault: { icon: KeyRound, tileCls: 'bg-gold-soft', iconCls: 'text-gold-ink' },
   'show-runtime': { icon: LayoutDashboard, tileCls: 'bg-cyan-soft', iconCls: 'text-cyan-ink' },
   'model-hub-engine': { icon: Network, tileCls: 'bg-mint-soft', iconCls: 'text-mint-ink' },
-  'memory-package': { icon: Brain, tileCls: 'bg-gold-soft', iconCls: 'text-gold-ink' },
   'memory-runtime': { icon: Brain, tileCls: 'bg-violet-soft', iconCls: 'text-violet-ink' },
   tmux: { icon: SquareTerminal, tileCls: 'bg-surface-3', iconCls: 'text-foreground' },
   node: { icon: Hexagon, tileCls: 'bg-violet-soft', iconCls: 'text-violet-ink' },
@@ -104,14 +105,23 @@ export const SettingsDependenciesPage: React.FC = () => {
     );
   };
 
-  const install = async (dep: DependencyItem) => {
+  const install = async (dep: DependencyItem, displayId: string, recoverRuntime: boolean) => {
     if (busy !== null) return;
     setBusy(dep.id);
     try {
+      if (recoverRuntime) {
+        // Wake owns stop proof and artifact recovery for an active runtime.
+        const result = await api.wakeMemory();
+        showToast(
+          result.ok ? t('memory.runtimeAction.completed') : memoryErrorMessage(t, result.error),
+          result.ok ? 'success' : 'error',
+        );
+        return;
+      }
       const res = await api.installDependency(dep.id);
       showToast(
         res.ok
-          ? t('settings.dependencies.installed', { name: t(`settings.dependencies.items.${dep.id}.label`) })
+          ? t('settings.dependencies.installed', { name: t(`settings.dependencies.items.${displayId}.label`) })
           : localizedFailure(res),
         res.ok ? 'success' : 'error'
       );
@@ -157,7 +167,7 @@ export const SettingsDependenciesPage: React.FC = () => {
       return t('settings.dependencies.repair');
     }
     if (!d.installed) return t('settings.dependencies.install');
-    if (d.id === 'show-runtime' || d.id === 'memory-runtime') {
+    if (d.id === 'show-runtime' || d.id.startsWith('memory-')) {
       return t('settings.dependencies.repair');
     }
     return t('settings.dependencies.reinstall');
@@ -183,7 +193,11 @@ export const SettingsDependenciesPage: React.FC = () => {
 
           {Object.entries(DEP_META).map(([id, meta]) => {
             const check = checks[id];
-            const d = check.data;
+            const isMemoryEntry = id === 'memory-runtime';
+            const memoryPackage = checks['memory-package'].data;
+            const d = isMemoryEntry
+              ? memoryDependencyForDisplay(memoryPackage, check.data)
+              : check.data;
             const checkFailure = check.error
               ? t(`settings.dependencies.${check.error === 'timeout' ? 'checkTimeout' : 'checkFailed'}`)
               : null;
@@ -231,24 +245,26 @@ export const SettingsDependenciesPage: React.FC = () => {
             const showAction = dependencyHasInstallAction(d);
             const isMemoryRuntime = d.id === 'memory-runtime';
             const sidecarRunning = isMemoryRuntime && memoryRuntimeSidecarRunning(memoryStatus);
-            const repairBlockedBySidecar = isMemoryRuntime && (!memoryStatusLoaded || sidecarRunning);
+            const recoverRuntime = sidecarRunning && d.installed === false;
+            const repairBlockedBySidecar = isMemoryRuntime && (!memoryStatusLoaded || (sidecarRunning && !recoverRuntime));
             const dependencyOperationBusy = busy !== null || check.checking || check.error !== null;
             const sourceManaged = memoryPackageIsSourceManaged(d);
-            const notice = sourceManaged
-              ? t('settings.dependencies.memoryPackageSourceManaged')
-              : isMemoryRuntime && sidecarRunning
-                ? t('settings.dependencies.memoryRuntimeDisableBeforeRepair')
+            const notice = isMemoryRuntime && sidecarRunning && !recoverRuntime
+              ? t('settings.dependencies.memoryRuntimeDisableBeforeRepair')
+              : isMemoryEntry && memoryPackage && memoryPackageIsSourceManaged(memoryPackage)
+                ? t('settings.dependencies.memoryPackageSourceManaged')
                 : null;
+            const canConfigureMemory = isMemoryEntry && d.installed === true;
             const persistedFailure = !sourceManaged && d.status === 'error' && d.reason
               ? localizedReason(d.reason, t('settings.dependencies.installFailed'))
               : null;
             return (
               <SettingsResourceRow
-                key={d.id}
+                key={id}
                 icon={meta.icon}
                 tileClassName={meta.tileCls}
                 iconClassName={meta.iconCls}
-                title={t(`settings.dependencies.items.${d.id}.label`)}
+                title={t(`settings.dependencies.items.${id}.label`)}
                 badges={
                   d.required && (
                     <Badge variant="secondary" className="font-mono uppercase tracking-[0.08em]">
@@ -258,7 +274,7 @@ export const SettingsDependenciesPage: React.FC = () => {
                 }
                 detail={
                   <>
-                    {t(`settings.dependencies.items.${d.id}.detail`)}
+                    {t(`settings.dependencies.items.${id}.detail`)}
                     {d.id === 'model-hub-engine' && d.latest_version && (
                       <span className="mt-1 block font-mono text-[11px]">
                         {t('settings.dependencies.targetVersion', {
@@ -275,7 +291,7 @@ export const SettingsDependenciesPage: React.FC = () => {
                       {checkFailure || statusText(d)}
                     </Badge>
                     {retryCheck}
-                    {isMemoryRuntime && d.installed && (
+                    {canConfigureMemory && (
                       <Button asChild variant="secondary" size="xs">
                         <Link to="/settings/memory">
                           {t('common.configure')}
@@ -288,7 +304,7 @@ export const SettingsDependenciesPage: React.FC = () => {
                         variant={d.installed ? 'secondary' : 'brand'}
                         size="xs"
                         disabled={dependencyOperationBusy || repairBlockedBySidecar}
-                        onClick={() => void install(d)}
+                        onClick={() => void install(d, id, recoverRuntime)}
                       >
                         {installing ? (
                           <Loader2 className="size-3.5 animate-spin" />
@@ -297,7 +313,9 @@ export const SettingsDependenciesPage: React.FC = () => {
                         ) : (
                           <Download className="size-3.5" />
                         )}
-                        {actionText(d, installing)}
+                        {recoverRuntime
+                          ? t(installing ? 'memory.runtimeAction.retryRunning' : 'memory.runtimeAction.retryButton')
+                          : actionText(d, installing)}
                       </Button>
                     )}
                   </>
@@ -311,6 +329,7 @@ export const SettingsDependenciesPage: React.FC = () => {
                 ) : notice ? (
                   <div className="border-t border-border pt-3 text-[11px] leading-snug text-muted">
                     {notice}
+                    {persistedFailure && <div role="alert" className="mt-1 text-destructive-ink">{persistedFailure}</div>}
                   </div>
                 ) : persistedFailure ? (
                   <div

--- a/ui/src/components/settings/SettingsMemoryPage.test.tsx
+++ b/ui/src/components/settings/SettingsMemoryPage.test.tsx
@@ -1,6 +1,6 @@
 /* @vitest-environment jsdom */
 
-import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
@@ -177,9 +177,52 @@ describe('SettingsMemoryPage', () => {
 
     renderPage();
 
-    await screen.findByText('repair-supported');
-    expect(screen.getByText('memory.setup.runtimeRequired')).toBeTruthy();
+    await screen.findByText('memory.setup.runtimeRequired');
     expect(screen.getByRole('link', { name: /memory.settings.goToDependencies/ })).toBeTruthy();
+    expect(screen.queryByTestId('memory-tabs-scroll')).toBeNull();
+    expect(screen.queryByText('repair-supported')).toBeNull();
+    expect(screen.queryByText('open-delete')).toBeNull();
+  });
+
+  it.each(['running', 'degraded', 'needs_repair'] as const)(
+    'shows only installation guidance for a missing runtime even with stale %s status',
+    async (state) => {
+      api.getMemoryStatus.mockResolvedValue(status(state));
+      api.listDependencies.mockResolvedValue({
+        deps: [{ id: 'memory-runtime', installed: false, status: 'missing' }],
+      });
+      renderPage();
+
+      await screen.findByText('memory.setup.runtimeRequired');
+      expect(screen.queryByTestId('memory-tabs-scroll')).toBeNull();
+      expect(screen.queryByTestId('memory-failures-message')).toBeNull();
+      expect(screen.queryByRole('button', { name: 'memory.runtimeAction.retryButton' })).toBeNull();
+      expect(screen.queryByRole('button', { name: 'memory.runtimeAction.moreActions' })).toBeNull();
+      expect(api.wakeMemory).not.toHaveBeenCalled();
+    },
+  );
+
+  it('keeps configuration hidden until dependency inspection has finished', async () => {
+    let finish!: (value: unknown) => void;
+    api.listDependencies.mockImplementationOnce(() => new Promise((resolve) => { finish = resolve; }));
+    renderPage();
+
+    await waitFor(() => expect(api.getMemorySettings).toHaveBeenCalled());
+    expect(screen.queryByTestId('memory-tabs-scroll')).toBeNull();
+    await act(async () => finish({ deps: [{ id: 'memory-runtime', installed: true, status: 'ready' }] }));
+    expect(await screen.findByTestId('memory-tabs-scroll')).toBeTruthy();
+  });
+
+  it('shows installation guidance when a missing package also prevents settings from loading', async () => {
+    api.getMemorySettings.mockRejectedValue(new Error('Memory package unavailable'));
+    api.listDependencies.mockResolvedValue({
+      deps: [{ id: 'memory-package', installed: false, status: 'missing', action_class: 'repairable' }],
+    });
+    renderPage();
+
+    await screen.findByText('memory.setup.runtimeRequired');
+    expect(screen.queryByText('memory.settings.loadFailed')).toBeNull();
+    expect(screen.queryByTestId('memory-tabs-scroll')).toBeNull();
   });
 
   it('offers Retry startup for degraded Memory', async () => {

--- a/ui/src/components/settings/SettingsMemoryPage.test.tsx
+++ b/ui/src/components/settings/SettingsMemoryPage.test.tsx
@@ -225,6 +225,28 @@ describe('SettingsMemoryPage', () => {
     expect(screen.queryByTestId('memory-tabs-scroll')).toBeNull();
   });
 
+  it.each(['memory-package', 'memory-runtime'])(
+    'keeps administration available when the %s entry has no admitted installation action',
+    async (id) => {
+      for (const evidence of [
+        { installed: false, status: 'unsupported', action_class: 'none' },
+        { installed: false, status: 'error', action_class: 'operator_only' },
+        { installed: null, status: 'unknown', action_class: 'operator_only' },
+        { installed: null, status: 'missing', action_class: 'repairable' },
+        { installed: null, status: 'not_required', action_class: 'none' },
+      ]) {
+        api.listDependencies.mockResolvedValue({ deps: [{ id, ...evidence }] });
+        const view = renderPage();
+
+        await screen.findByTestId('memory-tabs-scroll');
+        expect(screen.queryByText('memory.setup.runtimeRequired')).toBeNull();
+        await userEvent.click(screen.getByRole('radio', { name: 'memory.tabs.settings' }));
+        expect(screen.getByText('open-delete')).toBeTruthy();
+        view.unmount();
+      }
+    },
+  );
+
   it('offers Retry startup for degraded Memory', async () => {
     api.getMemoryStatus.mockResolvedValue(status('degraded'));
     renderPage();

--- a/ui/src/components/settings/SettingsMemoryPage.tsx
+++ b/ui/src/components/settings/SettingsMemoryPage.tsx
@@ -51,6 +51,7 @@ export const SettingsMemoryPage: React.FC = () => {
   const [repairing, setRepairing] = useState(false);
   const [settingsSaving, setSettingsSaving] = useState(false);
   const [runtimeInstalled, setRuntimeInstalled] = useState<boolean | null>(null);
+  const [dependencyLoaded, setDependencyLoaded] = useState(false);
   const [repairError, setRepairError] = useState<string | null>(null);
   const [deleteResult, setDeleteResult] = useState<MemoryDataOperationResult | null>(null);
   const [logGeneration, setLogGeneration] = useState(0);
@@ -107,6 +108,8 @@ export const SettingsMemoryPage: React.FC = () => {
       }
     } catch {
       setRuntimeInstalled(true);
+    } finally {
+      setDependencyLoaded(true);
     }
   }, [api]);
 
@@ -200,7 +203,7 @@ export const SettingsMemoryPage: React.FC = () => {
     ...(canAdminister ? [{ id: 'settings' as const, label: t('memory.tabs.settings') }] : []),
   ], [canAdminister, t]);
   const activeTab = tabs.some((entry) => entry.id === tab) ? tab : 'processingRecord';
-  const runtimeAction = !remoteUnavailable && canAdminister && settings?.enabled === true
+  const runtimeAction = dependencyLoaded && runtimeInstalled !== false && !remoteUnavailable && canAdminister && settings?.enabled === true
     ? runtimeState === 'degraded' ? (
         <Button variant="secondary" size="xs" onClick={() => void runMemoryRuntimeAction()} disabled={mutationBusy}>
           {waking ? <Loader2 className="animate-spin" /> : <RotateCw />}
@@ -281,7 +284,21 @@ export const SettingsMemoryPage: React.FC = () => {
           <span className="text-[14px] font-semibold text-foreground">{t('memory.remoteUnavailable.title')}</span>
           <span className="max-w-md text-[12.5px] text-muted">{t('memory.remoteUnavailable.description')}</span>
         </div>
-      ) : !settings ? (
+      ) : dependencyLoaded && runtimeInstalled === false ? (
+        <div className="flex flex-col items-start gap-3 rounded-lg border border-border bg-surface p-5">
+          <div className="flex items-center gap-2 text-[14px] font-semibold text-foreground">
+            <Brain className="size-4 text-violet-ink" />
+            {t('memory.setup.runtimeRequired')}
+          </div>
+          <p className="text-[12.5px] text-muted">{t('memory.setup.runtimeRequiredHint')}</p>
+          <Button asChild variant="secondary" size="sm">
+            <Link to="/settings/dependencies">
+              {t('memory.settings.goToDependencies')}
+              <ArrowUpRight className="size-3.5" />
+            </Link>
+          </Button>
+        </div>
+      ) : !dependencyLoaded || !settings ? (
         settingsRead.error ? (
           <div className="rounded-lg border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive-ink">{settingsRead.error}</div>
         ) : (
@@ -292,21 +309,6 @@ export const SettingsMemoryPage: React.FC = () => {
         )
       ) : (
         <>
-          {runtimeInstalled === false ? (
-            <div className="flex flex-col items-start gap-3 rounded-lg border border-border bg-surface p-5">
-              <div className="flex items-center gap-2 text-[14px] font-semibold text-foreground">
-                <Brain className="size-4 text-violet-ink" />
-                {t('memory.setup.runtimeRequired')}
-              </div>
-              <p className="text-[12.5px] text-muted">{t('memory.setup.runtimeRequiredHint')}</p>
-              <Button asChild variant="secondary" size="sm">
-                <Link to="/settings/dependencies">
-                  {t('memory.settings.goToDependencies')}
-                  <ArrowUpRight className="size-3.5" />
-                </Link>
-              </Button>
-            </div>
-          ) : null}
           <div data-testid="memory-tabs-scroll" className="max-w-full overflow-x-auto pb-1">
             <div className="min-w-max">
               <SegmentedRadio value={activeTab} onChange={setTab} options={tabs} ariaLabel={t('memory.title')} tone="mint" />

--- a/ui/src/components/settings/SettingsMemoryPage.tsx
+++ b/ui/src/components/settings/SettingsMemoryPage.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { ArrowUpRight, Brain, Loader2, MoreHorizontal, RotateCw, ShieldAlert } from 'lucide-react';
 
 import { SettingsPageShell } from './SettingsPageShell';
+import { dependencyHasInstallAction, memoryDependencyForDisplay } from './SettingsDependenciesPage.logic';
 import { Button } from '../ui/button';
 import { ConfirmDialog } from '../ui/confirm-dialog';
 import { InfoHint } from '../ui/info-hint';
@@ -50,8 +51,7 @@ export const SettingsMemoryPage: React.FC = () => {
   const [waking, setWaking] = useState(false);
   const [repairing, setRepairing] = useState(false);
   const [settingsSaving, setSettingsSaving] = useState(false);
-  const [runtimeInstalled, setRuntimeInstalled] = useState<boolean | null>(null);
-  const [dependencyLoaded, setDependencyLoaded] = useState(false);
+  const [runtimeRequired, setRuntimeRequired] = useState<boolean | null>(null);
   const [repairError, setRepairError] = useState<string | null>(null);
   const [deleteResult, setDeleteResult] = useState<MemoryDataOperationResult | null>(null);
   const [logGeneration, setLogGeneration] = useState(0);
@@ -93,23 +93,13 @@ export const SettingsMemoryPage: React.FC = () => {
   const loadDependency = useCallback(async () => {
     try {
       const res = await api.listDependencies({ ids: ['memory-package', 'memory-runtime'] });
-      const memoryPackage = res.deps?.find((item) => item.id === 'memory-package');
-      const memoryRuntime = res.deps?.find((item) => item.id === 'memory-runtime');
-      if (memoryPackage?.action_class === 'repairable' && memoryPackage.installed !== true) {
-        setRuntimeInstalled(false);
-      } else if (memoryRuntime) {
-        setRuntimeInstalled(
-          memoryRuntime.status === 'not_required'
-            ? null
-            : memoryRuntime.installed === true,
-        );
-      } else {
-        setRuntimeInstalled(true);
-      }
+      const dependency = memoryDependencyForDisplay(
+        res.deps?.find((item) => item.id === 'memory-package') ?? null,
+        res.deps?.find((item) => item.id === 'memory-runtime') ?? null,
+      );
+      setRuntimeRequired(dependency?.installed === false && dependencyHasInstallAction(dependency));
     } catch {
-      setRuntimeInstalled(true);
-    } finally {
-      setDependencyLoaded(true);
+      setRuntimeRequired(false);
     }
   }, [api]);
 
@@ -203,7 +193,7 @@ export const SettingsMemoryPage: React.FC = () => {
     ...(canAdminister ? [{ id: 'settings' as const, label: t('memory.tabs.settings') }] : []),
   ], [canAdminister, t]);
   const activeTab = tabs.some((entry) => entry.id === tab) ? tab : 'processingRecord';
-  const runtimeAction = dependencyLoaded && runtimeInstalled !== false && !remoteUnavailable && canAdminister && settings?.enabled === true
+  const runtimeAction = runtimeRequired === false && !remoteUnavailable && canAdminister && settings?.enabled === true
     ? runtimeState === 'degraded' ? (
         <Button variant="secondary" size="xs" onClick={() => void runMemoryRuntimeAction()} disabled={mutationBusy}>
           {waking ? <Loader2 className="animate-spin" /> : <RotateCw />}
@@ -284,7 +274,7 @@ export const SettingsMemoryPage: React.FC = () => {
           <span className="text-[14px] font-semibold text-foreground">{t('memory.remoteUnavailable.title')}</span>
           <span className="max-w-md text-[12.5px] text-muted">{t('memory.remoteUnavailable.description')}</span>
         </div>
-      ) : dependencyLoaded && runtimeInstalled === false ? (
+      ) : runtimeRequired === true ? (
         <div className="flex flex-col items-start gap-3 rounded-lg border border-border bg-surface p-5">
           <div className="flex items-center gap-2 text-[14px] font-semibold text-foreground">
             <Brain className="size-4 text-violet-ink" />
@@ -298,7 +288,7 @@ export const SettingsMemoryPage: React.FC = () => {
             </Link>
           </Button>
         </div>
-      ) : !dependencyLoaded || !settings ? (
+      ) : runtimeRequired === null || !settings ? (
         settingsRead.error ? (
           <div className="rounded-lg border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive-ink">{settingsRead.error}</div>
         ) : (

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -437,10 +437,6 @@
           "label": "Node.js",
           "detail": "Shared prerequisite for the runtimes above."
         },
-        "memory-package": {
-          "label": "Memory Python package",
-          "detail": "Optional Memory implementation matched to this Avibe release."
-        },
         "memory-runtime": {
           "label": "Memory runtime",
           "detail": "Runs local memory distillation and search on your machine."
@@ -4617,7 +4613,7 @@
     },
     "setup": {
       "runtimeRequired": "Install the Memory runtime first",
-      "runtimeRequiredHint": "Install or repair the Memory runtime from Dependencies. You can still disable Memory or delete stored data below."
+      "runtimeRequiredHint": "Install the Memory runtime from Dependencies, then return here to configure and use Memory."
     },
     "tabs": {
       "processingRecord": "Processing Record",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -437,10 +437,6 @@
           "label": "Node.js",
           "detail": "上述运行时的共同前置依赖。"
         },
-        "memory-package": {
-          "label": "记忆 Python 包",
-          "detail": "与当前 Avibe 版本匹配的可选记忆实现。"
-        },
         "memory-runtime": {
           "label": "记忆运行时",
           "detail": "在本机运行记忆提炼与搜索。"
@@ -4617,7 +4613,7 @@
     },
     "setup": {
       "runtimeRequired": "请先安装记忆运行时",
-      "runtimeRequiredHint": "请前往依赖页面安装或修复记忆运行时。你仍可在下方停用记忆或删除已存储的数据。"
+      "runtimeRequiredHint": "请前往依赖页面安装记忆运行时，完成后即可配置和使用记忆。"
     },
     "tabs": {
       "processingRecord": "处理记录",


### PR DESCRIPTION
Settings now exposes the Memory companion package and managed artifact through one **Memory runtime** entry. The entry shows the prerequisite that needs attention and routes its action to the existing owner. When an installable runtime prerequisite is missing, the Memory page shows only the installation banner, without tabs, configuration, or runtime actions. Those controls also stay hidden while the initial dependency inspection is pending.

Missing artifacts on active Memory retain recovery through **Retry startup** on Dependencies, using the existing non-destructive Wake path. This avoids directing users back to configuration that is now hidden. English and Chinese copy and the Memory behavior contract are updated.

Validation: 71 focused UI tests pass; production build passes; changed-file ESLint has no errors (one pre-existing hook warning). Browser checks against the current-head build in an isolated local Incus worktree environment confirm one dependency entry, banner-only missing state, the dependency link, and restored tabs when installed. English and Chinese mobile layouts and the Chinese desktop layout have no horizontal overflow. Dependency responses were controlled in the browser to exercise both states; real released-package downloads and external provider processing are outside this UI check. Related scenario: MEMORY-RUNTIME-INSTALL-001; its backend installation contract is unchanged.

Known by design: the API retains separate package/artifact evidence and installation owners. Unsupported and operator-only results retain administration, since the installation banner offers no recovery for those states. A disabled runtime's `not_required` result does not prove absence, so an installed companion remains configurable. Package installation keeps its normal service restart; the UI does not chain artifact installation across that restart.

Dependencies: none.
