### PR TITLE
fix(codex): complete required custom model catalog defaults

### DIFF
--- a/tests/test_backend_model_catalog.py
+++ b/tests/test_backend_model_catalog.py
@@ -257,11 +257,15 @@ def test_codex_hub_catalog_projects_custom_backend_models_from_native_shape():
             "model_messages": {"instructions_template": "preserved"},
             "support_verbosity": False,
             "experimental_supported_tools": [],
+            "supports_parallel_tool_calls": False,
         }
     ]
 
 
-def test_codex_hub_catalog_does_not_inherit_native_model_metadata_for_custom_rows():
+@pytest.mark.parametrize("supports_parallel_tool_calls", [False, True])
+def test_codex_hub_catalog_does_not_inherit_native_model_metadata_for_custom_rows(
+    supports_parallel_tool_calls,
+):
     raw = json.dumps(
         {
             "models": [
@@ -286,6 +290,7 @@ def test_codex_hub_catalog_does_not_inherit_native_model_metadata_for_custom_row
                     "shell_type": "unified_exec",
                     "support_verbosity": True,
                     "experimental_supported_tools": ["native_tool"],
+                    "supports_parallel_tool_calls": supports_parallel_tool_calls,
                     "truncation_policy": {"mode": "tokens", "limit": 10_000},
                     "model_messages": {"instructions_template": "preserved"},
                 }
@@ -296,7 +301,10 @@ def test_codex_hub_catalog_does_not_inherit_native_model_metadata_for_custom_row
     payload = json.loads(
         backend_model_catalog._codex_hub_catalog_bytes(
             raw,
-            [{"id": "custom-model", "input_modalities": [], "reasoning_efforts": []}],
+            [
+                {"id": "custom-model", "input_modalities": [], "reasoning_efforts": []},
+                {"id": "gpt-native"},
+            ],
         )
     )
     custom = payload["models"][0]
@@ -309,6 +317,11 @@ def test_codex_hub_catalog_does_not_inherit_native_model_metadata_for_custom_row
     assert custom["supported_reasoning_levels"] == [{"effort": "none", "description": "None"}]
     assert custom["support_verbosity"] is False
     assert custom["experimental_supported_tools"] == []
+    assert custom["supports_parallel_tool_calls"] is False
+    native = payload["models"][1]
+    assert native["support_verbosity"] is True
+    assert native["experimental_supported_tools"] == ["native_tool"]
+    assert native["supports_parallel_tool_calls"] is supports_parallel_tool_calls
     for key in (
         "description",
         "context_window",

--- a/vibe/backend_model_catalog.py
+++ b/vibe/backend_model_catalog.py
@@ -105,6 +105,11 @@ _CODEX_CUSTOM_SCAFFOLD_KEYS = (
     "tool_mode",
     "prefer_websockets",
 )
+_CODEX_CUSTOM_REQUIRED_DEFAULTS: dict[str, Any] = {
+    "support_verbosity": False,
+    "experimental_supported_tools": [],
+    "supports_parallel_tool_calls": False,
+}
 
 _REMOTE_LOCK = threading.Lock()
 _REMOTE_REFRESH_IN_FLIGHT = False
@@ -177,9 +182,9 @@ def _codex_hub_catalog_bytes(
                     if key in template
                 }
                 # Required in some Codex catalog versions, with no matching
-                # user-authored BackendModel field.
-                row["support_verbosity"] = False
-                row["experimental_supported_tools"] = []
+                # user-authored BackendModel field. Codex 0.146.0 also requires
+                # supports_parallel_tool_calls.
+                row.update(_CODEX_CUSTOM_REQUIRED_DEFAULTS)
             row["slug"] = model_id
             display_name = configured.get("display_name")
             row["display_name"] = (


### PR DESCRIPTION
## Summary

- Capability: custom Model Hub models produce a Codex catalog with the required non-user-authored fields, including `supports_parallel_tool_calls` required by Codex 0.146.0.
- User-visible change: custom model rows no longer omit this field and prevent the Codex app-server from parsing the complete catalog.
- Motivation: consolidate the existing ad-hoc defaults into `_CODEX_CUSTOM_REQUIRED_DEFAULTS` and add the missing capability default at the existing custom-row boundary.

## Change Contract

- Every custom row receives `support_verbosity: false`, `experimental_supported_tools: []`, and `supports_parallel_tool_calls: false`, independently of the native template's capability values.
- Native-slug rows retain their inherited values for these fields. Existing projection behavior is otherwise unchanged.
- Scope: `vibe/backend_model_catalog.py` and its existing catalog unit tests only.
- Non-goals: no Codex version pin, dependency change, configuration migration, service restart, or deployment.
- Dependencies: none; based on `origin/master` at `84fd281028eb924ef7da0551d14dabf2442e771a`.

## Scenario Coverage

- Scenario IDs: none in the existing scenario catalogs cover this projection contract.
- Unit / contract coverage: the existing full-row custom projection assertion now requires the missing field even when the native template lacks it. The metadata-isolation test covers both native boolean values, asserts all custom defaults, and verifies native-slug values survive unchanged.
- Scenario coverage: existing Model Hub injection, Codex adapter, and agent-auth tests pass.
- Residual manual checks: native Codex prompt-contract tests remain opt-in and were skipped. Live Codex 0.146.0 startup and multi-surface acceptance remain with the orchestrator's integration pass; this lane did not restart or modify the user's runtime. The dispatching session supplied the already-verified startup diagnosis.

## Validation

- Red/green: both new native-value parameter cases fail with `KeyError: supports_parallel_tool_calls` before the implementation change and pass afterward.
- `ruff check vibe/backend_model_catalog.py tests/test_backend_model_catalog.py`: passed.
- `pytest tests/test_backend_model_catalog.py -q`: 48 passed.
- Separate pytest processes for catalog, Model Hub injection, Codex prompt delivery contract, Codex adapter, and agent-auth modules: 301 passed, 3 opt-in tests skipped, 31 subtests passed.
- Tests run in an isolated worktree environment synced from the existing frozen lockfile. Repository home/config isolation remains enabled.
- `git diff --check`: passed.
- Full local suite not run: more than 500 test files and the repository requires per-file process isolation; the normal GitHub CI shards cover the broader suite.

## Risks / Follow-ups

- Risk: low; the new default is conservative and applied only to custom model rows. Native capabilities and the two existing defaults are preserved.
- Known-by-design ledger: no new exceptions.
- Follow-up: Codex version pinning is a separate owner decision and explicitly out of scope. Do not merge without owner authorization.
