### PR TITLE
fix(ui): keep mobile status badges visually compact

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,6 +59,7 @@ jobs:
           npm run test:model-provider
           npm run test:project-order
           npm run test:inbox-return
+          npm run test:badge-triggers
 
   build-linux-artifacts:
     runs-on: ubuntu-latest

--- a/ui/e2e/badge-triggers/README.md
+++ b/ui/e2e/badge-triggers/README.md
@@ -1,0 +1,18 @@
+# Badge Trigger Regression
+
+Run `npm run test:badge-triggers` from `ui/` after installing Chromium and WebKit
+with `npx playwright install --with-deps chromium webkit`.
+
+The fixture renders the production `VersionBadge` and `BackendRuntimeCard` with
+real CSS, mocked API responses, and local toggle state. No Avibe service is used.
+English and Chinese checks run on desktop Chromium, mobile Chromium, and mobile
+WebKit. They cover compact version and lifecycle visuals (ready, update available,
+disabled, missing, and unchecked), taps near both edges of the 44px mobile target,
+desktop hit bounds, keyboard activation, and the adjacent switch and path input.
+Screenshots and failure traces go under `e2e/.artifacts/badge-triggers/`.
+
+The audit found that `VersionBadge` and `BackendLifecycleChip` are the only
+consumers of the mobile badge trigger recipe. Full-row settings navigation,
+primary actions, and icon tiles intentionally retain their larger dimensions.
+The fixture proves browser layout and pointer routing; full-service local Incus
+acceptance and native-device touch checks remain separate manual validation.

--- a/ui/e2e/badge-triggers/badges.spec.ts
+++ b/ui/e2e/badge-triggers/badges.spec.ts
@@ -1,0 +1,82 @@
+import { expect, test } from '@playwright/test';
+import { copy } from '../support/copy';
+
+const labels = {
+  ready: 'backendLifecycle.statusReady', update: 'backendLifecycle.statusUpdateAvailable',
+  disabled: 'backendLifecycle.statusDisabled', error: 'backendLifecycle.statusError', loading: 'common.notChecked',
+};
+
+for (const locale of ['en', 'zh'] as const) {
+  test.describe(locale, () => {
+    test.beforeEach(async ({ page }) => {
+      await page.addInitScript((language) => localStorage.setItem('i18nextLng', language), locale);
+      await page.route('**/api/**', (route) => route.fulfill({ status: 503, json: { error: 'No backend in this fixture' } }));
+      await page.route('**/api/config', (route) => route.fulfill({ json: { update: { auto_update: false } } }));
+      await page.route('**/api/version', (route) => route.fulfill({ json: {
+        current: '3.1.4', latest: '3.1.5', has_update: true,
+      } }));
+      await page.route('**/api/backend/codex/runtime', (route) => route.fulfill({ json: {
+        installed: true, version: '1.0.0', latest_version: '1.1.0',
+        has_update: new URL(page.url()).searchParams.get('state') === 'update',
+      } }));
+    });
+
+    test(`compact version and lifecycle badges (${locale})`, async ({ page }, testInfo) => {
+      for (const [state, label] of Object.entries(labels)) {
+        await page.goto(`/e2e/badge-triggers/fixture.html?state=${state}`);
+        const version = page.getByTitle('v3.1.4', { exact: true });
+        const lifecycle = page.getByRole('button', { name: copy(label, undefined, locale), exact: true });
+        await expect(version).toBeVisible();
+        await expect(lifecycle).toBeVisible();
+        const reference = (await page.getByText('Reference badge', { exact: true }).boundingBox())!;
+        for (const badge of [version, lifecycle]) {
+          const bounds = (await badge.boundingBox())!;
+          expect(bounds.height).toBeCloseTo(reference.height, 0);
+          expect(bounds.height).toBeLessThan(30);
+        }
+        if (state === 'ready' || state === 'update') {
+          await page.screenshot({ path: testInfo.outputPath(`${state}-${locale}.png`), scale: 'css' });
+        }
+      }
+    });
+
+    test(`badge hit areas preserve adjacent controls and keyboard access (${locale})`, async ({ page, isMobile }) => {
+      await page.goto('/e2e/badge-triggers/fixture.html?state=update');
+      const version = page.getByTitle('v3.1.4', { exact: true });
+      const lifecycle = page.getByRole('button', { name: copy(labels.update, undefined, locale), exact: true });
+      const close = page.getByRole('button', { name: copy('common.close', undefined, locale), exact: true });
+      await expect(version).toBeVisible();
+      await expect(lifecycle).toBeVisible();
+
+      // Check actual pointer targeting, including transparent space beyond the painted badge.
+      for (const badge of [version, lifecycle]) {
+        const bounds = (await badge.boundingBox())!;
+        for (const offset of [-21, 21]) {
+          const x = bounds.x + bounds.width / 2;
+          const y = bounds.y + bounds.height / 2 + offset;
+          if (isMobile) {
+            await page.touchscreen.tap(x, y);
+            await expect(close).toBeVisible();
+            await close.tap();
+          } else {
+            await page.mouse.click(x, y);
+            await expect(close).toHaveCount(0);
+          }
+        }
+        await badge.focus();
+        await page.keyboard.press('Enter');
+        await expect(close).toBeVisible();
+        await close.click();
+      }
+
+      const toggle = page.getByRole('switch');
+      await expect(toggle).toHaveAttribute('aria-checked', 'true');
+      await toggle.click({ position: { x: 1, y: 10 } });
+      await expect(toggle).toHaveAttribute('aria-checked', 'false');
+      await expect(close).toHaveCount(0);
+      const input = page.getByRole('textbox');
+      await input.click();
+      await expect(input).toBeFocused();
+    });
+  });
+}

