### PR TITLE
fix(regression): exclude host artifacts from source sync

### DIFF
--- a/docs/regression/README.md
+++ b/docs/regression/README.md
@@ -127,6 +127,22 @@ entries are never sent, and stale entries in the receiver's source directories
 are deleted during normal synchronization. Excluded runtime/dependency trees
 remain outside this cleanup boundary.
 
+The same sender-only policy covers `.DS_Store` at any depth and these
+repository-root host artifacts: `.bot.pid`, `.gstack/`, `.tmp/`,
+`vibe/_version.py`, and `vibe/show_runtime_manifest.json`. Their stale copies
+are removed only from the disposable synced source, never from the operator's
+checkout or persistent product home.
+
+This is not a blanket `.gitignore` filter: worktree regression still accepts
+uncommitted source files, and similarly named files inside test fixtures remain
+source inputs. When checking a master deployment against its Git tree, compare
+the filtered files and symlinks; empty directories carry no versioned content.
+UI assets are built in the instance. Editable installation generates its own
+Python version file when installation is needed; otherwise the source checkout
+supports its build-less version fallback, and `/api/version` identifies the
+deployed commit from the source receipt. Show Runtime uses the regression
+archive prepared below, not a host's generated release-packaging manifest.
+
 Show Runtime resolves the upstream commit on each update, but builds only when
 that commit, the target Node/platform/npm versions, the build recipe, or the
 archive checksum changes. The archive and its build receipt are kept together

