### PR TITLE
fix(ui): keep desktop Dock above app windows

### DIFF
--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -374,10 +374,8 @@ export const AppShell: React.FC = () => {
       )}
     >
       <ConfigRecoveryNotice config={config} />
-      {/* The sidebar forms its own stacking context BELOW the window layer (aside z-10 < window
-          layer z-20), so a maximized window covers the WHOLE sidebar — including the Apps launcher.
-          The Apps button no longer floats on top in full-screen (a Dock redesign comes later);
-          un-maximize to reach it. */}
+      {/* Windows cover the sidebar (z-10 < z-20). AppsLauncher portals its button and Dock
+          above the window layer so app switching remains reachable even when maximized. */}
       {!chromeless && (
       <aside className="fixed inset-y-0 left-0 z-10 hidden w-[240px] flex-col border-r border-border bg-surface md:flex">
         <div className="flex h-full flex-col">
@@ -405,8 +403,8 @@ export const AppShell: React.FC = () => {
           </div>
 
           {/* Bottom (design.pen NbPMq): Apps + Settings, then run state + version.
-              Preferences now live with the rest of Settings. The whole bottom cluster sits at the
-              sidebar's level (z-10) and is covered by a maximized window. The
+              Preferences now live with the rest of Settings. AppsLauncher keeps its layout slot
+              here while its interactive surface floats above app windows. The
               outer container no longer owns padding (the brand band is flush to
               the top edge), so this cluster carries its own px-4 + bottom pad. */}
           <div className="relative flex flex-col gap-3 px-4 pb-4">
@@ -557,10 +555,6 @@ export const AppShell: React.FC = () => {
 
       {/* App windows float over the workbench main area (desktop). The Dock (P2)
           and the AppsLauncher bridge open windows via the WindowManager. */}
-      {/* A maximized window covers the sidebar Apps launcher. We intentionally do NOT float a
-          second launcher on top in full-screen anymore (product: avoid the fullscreen floating
-          button; a Dock redesign comes later). Un-maximize via the window traffic-lights to reach
-          the sidebar launcher. */}
       {canUseApps && <WindowLayer />}
     </div>
     </ShowPageDragProvider>

--- a/ui/src/components/AppsLauncher.tsx
+++ b/ui/src/components/AppsLauncher.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { ChevronUp, LayoutGrid, Pin } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import clsx from 'clsx';
@@ -27,11 +28,46 @@ export const AppsLauncher: React.FC = () => {
   // Cursor-positioned right-click menu, on the shared ContextMenu primitive.
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   const closeTimer = useRef<number | null>(null);
+  const slotRef = useRef<HTMLDivElement | null>(null);
+  const launcherRef = useRef<HTMLDivElement | null>(null);
+  const [placement, setPlacement] = useState({ left: 0, bottom: 0, width: 0, height: 0 });
   // Set on unpin so the lingering hover doesn't immediately re-open the panel;
   // cleared once the cursor actually leaves the trigger+panel.
   const suppressHover = useRef(false);
 
   const visible = pinned || hovering || (showPageDrag.active && dragHovering);
+
+  useLayoutEffect(() => {
+    const slot = slotRef.current;
+    const launcher = launcherRef.current;
+    if (!slot || !launcher) return;
+    const measure = () => {
+      const rect = slot.getBoundingClientRect();
+      const next = {
+        left: rect.left,
+        bottom: window.innerHeight - rect.bottom,
+        width: rect.width,
+        height: launcher.getBoundingClientRect().height,
+      };
+      setPlacement((current) =>
+        current.left === next.left && current.bottom === next.bottom
+          && current.width === next.width && current.height === next.height ? current : next,
+      );
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(slot);
+    observer.observe(launcher);
+    // The optional hostname/version rows can move the slot without resizing it.
+    if (slot.parentElement?.parentElement) observer.observe(slot.parentElement.parentElement);
+    window.addEventListener('resize', measure);
+    window.addEventListener('scroll', measure, true);
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('resize', measure);
+      window.removeEventListener('scroll', measure, true);
+    };
+  }, []);
 
   useEffect(() => {
     const resetDragHover = () => setDragHovering(false);
@@ -77,12 +113,11 @@ export const AppsLauncher: React.FC = () => {
     setMenu(null);
   };
 
-  return (
-    // The sidebar aside owns the stacking context (z-10, below the window layer z-20), so the Apps
-    // button is covered by a maximized window like the rest of the sidebar. `relative` is just the
-    // positioning context for the Dock popover below; the popover's z-50 is scoped to the sidebar.
+  const launcher = (
     <div
-      className="relative flex-1"
+      ref={launcherRef}
+      className="fixed z-30 hidden md:block"
+      style={{ left: placement.left, bottom: placement.bottom, width: placement.width }}
       data-show-page-dock-drop-target
       onMouseEnter={openHover}
       onMouseLeave={queueClose}
@@ -166,5 +201,14 @@ export const AppsLauncher: React.FC = () => {
         </ContextMenu>
       )}
     </div>
+  );
+
+  return (
+    <>
+      {/* Keep the sidebar's layout slot, but let this single launcher and its Dock escape the
+          sidebar stacking context. z-30 is above all app windows (z-20), below dialogs (z-50). */}
+      <div ref={slotRef} className="flex-1" style={{ height: placement.height }} />
+      {createPortal(launcher, document.body)}
+    </>
   );
 };

--- a/ui/src/components/apps/WindowLayer.tsx
+++ b/ui/src/components/apps/WindowLayer.tsx
@@ -288,7 +288,7 @@ export const WindowLayer: React.FC = () => {
       // Code editor / a terminal. So the layer itself no longer forces a theme — each window opts in.
       // Spans the FULL viewport (no longer offset past the sidebar): windows can move over
       // the sidebar and maximize fills the whole screen. This layer (z-20) sits ABOVE the sidebar
-      // (z-10), so a maximized window covers the whole sidebar, Apps launcher included.
+      // (z-10), but below the portaled Apps launcher and Dock (z-30).
       className="pointer-events-none fixed inset-0 z-20 hidden md:block"
     >
       {windows.map((w) => {


### PR DESCRIPTION
Opening or maximizing an app window can cover both the Dock and the Apps button, leaving no clickable way to switch apps. They were trapped inside the sidebar's stacking context, below the window layer.

Render the existing launcher and Dock once through a portal above app windows. Preserve their sidebar position with a measured layout slot that follows footer content and viewport changes. Update the obsolete comments describing the launcher as intentionally covered.

### Scope and acceptance

- Desktop app launching, switching, restoring minimized windows, and context menus remain reachable above normal and maximized windows.
- Existing hover/pin behavior and sidebar alignment remain intact.
- No backend/API changes, new dependencies, or applicable catalog scenario IDs.

### Validation

- `npm run build` and the repository's `npm run lint` gate passed.
- 62 focused tests passed across AppShell, WindowManagerProvider, window inventory/gestures/motion, app launching, and Dock shortcuts.
- Two one-off hermetic Chromium scenarios passed against the real AppShell, AppsLauncher, Dock, WindowLayer, and WindowManagerProvider with isolated transport and app bodies: maximize, launch/switch/restore, context-menu new window, hover after unpin, asynchronous footer content, resizing, desktop/mobile transitions, and dialog hit testing. The temporary validation fixture was removed afterward.
- Live local Incus verification remains an optional post-merge acceptance step; no running instance was updated or restarted.

### Known-by-design ledger

- Normal sidebar navigation stays below app windows; only the Apps launcher and Dock float above them.
- System dialogs retain priority above the Dock. Mobile and standalone-app surfaces retain their existing behavior.
- This changes stacking and placement ownership, not Dock appearance, app state, or window focus rules.