--- a/ui/e2e/badge-triggers/fixture.html
+++ b/ui/e2e/badge-triggers/fixture.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Badge Trigger Regression</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./fixture.tsx"></script>
+  </body>
+</html>

--- a/ui/e2e/badge-triggers/fixture.tsx
+++ b/ui/e2e/badge-triggers/fixture.tsx
@@ -1,0 +1,44 @@
+import { StrictMode, useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import { Terminal } from 'lucide-react';
+import { VersionBadge } from '../../src/components/VersionBadge';
+import { Badge } from '../../src/components/ui/badge';
+import { BackendRuntimeCard } from '../../src/components/settings/shared/BackendRuntimeCard';
+import type { BackendRuntimeState } from '../../src/components/settings/shared/useBackendRuntime';
+import { ApiProvider } from '../../src/context/ApiContext';
+import { ToastContext } from '../../src/context/ToastContext';
+import '../../src/i18n';
+import '../../src/index.css';
+
+const noop = () => {};
+const asyncNoop = async () => {};
+const state = new URLSearchParams(window.location.search).get('state');
+
+export function Fixture() {
+  const [enabled, setEnabled] = useState(state !== 'disabled');
+  const [cliPath, setCliPath] = useState('codex');
+  const runtime: BackendRuntimeState = {
+    loaded: true, configError: false, enabled, cliPath,
+    cliStatus: state === 'error' ? 'missing' : state === 'loading' ? 'unknown' : 'ok',
+    detecting: false, installing: false, installResult: null, installOutputOpen: false,
+    savingRuntime: false, runtimeDirty: false, setCliPath, setInstallOutputOpen: noop,
+    detect: asyncNoop, install: asyncNoop, onSaveRuntime: asyncNoop,
+    toggleEnabled: () => setEnabled((previous) => !previous), handleLifecycleChanged: asyncNoop,
+  };
+  return <div className="min-h-dvh bg-background text-foreground">
+    <header className="flex h-14 items-center justify-between border-b border-border px-4">
+      <span>Settings</span><VersionBadge />
+    </header>
+    <main className="mx-auto max-w-3xl space-y-6 p-4">
+      <div><Badge variant="secondary">Reference badge</Badge></div>
+      <BackendRuntimeCard backend="codex" label="Codex" description="Backend runtime"
+        Icon={Terminal} iconTileClassName="bg-gold" iconClassName="text-gold-ink" runtime={runtime} />
+    </main>
+  </div>;
+}
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode><ToastContext.Provider value={{ showToast: noop }}><ApiProvider>
+    <Fixture />
+  </ApiProvider></ToastContext.Provider></StrictMode>,
+);

--- a/ui/e2e/badge-triggers/tsconfig.json
+++ b/ui/e2e/badge-triggers/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.app.json",
+  "compilerOptions": { "types": ["vite/client", "node"] },
+  "include": ["*.ts", "*.tsx", "../../playwright.badge-triggers.config.ts", "../../agentation.d.ts"],
+  "exclude": []
+}

--- a/ui/package.json
+++ b/ui/package.json
@@ -21,6 +21,7 @@
     "e2e:headed": "playwright test --headed",
     "test:chat-paging": "tsc -p e2e/chat-paging/tsconfig.json --noEmit && playwright test --config playwright.chat-paging.config.ts",
     "test:inbox-return": "tsc -p e2e/inbox-return/tsconfig.json --noEmit && playwright test --config playwright.inbox-return.config.ts",
+    "test:badge-triggers": "tsc -p e2e/badge-triggers/tsconfig.json --noEmit && playwright test --config playwright.badge-triggers.config.ts",
     "test:project-order": "tsc -p e2e/project-order/tsconfig.json --noEmit && playwright test --config playwright.project-order.config.ts",
     "test:model-catalog": "tsc -p e2e/model-catalog/tsconfig.json --noEmit && playwright test --config playwright.model-catalog.config.ts",
     "test:model-provider": "tsc -p e2e/model-provider/tsconfig.json --noEmit && playwright test --config playwright.model-provider.config.ts",