--- a/scripts/incus_regression.py
+++ b/scripts/incus_regression.py
@@ -1602,7 +1602,7 @@ def root_exec(target: RegressionTarget, command: str, *, remote: str | None = No
 
 
 def source_excludes(*, include_ui_dist: bool = False) -> tuple[str, ...]:
-    """Path patterns dropped from the deployed source tree.
+    """Paths omitted from source sync and protected on the receiver.
 
     A bare pattern matches that name at any depth. A pattern with a leading
     ``/`` is anchored at the repository root, which is what keeps ``/dist``
@@ -1631,6 +1631,25 @@ def source_excludes(*, include_ui_dist: bool = False) -> tuple[str, ...]:
     return tuple(excludes)
 
 
+def source_hides() -> tuple[str, ...]:
+    """Host-only inputs: never send them or retain their stale deployed copies.
+
+    Unlike reusable dependency caches, these paths do not belong in the synced
+    source. Editable installs can generate their own version file; source
+    regression prepares its own Show Runtime archive, not a packaged manifest.
+    """
+    return (
+        ".env",
+        ".env.*",
+        ".DS_Store",
+        "/.bot.pid",
+        "/.gstack",
+        "/.tmp",
+        "/vibe/_version.py",
+        "/vibe/show_runtime_manifest.json",
+    )
+
+
 def is_env_file(relative: str) -> bool:
     return any(part == ".env" or part.startswith(".env.") for part in relative.split("/"))
 
@@ -1639,7 +1658,7 @@ def should_exclude(relative: str, *, include_ui_dist: bool = False) -> bool:
     if is_env_file(relative):
         return True
     parts = relative.split("/")
-    for pattern in source_excludes(include_ui_dist=include_ui_dist):
+    for pattern in (*source_excludes(include_ui_dist=include_ui_dist), *source_hides()):
         if pattern.startswith("/"):
             anchored = pattern[1:]
             if relative == anchored or relative.startswith(anchored + "/"):
@@ -1710,9 +1729,9 @@ def sync_source(
         shell.chmod(0o700)
         runner.run([
             "rsync", "-rltp", "--delete", "--stats",
-            # Hide secrets only on the sender. A receiver-side exclude would
-            # retain stale .env files that can change Vite's build environment.
-            "--filter=H .env", "--filter=H .env.*",
+            # Sender-only hides let --delete remove stale host artifacts.
+            # Receiver-side excludes below protect reusable target caches.
+            *(f"--filter=H {pattern}" for pattern in source_hides()),
             *(f"--exclude={pattern}" for pattern in excludes),
             "--rsh", str(shell), "--", str(repo_root) + "/", f"incus:{SOURCE_DIR}/",
         ])

--- a/tests/test_incus_regression.py
+++ b/tests/test_incus_regression.py
@@ -1050,17 +1050,26 @@ def test_source_sync_excludes_all_local_env_files(tmp_path: Path, monkeypatch) -
 
 
 @pytest.mark.parametrize("shape", ["file", "directory", "symlink"])
-def test_source_sync_removes_stale_environment_entries_but_preserves_runtime_trees(tmp_path, monkeypatch, shape):
+def test_source_sync_removes_host_artifacts_but_preserves_runtime_trees(tmp_path, monkeypatch, shape):
     source, deployed, outside = (tmp_path / name for name in ("source", "deployed", "outside"))
     for root in (source, deployed, outside):
         root.mkdir()
     sentinel = outside / "sentinel"
     sentinel.write_text("not deployed source")
-    obsolete = [".env", "ui/.env.local", "nested/source/.env.preview.local"]
+    obsolete = [
+        ".env", "ui/.env.local", "nested/source/.env.preview.local",
+        ".DS_Store", "ui/src/.DS_Store", ".bot.pid", ".gstack", ".tmp",
+        "vibe/_version.py", "vibe/show_runtime_manifest.json",
+    ]
+    hosts = []
     for relative in obsolete:
         host = source / relative
         host.parent.mkdir(parents=True, exist_ok=True)
+        if relative in {".gstack", ".tmp"}:
+            host.mkdir()
+            host = host / "tool-state"
         host.write_text("host-only fixture secret")
+        hosts.append(host)
         receiver = deployed / relative
         receiver.parent.mkdir(parents=True, exist_ok=True)
         if shape == "directory":
@@ -1070,18 +1079,97 @@ def test_source_sync_removes_stale_environment_entries_but_preserves_runtime_tre
             receiver.symlink_to(outside, target_is_directory=True)
         else:
             receiver.write_text("old fixture secret")
-    protected = [deployed / "ui/node_modules/pkg/.env", deployed / ".runtime/.env.local"]
+    protected = [
+        deployed / "ui/node_modules/pkg/.env",
+        deployed / "ui/node_modules/pkg/.DS_Store",
+        deployed / ".runtime/.env.local",
+        deployed / ".runtime/.bot.pid",
+    ]
     for path in protected:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text("runtime-owned fixture")
-    before = {path: path.stat().st_ctime_ns for path in [sentinel, *protected]}
+    before = {path: path.stat().st_ctime_ns for path in [sentinel, *protected, *hosts]}
 
     local_source_sync(monkeypatch, source, deployed)
 
+    assert all(incus_regression.should_exclude(relative) for relative in obsolete)
     assert all(not os.path.lexists(deployed / relative) for relative in obsolete)
-    assert all((source / relative).read_text() == "host-only fixture secret" for relative in obsolete)
+    assert all(host.read_text() == "host-only fixture secret" for host in hosts)
     assert all(path.stat().st_ctime_ns == timestamp for path, timestamp in before.items())
     assert sentinel.read_text() == "not deployed source"
+
+
+def test_source_sync_keeps_uncommitted_inputs_and_nested_artifact_fixtures(tmp_path, monkeypatch):
+    """Do not turn the host-artifact policy into gitignore or basename filtering."""
+    source, deployed = (tmp_path / name for name in ("source", "deployed"))
+    source.mkdir()
+    deployed.mkdir()
+    inputs = [
+        "draft.py", "新目录/未提交.py",
+        "fixtures/vibe/_version.py", "fixtures/vibe/show_runtime_manifest.json",
+        "fixtures/.bot.pid", "fixtures/.gstack/example", "fixtures/.tmp/example",
+    ]
+    (source / ".gitignore").write_text("draft.py\n")
+    for relative in inputs:
+        path = source / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("source fixture")
+
+    local_source_sync(monkeypatch, source, deployed)
+
+    assert all(not incus_regression.should_exclude(relative) for relative in inputs)
+    assert all((deployed / relative).read_text() == "source fixture" for relative in inputs)
+
+
+def test_source_sync_leaves_only_empty_parents_of_excluded_caches(tmp_path, monkeypatch):
+    source, deployed = (tmp_path / name for name in ("source", "deployed"))
+    source.mkdir()
+    deployed.mkdir()
+    (source / "empty").mkdir()
+    cache = source / "retired/nested/__pycache__/old.pyc"
+    cache.parent.mkdir(parents=True)
+    cache.write_bytes(b"host bytecode")
+    target_cache = deployed / "ui/node_modules/pkg/cache"
+    target_cache.parent.mkdir(parents=True)
+    target_cache.write_bytes(b"target dependency")
+    before = target_cache.stat().st_ctime_ns
+    (source / "app.py").write_text("source")
+
+    local_source_sync(monkeypatch, source, deployed)
+
+    # Empty directories have no versioned content; compare files and links,
+    # without changing rsync's deletion traversal or target-cache protection.
+    entries = {
+        path.relative_to(deployed).as_posix()
+        for path in deployed.rglob("*") if path.is_symlink() or not path.is_dir()
+    }
+    assert entries == {"app.py", "ui/node_modules/pkg/cache"}
+    assert (deployed / "app.py").read_text() == "source"
+    assert target_cache.read_bytes() == b"target dependency"
+    assert target_cache.stat().st_ctime_ns == before
+    assert cache.read_bytes() == b"host bytecode"
+    assert (source / "empty").is_dir()
+
+
+def test_synced_source_imports_without_host_generated_version(tmp_path, monkeypatch):
+    source, deployed = (tmp_path / name for name in ("source", "deployed"))
+    (source / "vibe").mkdir(parents=True)
+    deployed.mkdir()
+    shutil.copyfile(SCRIPT_PATH.parent.parent / "vibe/__init__.py", source / "vibe/__init__.py")
+    (source / "vibe/_version.py").write_text("raise RuntimeError('host build must not be imported')\n")
+
+    local_source_sync(monkeypatch, source, deployed)
+    result = subprocess.run(
+        [
+            sys.executable, "-I", "-B", "-c",
+            "import sys; sys.path.insert(0, sys.argv[1]); import vibe; print(vibe.__version__)",
+            str(deployed),
+        ],
+        check=True, capture_output=True, text=True,
+    )
+
+    assert not (deployed / "vibe/_version.py").exists()
+    assert result.stdout.strip() == "0.0.0.dev0"
 
 
 def test_source_sync_can_include_existing_ui_dist_when_build_is_skipped(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary and change contract

Unblock clean master regression updates after Dock PR #1955 by separating
host-only artifacts from reusable receiver-side caches.

- Hide `.DS_Store` at any depth and root-local `.bot.pid`, `.gstack`, `.tmp`,
  `vibe/_version.py`, and `vibe/show_runtime_manifest.json` on the sender.
- Reuse the existing environment-file policy: normal rsync deletion removes
  stale deployed copies, including files, directories, and symlinks, without
  changing the operator's checkout or following symlinks outside the source.
- Keep receiver-owned dependency/runtime caches protected, and keep the
  directory-walk predicate consistent with the sender filters.
- Document file/symlink-based Git equivalence: empty cache-parent directories
  are not source drift. Keep the existing rsync directory/deletion traversal.

Scope is the regression runner, its existing tests, and regression documentation.
No UI, credentials, product state, pairing, or session behavior changes.

## Validation

- 423 tests passed across the Incus runner, regression wrapper/supervisor,
  state preparation, and source-version identity suites.
- 15 focused runtime/archive and manifest-packaging tests passed.
- Real-rsync coverage checks stale artifact removal for all three path shapes,
  source and outside-symlink-target preservation, protected target caches,
  uncommitted/non-ASCII source inputs, nested similarly named fixtures, empty
  cache parents, and importing synced source without the host version file.
- Read-only comparison of the primary checkout against master
  `4a504f375b73f9e23b058d914398ec76abf8c1a6` under the proposed sender policy:
  2,366 files/symlinks, zero content/type/executable-bit differences.
- Changed-file Ruff, repository-wide pre-commit, and `git diff --check` passed.
- `npm ci` and `npm run build` passed in the isolated task worktree.
- `uv sync --frozen --group dev` and a Python source import passed after the UI
  build, with no host-generated Show Runtime packaging manifest present.

No separate scenario catalog applies; coverage extends the existing regression
runner and runtime/version test suites. No new dependencies.

## Known-by-design ledger

- This is not a blanket `.gitignore` or Git-tracked-only sync. Worktree
  regression must still ship intentional uncommitted source. Root-only
  artifact names do not suppress nested test fixtures.
- Incremental target-cache protection and `--no-build-ui` behavior are unchanged.
  Only disposable synced source copies of host-only artifacts are removed.
- Source regression prepares its own Show Runtime archive. Release packaging
  still requires its manifest; editable source installs do not. A skipped
  Python reinstall may use the supported build-less version fallback, while
  the deployment receipt identifies the source commit.
- Empty directories remain allowed; pruning them at transfer time is not
  needed to establish versioned-source equivalence.

## Delivery and residual acceptance

No unmerged dependencies; #1955 is already merged. No environment was updated,
reset, or restarted. After this PR is reviewed and explicitly authorized for
merge, the previously requested local master update and real Dock interaction
verification remain to be performed with state and runtime credentials preserved.