--- a/ui/playwright.badge-triggers.config.ts
+++ b/ui/playwright.badge-triggers.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e/badge-triggers',
+  outputDir: './e2e/.artifacts/badge-triggers',
+  workers: 1,
+  retries: 0,
+  use: { baseURL: 'http://127.0.0.1:5211', locale: 'en-US', trace: 'retain-on-failure' },
+  webServer: {
+    command: 'npm run dev -- --host 127.0.0.1 --port 5211 --strictPort',
+    env: { VIBE_UI_BACKEND: 'http://127.0.0.1:9' },
+    url: 'http://127.0.0.1:5211/e2e/badge-triggers/fixture.html',
+  },
+  projects: [
+    { name: 'desktop', use: { ...devices['Desktop Chrome'] } },
+    { name: 'mobile', use: { ...devices['iPhone 13'], browserName: 'chromium' } },
+    { name: 'mobile-webkit', use: { ...devices['iPhone 13'] } },
+  ],
+});

--- a/ui/src/components/settings/SettingsLayout.test.tsx
+++ b/ui/src/components/settings/SettingsLayout.test.tsx
@@ -356,13 +356,11 @@ describe('SettingsLayout', () => {
     expect(back.className).toContain('size-11');
   });
 
-  it('shows a touch-sized current version with a safe-area-aware mobile popup', async () => {
+  it('shows the current version with a safe-area-aware mobile popup', async () => {
     const user = userEvent.setup();
     renderLayout('/settings');
 
     const version = await screen.findByTitle('v3.1.4');
-    expect(version.className).toContain('min-h-11');
-    expect(version.className).toContain('min-w-11');
     expect(version.parentElement?.parentElement?.className).toContain('md:hidden');
 
     await user.click(version);

--- a/ui/src/components/ui/badge-variants.ts
+++ b/ui/src/components/ui/badge-variants.ts
@@ -28,10 +28,11 @@ export const badgeVariants = cva(
   }
 );
 
-// Native buttons styled as badges remain compact on desktop, but every mobile
-// projection needs a complete touch target rather than the visual chip alone.
+// Keep the painted badge compact on every screen. On mobile, a transparent
+// pseudo-element expands the native button's hit area without stretching its
+// border/background or the surrounding layout. Consumers must leave room for it.
 export const interactiveBadgeTriggerClassName =
-  'min-h-11 min-w-11 cursor-pointer justify-center md:min-h-0 md:min-w-0';
+  "relative cursor-pointer justify-center before:absolute before:left-1/2 before:top-1/2 before:h-full before:min-h-11 before:w-full before:min-w-11 before:-translate-x-1/2 before:-translate-y-1/2 before:content-[''] md:before:hidden";
 
 // Mobile badge popovers sit below shell headers and must reserve the notch area
 // in both their origin and their available height.


### PR DESCRIPTION
Mobile version and backend lifecycle badges currently paint a 44px-tall pill instead of their compact badge shape. Keep the visual badge at its natural height (about 22.5px) while expanding its mobile pointer target with a transparent pseudo-element. The shared recipe fixes both consumers, including every backend lifecycle state, without changing desktop hit bounds.

Scope audit: these are the only consumers of the affected recipe. Full-row navigation, primary actions, and icon tiles intentionally retain their existing sizes. No API, dependency, or lifecycle behavior changes; no unmerged PR dependencies. Scenario IDs: no existing scenario catalog covers this visual regression; the focused browser suite lives in `ui/e2e/badge-triggers/` and runs in CI.

Validation:
- Reproduced before the fix: the browser regression expected 22.5px and received 44px.
- 12 browser checks passed across desktop Chromium, mobile Chromium, and mobile WebKit in English and Chinese: compact version and lifecycle states, taps above/below the painted badge, desktop hit bounds, keyboard activation, and adjacent switch/input access. Inspected the rendered mobile screenshot against the compact badge design.
- 24 focused component tests passed. UI lint baseline, changed-file ESLint, test TypeScript, production UI build, and Ruff 0.4.9 lint passed.
- An additional whole-repository Ruff formatting check reports 585 existing unformatted Python files; formatting is not a repository CI gate and this PR changes no Python files.

Residual acceptance: native-device touch and full-service local Incus manual checks remain deferred. Browser tests use production components with mocked APIs and never access or restart the owner's service.

Known by design: the transparent 44px mobile target extends beyond the visible chip; the browser tests verify the existing adjacent controls remain reachable. Other large navigation/actions are intentionally unchanged.
