### PR TITLE
fix(model-hub): accept requests through 128 MiB

### DIFF
--- a/core/handlers/model_hub/turn_gateway.py
+++ b/core/handlers/model_hub/turn_gateway.py
@@ -15,7 +15,9 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import BinaryIO, Final, Optional
 
+import aiohttp
 from aiohttp import web
+from packaging.version import Version
 
 from config import paths
 from core.run_settlement import SETTLED_BY_TERMINAL_RESULT
@@ -490,8 +492,12 @@ class ModelHubTurnGateway:
         async with self._start_lock:
             if self._runner is not None:
                 return
-            # aiohttp rejects at >= client_max_size; our byte budget is inclusive.
-            app = web.Application(client_max_size=_MAX_REQUEST_BYTES + 1)
+            # Before 3.14, aiohttp's reader rejects at >= instead of >.
+            # Compensate only there so our byte budget stays inclusive.
+            client_max_size = _MAX_REQUEST_BYTES
+            if Version(aiohttp.__version__).release < (3, 14):
+                client_max_size += 1
+            app = web.Application(client_max_size=client_max_size)
             app.router.add_get("/{backend}/v1/models", self._handle_models)
             app.router.add_post("/{backend}/v1/{endpoint:.*}", self._handle_request)
             runner = web.AppRunner(

--- a/core/handlers/model_hub/turn_gateway.py
+++ b/core/handlers/model_hub/turn_gateway.py
@@ -63,7 +63,7 @@ from .service import (
 )
 
 
-_MAX_REQUEST_BYTES: Final = 16 * 1024 * 1024
+_MAX_REQUEST_BYTES: Final = 128 * 1024 * 1024
 _BUFFERED_RESPONSE_MEMORY_BYTES: Final = 256 * 1024
 _RESPONSE_CHUNK_BYTES: Final = 64 * 1024
 _SUPPORTED_PATHS: Final = frozenset(
@@ -490,7 +490,8 @@ class ModelHubTurnGateway:
         async with self._start_lock:
             if self._runner is not None:
                 return
-            app = web.Application(client_max_size=_MAX_REQUEST_BYTES)
+            # aiohttp rejects at >= client_max_size; our byte budget is inclusive.
+            app = web.Application(client_max_size=_MAX_REQUEST_BYTES + 1)
             app.router.add_get("/{backend}/v1/models", self._handle_models)
             app.router.add_post("/{backend}/v1/{endpoint:.*}", self._handle_request)
             runner = web.AppRunner(
@@ -758,6 +759,15 @@ class ModelHubTurnGateway:
             )
         try:
             payload = await request.json(loads=json.loads)
+        except web.HTTPRequestEntityTooLarge:
+            terminalizer.fail("invalid_parameter")
+            return self._terminal_error_response(
+                execution,
+                terminalizer,
+                status=413,
+                code="request_too_large",
+                turn_outcome=REQUEST_NONFALLBACK_TURN_OUTCOME,
+            )
         except (json.JSONDecodeError, UnicodeDecodeError):
             terminalizer.fail("invalid_parameter")
             return self._terminal_error_response(
@@ -1225,7 +1235,11 @@ class ModelHubTurnGateway:
         copy = project_turn_outcome_copy(turn_outcome) if turn_outcome is not None else None
         message = render_turn_outcome_copy(turn_outcome, language) if turn_outcome is not None else None
         key = copy.key if copy is not None else None
-        if message is None and fallback_code is not None:
+        if fallback_code == "request_too_large":
+            # Refine the local admission error without changing its turn outcome.
+            key = "modelHub.errors.request_too_large"
+            message = i18n_t(key, language, limit_mib=f"{_MAX_REQUEST_BYTES / (1024 * 1024):g}")
+        elif message is None and fallback_code is not None:
             fallback_key = f"modelHub.errors.{fallback_code}"
             fallback_message = i18n_t(fallback_key, language)
             if fallback_message == fallback_key:

--- a/docs/plans/model-hub-permissive-boundaries.md
+++ b/docs/plans/model-hub-permissive-boundaries.md
@@ -131,3 +131,42 @@ any contract decision required. A callback is evidence to inspect, not approval.
 - Initial decision: implement the 128 MiB compatibility boundary, not unlimited
   buffering; investigate the identifier and engine seams before choosing edits.
 - Initial findings-bearing review heads: zero. No PR has been submitted yet.
+
+### Capability and launch-limit decision (2026-09-09)
+
+The orchestrator independently inspected catalog projection, Claude environment
+construction, its SessionHandler call site, and injection/CLI-path consuming
+tests at the shared contract base. The current Hub path both tombstones limit
+variables as though they were credentials and promotes catalog limits into
+highest-priority launch settings. Native CLI launches also overwrite explicit
+environment limits. These are competing owners, not evidence that a persisted
+provenance system is needed.
+
+Approved scope:
+
+- Keep existing BackendModel storage and the requested alias's metadata
+  authority. A saved non-null limit remains that selected model's planning
+  description; do not infer field provenance from row-level `origin`.
+- For Claude, leave credential/connection tombstones intact but remove the
+  two context/output limit variables from that boundary. Catalog limits fill
+  only absent subprocess variables. Empty explicit values are not permission
+  to invent another override. Do not inject model limits in the Hub connection
+  settings override; preserve native project/local settings precedence.
+- Verify the real launch consumer as well as pure environment helpers: parent
+  environment, explicit settings, absent limits, selected aliases, and both Hub
+  and native CLI paths. Do not broaden the enabled native setting sources.
+- Codex keeps its native configuration precedence if consumer evidence
+  confirms it. Custom capability absence must allow supplied images/reasoning
+  without importing a different model's private features or expensive default
+  effort. Explicit negatives and nonempty lists retain their meanings.
+- OpenCode retains the selected BackendModel as owner of the managed Hub
+  provider's planning metadata. Preserve separate native providers; do not merge
+  arbitrary native provider objects into a managed authentication definition.
+- No new persisted schema, UI policy, engine policy, credential flow, routing
+  policy, or output cap is approved by this decision.
+
+The remaining uncertainty is the native CLI consumer's treatment of absent
+capabilities and conflicting settings. Hermetic consumer evidence must confirm
+the representation and precedence before integration; a schema requirement or
+unexpected consumer override calls for another bounded decision, not a fallback
+to silent filtering.

--- a/docs/plans/model-hub-permissive-boundaries.md
+++ b/docs/plans/model-hub-permissive-boundaries.md
@@ -300,3 +300,41 @@ An upstream acceptance/release or a separately authorized Avibe source/
 provenance release contract is required before shipping this engine change.
 The Avibe PR may carry the reviewed inactive patch, but must explicitly state
 that its current engine pin and installed behavior remain unchanged.
+
+### xAI post-translation capability gate
+
+The orchestrator independently inspected the exact pinned source's
+`prepareResponsesRequestTo` chain, `sanitizeXAIResponsesBody`,
+`xaiSupportsReasoningEffort`, both existing catalog-strip tests, and the new
+fake-OAuth executor consumer and failing wire record. A whole-source search
+found one production caller of the capability helper: the sanitizer removes
+`reasoning.effort` after shared thinking and payload rules when registry
+thinking levels are absent. This is another catalog policy owner, not a
+Responses representation constraint. Shared passthrough alone cannot satisfy
+the accepted intent contract.
+
+Approve this additional source-only scope:
+
+- Remove only the catalog-conditioned reasoning deletion from
+  `sanitizeXAIResponsesBody`. Keep its `stop` removal and every other xAI
+  schema, tool-choice, replay, image, normalizer, and payload-rule constraint.
+  Preserve the current prepared target fields; do not restore the whole
+  original request or override configured payload rules.
+- Remove the now-unconsumed private `xaiSupportsReasoningEffort` helper,
+  its obsolete assertion-only test, unused imports, and the sanitizer's
+  now-unused model argument. No registry or registration policy change.
+- Replace catalog-strip assertions with actual executor evidence for unknown,
+  known-nil, empty/narrow, and supported metadata populations; native future
+  effort and explicit disable remain present, missing native intent remains
+  absent, and `stop` still does not reach Responses. Cover cross-protocol
+  conversion and stream/non-stream paths without claiming upstream support.
+- Reconcile the complete manager/credential-replacement and Kimi fixture
+  failures from the same test run independently of this xAI defect. A passing
+  xAI case alone is not source acceptance. Check the final egress preparation
+  of the other supported executor paths for an equivalent downstream
+  catalog-only gate; report another boundary before expanding changes.
+
+This narrowly supersedes the earlier blanket preservation of normalizers
+only for the identified catalog deletion. All changes stay in the inactive
+exact-base source/test patch. Avibe runtime/config/manifest, release guards,
+publication authority, and the installed engine remain unchanged.

--- a/docs/plans/model-hub-permissive-boundaries.md
+++ b/docs/plans/model-hub-permissive-boundaries.md
@@ -1,0 +1,133 @@
+# Model Hub permissive request boundaries
+
+## Ownership and authorization
+
+Owner approval on 2026-09-09 authorizes implementation and parallel Codex
+delegation following the preceding request-path audit. The user-started Session
+remains the orchestrator and final reviewer. This is not authorization to merge,
+publish an engine or application release, deploy, update/restart the running
+local Avibe, mutate user configuration, or advance the primary checkout.
+
+Implementation starts from default-branch commit
+`e4924db41bcbf37581cda08cf1376a899e70906c`. Independent lanes share this committed
+contract before they branch. Avibe changes integrate into one task branch and
+one normally reviewed PR; no lane stacks a PR on an unmerged peer.
+
+## Evidence and goal
+
+A Codex Blender Session failed at the authenticated Avibe gateway's 16 MiB
+request boundary. Reconstructing its latest persisted context checkpoint and
+subsequent model items found 20 inline PNG images totaling approximately 42 MiB.
+This was not a capture of the rejected wire request. The new user text was
+39 UTF-8 bytes. A hermetic 18 MiB aiohttp request passed with the boundary
+disabled, but the read/parse/reserialize fixture recorded about 76.5 MiB of peak
+Python allocations, excluding the engine. Removing every resource bound is
+therefore not the immediate remedy.
+
+The product should accept legitimate multi-image requests, preserve explicit
+model intent, and never equate absent capability knowledge with demonstrated
+non-support. Resource ownership, authentication, cancellation, routing, and
+persisted identity remain real constraints.
+
+## Shared invariants
+
+1. **Request envelope.** The common authenticated gateway accepts valid request
+   bodies through 128 MiB for Messages, Responses, and Chat Completions, with
+   consistent byte semantics for Content-Length and chunked bodies. Oversize
+   input returns a structured, non-secret 413 describing the local boundary,
+   before upstream admission. It does not mark a provider unhealthy, consume an
+   alternative provider, or silently truncate history. Do not add image-count,
+   turn-count, output-length, or normal-inference-duration caps.
+2. **Capabilities.** An absent override remains distinct from an explicit
+   negative or an explicit user selection. Custom model projection must not
+   silently strip supplied images or force reasoning to `none` solely because
+   catalog metadata is absent. Do not inherit a different model's provider-only
+   features, context size, tools, or expensive defaults. Preserve native known
+   rows, explicit negatives, persisted shapes, and model-selection ownership.
+3. **Limit authority.** Catalog context/output metadata assists planning; it
+   must not silently replace explicit user configuration with a stale default.
+   Preserve useful automatic compaction and backend schema requirements.
+   Determine authority from existing fields/owners where possible. A new
+   persisted provenance model requires an orchestrator decision before editing.
+4. **Model identity.** Reassess the 256-character admission bound across manual
+   input, discovery, routing, UI/API, metering, and load. Do not replace it with
+   another arbitrary number or remove it without checking downstream identity
+   and usage-key behavior. No truncation, identity merging, secret admission,
+   startup breakage, or silent loss of historical usage is permitted. The lane
+   reports its smallest complete proposal before implementation.
+5. **Engine intent.** Inspect the exact pinned CLIProxyAPI v7.2.149 source
+   `2a6b87aca083a5bf498ac1f68a1b636c500d7aaa`. Same-protocol explicit reasoning
+   intent must not be removed or downgraded solely by incomplete capability
+   metadata. Preserve required cross-protocol translation, OAuth lifetimes,
+   credential replacement, Source/model identity, and all routing policy.
+   Do not remove registration metadata as a shortcut: it can worsen stripping.
+   Report the source/build/release plan before implementing engine policy.
+   Never point a shipped manifest at missing assets or claim wire preservation
+   from a fake-adapter-only test.
+6. **Non-goals.** Keep bounded observation copies, temporary-file spill
+   thresholds, chunk sizes, authentication, cancellation cleanup, real upstream
+   failures, and existing retry ownership. Do not weaken CI, migrate unrelated
+   state, add a detection save gate, replay live credentials, or change unrelated
+   pending PRs.
+
+## Boundary ownership
+
+| Boundary | Producer | Consumer | Contract owner |
+| --- | --- | --- | --- |
+| Native model request | Claude/Codex/OpenCode | authenticated turn gateway | gateway lane |
+| Request model/protocol/header envelope | gateway | resolver and managed adapter | existing shared request owner, unchanged |
+| Backend model capability/limit projection | selected backend model catalog | CLI launch/catalog consumers | capability lane |
+| Model ID admission and durable usage identity | setup/discovery | config, routes, ledger, UI | identity lane, orchestrator approval |
+| Reasoning wire conversion | managed engine | exact selected mock upstream | engine lane, orchestrator approval |
+| Integration, authority/scenario inventory, PR gates | all lanes | owner | orchestrator |
+
+No new signature or credential field is introduced. Existing local bearer
+authentication and exact Source/model binding must remain unchanged.
+
+## Parallel delivery
+
+- **Gateway lane:** owns gateway request-size/error handling and focused tests
+  plus only the locale/catalog entries required for its new error surface.
+- **Capability lane:** owns backend catalog projection, CLI limit precedence,
+  and their consuming tests. Report cross-lane changes rather than editing
+  gateway/engine/identity code.
+- **Identity lane:** owns the complete identifier/ledger boundary diagnosis
+  first; implementation is gated on the orchestrator's recorded decision.
+- **Engine lane:** owns exact-pinned-source diagnosis and a reproducible
+  hermetic wire/build proposal first; policy edits, publication, and a manifest
+  change are separate decisions.
+- **Orchestrator:** owns this plan, integration branch, final review, combined
+  validation, PR submission, durable PR/CI observation, and close-out.
+
+Lane commits remain local until integrated. Lanes must not push, open PRs,
+merge, create release tags/assets, deploy, or edit a peer's worktree. Each lane
+returns a stable Session/Run ID, commit SHA, tests actually run, known gaps, and
+any contract decision required. A callback is evidence to inspect, not approval.
+
+## Acceptance
+
+- Exercise real hermetic HTTP ingress with a multi-image-size payload exceeding
+  16 MiB; compare exact input reaching the fake upstream/adapter, including
+  non-ASCII text and image data. Check both body framing shapes, threshold
+  boundaries, bad credentials, malformed JSON, cancellation, and no provider
+  health mutation for a local 413.
+- Cover unknown custom models, known built-ins, explicit supported/unsupported
+  choices, aliases, user-selected reasoning, and context/output precedence in
+  consuming launch/catalog paths.
+- For any identifier change, cover every admission surface and legacy persisted
+  IDs, non-ASCII names, collision-shaped names, reload and usage stability.
+- For engine policy, require actual pinned engine-to-mock-upstream wire evidence
+  for applicable same- and cross-protocol paths; distinguish source proof,
+  built artifacts, published availability, and installed behavior.
+- Run focused Python checks and pinned Ruff, then relevant Model Hub suites,
+  authority closure and scenario/catalog checks. UI changes require UI tests,
+  TypeScript and build. Use only isolated fixtures/local regression targets.
+- Require current-head Codex pass, all expected CI jobs, and zero unresolved
+  paginated threads. Record findings-bearing heads/root causes before edits;
+  enforce the review circuit breaker. No automatic merge authorization exists.
+
+## Decisions and status
+
+- Initial decision: implement the 128 MiB compatibility boundary, not unlimited
+  buffering; investigate the identifier and engine seams before choosing edits.
+- Initial findings-bearing review heads: zero. No PR has been submitted yet.

--- a/docs/plans/model-hub-permissive-boundaries.md
+++ b/docs/plans/model-hub-permissive-boundaries.md
@@ -224,3 +224,79 @@ Historical merged counters cannot identify their original owner, so this PR
 must not rekey or split them speculatively. Preserve the diagnostic evidence
 and record that attribution-policy follow-up separately; do not claim a proof
 over every malformed legacy string.
+
+### Native consumer follow-up
+
+The orchestrator inspected Codex 0.153.2's
+`models-manager/src/model_info.rs::with_config_overrides` and lane B's actual
+app-server consumer test. Codex takes the minimum of explicit
+`model_context_window` and catalog `max_context_window`; Avibe currently
+synthesizes both catalog fields from one BackendModel planning value.
+
+Approve removing `max_context_window` only when applying an explicit saved
+BackendModel `context_window` override. Retain `context_window` as the planning
+fallback and remove its obsolete catalog compaction threshold as before.
+Native rows without that override and native-CLI launches remain unchanged.
+The consumer test must prove both the fallback and an explicit larger context,
+alongside the native compaction setting. No Codex output cap is introduced.
+
+Claude's bundled CLI consumer honors explicit output limits, but its normal
+context planner does not necessarily consume `CLAUDE_CODE_MAX_CONTEXT_TOKENS`;
+the diagnosed context branch checks it only with compaction disabled. Retain
+the approved environment/settings preservation, prove actual output and
+Avibe-to-SDK context delivery, and document this native planner limitation.
+Do not disable compaction or claim end-to-end context control from environment
+injection alone.
+
+### Engine source-only decision
+
+Lane D's complete assessment is at
+`2a756b4b19a1478d06e1cc2a382aad0a9268acb5`. The orchestrator independently
+verified the clean exact upstream SHA, read the shared thinking entry point,
+validation and configured-model consuming tests, inspected the HTTP fixture,
+and verified the baseline artifact digest and all 380 result records. The
+recorded native disable-to-positive outcomes agree with the inspected
+capability clamp. These are baseline defects, not patched acceptance results.
+
+Approve a maintained, inactive candidate source/test patch series under
+`patches/cliproxyapi/`, against upstream
+`2a6b87aca083a5bf498ac1f68a1b636c500d7aaa`, with a small apply/test recipe
+and frozen input receipt. This is a local source-maintenance decision only,
+not authorization for a public fork, upstream contribution, release assets,
+manifest changes, installation, or runtime replacement.
+
+Source scope:
+
+- Distinguish identical reasoning wire representations from broad provider
+  families at the shared thinking entry point. Without an explicit suffix,
+  preserve the already prepared native target payload instead of performing
+  catalog-driven strip/map/validate/reapply. Recognize verified Responses
+  aliases; do not conflate Chat/Responses or Kimi's different dialect.
+- Extract explicit disable before capability gating, retain suffix priority,
+  reuse native disable writers before their support guards, and never turn
+  disable into a positive level or reactivate it through summary handling.
+- For genuine conversion with missing thinking metadata, use the existing
+  capability-free conversion responsibility, supplying original source
+  payload/format instead of extracting source fields from translated data.
+  Preserve positive conversion with known metadata and real protocol
+  constraints, normalizer/payload-rule ownership, and forced tool choice.
+- Preserve all registration metadata, including the existing Chat conversion
+  hint, exact selected credential snapshot, aliases/prefixes, routing, OAuth,
+  replacement, and refresh lifetimes. No fabricated UserDefined/capability
+  claim, broad validator deletion, new user setting, or runtime config change.
+
+Acceptance must include the maintained policy tests, patched HTTP matrix
+through real registration/execution, source/auth identity and replacement,
+stream/cancellation, and fake-auth subscription HTTP/WebSocket/dialect tests
+with external egress rejected. Keep source execution isolated and concurrency
+bounded. Use the committed engine catalogs, locked Go modules and exact
+toolchain; no catalog refresh from a moving branch.
+
+Release/packaging is deliberately separate. The existing manifest guard only
+accepts a truthful upstream identity and verified available four-platform
+assets. Do not weaken it or label locally patched bytes as upstream. Local
+diagnostic builds are not four-platform production reproducibility evidence.
+An upstream acceptance/release or a separately authorized Avibe source/
+provenance release contract is required before shipping this engine change.
+The Avibe PR may carry the reviewed inactive patch, but must explicitly state
+that its current engine pin and installed behavior remain unchanged.

--- a/docs/plans/model-hub-permissive-boundaries.md
+++ b/docs/plans/model-hub-permissive-boundaries.md
@@ -338,3 +338,36 @@ This narrowly supersedes the earlier blanket preservation of normalizers
 only for the identified catalog deletion. All changes stay in the inactive
 exact-base source/test patch. Avibe runtime/config/manifest, release guards,
 publication authority, and the installed engine remain unchanged.
+
+### Kimi native representation clarification
+
+The orchestrator inspected the pinned Kimi executor's original/prepared payload
+flow, the original Kimi applier and extraction precedence, the current shared
+native-format gate, and the failing actual OAuth executor test. An OpenAI Chat
+transport can already carry Kimi's native `thinking` object. Treating every
+`openai` to `kimi` pair as conversion rejects a native future effort using
+catalog levels, although extraction already gives the native object priority.
+This is the same representation-identity defect, not evidence to remove
+genuine cross-protocol validation.
+
+Approve this bounded source-only clarification:
+
+- With no model suffix, recognize `openai` to `kimi` as native only when the
+  original source contains `thinking.type` or `thinking.effort`. A `keep`-only
+  object and a legacy `reasoning_effort` input do not establish native intent.
+- Preserve the prepared target payload and its native object without restoring
+  source fields or interpreting unknown effort/type values. Remove only the
+  legacy `reasoning_effort` alias, consistent with the existing Kimi wire writer.
+  Native disabled input must not be re-enabled or replaced by the legacy alias.
+- Preserve suffix priority and the existing conversion owner for legacy-only,
+  keep-only, and genuine cross-protocol inputs. No new interface, metadata,
+  configuration, registration, routing, or authentication policy is needed.
+- Verify native enabled/future/disabled/type-only input, conflicting legacy
+  input, keep-only conversion, suffix priority, and prepared-target authority
+  through policy tests and actual streaming/non-streaming executor captures.
+
+The expected result is exact prepared native intent reaching the loopback
+upstream, with the legacy alias absent; it is not a claim that a real upstream
+supports an arbitrary future value. Any target normalization or another
+protocol constraint that makes this preservation unsafe requires evidence and
+a new scope decision. The patch remains inactive and the engine pin unchanged.

--- a/docs/plans/model-hub-permissive-boundaries.md
+++ b/docs/plans/model-hub-permissive-boundaries.md
@@ -4,14 +4,19 @@
 
 Owner approval on 2026-09-09 authorizes implementation and parallel Codex
 delegation following the preceding request-path audit. The user-started Session
-remains the orchestrator and final reviewer. This is not authorization to merge,
-publish an engine or application release, deploy, update/restart the running
-local Avibe, mutate user configuration, or advance the primary checkout.
+remains the orchestrator and final reviewer. On 2026-09-09 at 04:11 +08
+(2026-09-08 at 20:11 UTC), the owner superseded the initial combined-PR plan:
+each lane must submit its own PR and merge after its delivery gates pass.
+The orchestrator owns final gate verification and merge execution. This does
+not authorize publishing an engine or application release, deploying,
+updating/restarting the running local Avibe, mutating user configuration, or
+advancing the primary checkout.
 
 Implementation starts from default-branch commit
 `e4924db41bcbf37581cda08cf1376a899e70906c`. Independent lanes share this committed
-contract before they branch. Avibe changes integrate into one task branch and
-one normally reviewed PR; no lane stacks a PR on an unmerged peer.
+contract before they branch. Each lane now delivers one independent Avibe PR
+against the current default branch; no lane stacks a PR on an unmerged peer.
+The combined task branch is retained only as integration-test evidence.
 
 ## Evidence and goal
 
@@ -96,13 +101,16 @@ authentication and exact Source/model binding must remain unchanged.
 - **Engine lane:** owns exact-pinned-source diagnosis and a reproducible
   hermetic wire/build proposal first; policy edits, publication, and a manifest
   change are separate decisions.
-- **Orchestrator:** owns this plan, integration branch, final review, combined
-  validation, PR submission, durable PR/CI observation, and close-out.
+- **Orchestrator:** owns this plan, cross-lane validation, independent PR/CI
+  observation, final review, guarded merge execution, and user-facing close-out.
 
-Lane commits remain local until integrated. Lanes must not push, open PRs,
-merge, create release tags/assets, deploy, or edit a peer's worktree. Each lane
-returns a stable Session/Run ID, commit SHA, tests actually run, known gaps, and
-any contract decision required. A callback is evidence to inspect, not approval.
+Each lane may push its assigned branch, open its own non-draft PR, and follow
+review/CI with one durable combined Watch. It must immediately return the PR,
+exact head, Watch/state, review inventory, tests, and known gaps to the
+orchestrator, who arms a separate gate Watch and independently inspects evidence.
+Lanes must not merge, create release tags/assets, deploy, or edit peers. The
+orchestrator executes the owner's gated merge authorization after all checks
+hold together. A callback is evidence to inspect, not proof of readiness.
 
 ## Acceptance
 
@@ -124,13 +132,41 @@ any contract decision required. A callback is evidence to inspect, not approval.
   TypeScript and build. Use only isolated fixtures/local regression targets.
 - Require current-head Codex pass, all expected CI jobs, and zero unresolved
   paginated threads. Record findings-bearing heads/root causes before edits;
-  enforce the review circuit breaker. No automatic merge authorization exists.
+  enforce the review circuit breaker. Before merging, the orchestrator must
+  also verify an open non-draft PR, CLEAN merge state, no running/queued lane
+  edits, and every merge gate in one fail-closed conditional, using the exact
+  validated head. Authorization does not permit skipping a gate.
 
 ## Decisions and status
 
 - Initial decision: implement the 128 MiB compatibility boundary, not unlimited
   buffering; investigate the identifier and engine seams before choosing edits.
 - Initial findings-bearing review heads: zero. No PR has been submitted yet.
+
+### Independent delivery allocation
+
+The four PRs own disjoint product concerns: A owns the gateway and request-budget
+scenario registration; B owns capability/limit projection and its CLI scenario
+registration; C owns identifier admission/discovery/UI plus the integration
+guard correction and qualified usage scenario descriptions; D owns the inactive
+exact-base engine patch, recipe, and consuming evidence. Each carries the same
+orchestrator-owned shared contract. Lane-specific assessments must describe
+independent delivery rather than the superseded combined-PR plan.
+
+Merge landed default-branch changes normally into each task branch before
+submission. Do not cherry-pick another lane's product changes or count the
+combined branch's tests as exact-head PR evidence. Recheck shared scenario IDs
+and catalog entries after each earlier PR lands. Subsequent gate evaluations
+remain exact-head and must inspect all paginated reviews/threads and every lint
+run, including old unresolved findings. Repeated root-cause classes are escalated
+to this same orchestrator before another edit/push; they do not automatically
+require another owner decision.
+
+Keep separate original durable lane and orchestrator gate Watch states across
+all rounds. Do not merge or remove a lane Watch merely because a callback reports
+green tests. After GitHub confirms a guarded merge, report that PR's result to
+the owner before removing its observation. Completed historical PR authority
+and Watches are not reused.
 
 ### Capability and launch-limit decision (2026-09-09)
 

--- a/docs/plans/model-hub-permissive-boundaries.md
+++ b/docs/plans/model-hub-permissive-boundaries.md
@@ -170,3 +170,57 @@ capabilities and conflicting settings. Hermetic consumer evidence must confirm
 the representation and precedence before integration; a schema requirement or
 unexpected consumer override calls for another bounded decision, not a fallback
 to silent filtering.
+
+### Identifier decision (2026-09-09, local +08)
+
+Lane C's diagnosis is committed as
+`e3f3628230333b141449684ba2f9af90ad0e3d1a`. The orchestrator independently
+inspected live and persisted ledger key owners, their consuming closure test,
+the selective parser and inventory projection, new-ID admission, OpenCode
+aggregate loading, and the typeahead refusal. A separate read-only synthetic
+run confirmed 12 valid long/Unicode/folded-literal identities remain distinct
+with stable read-back keys. It also reproduced the pre-existing whitespace
+normalization exception and admission of unencodable surrogate text.
+
+Approved smallest complete scope:
+
+- Remove the 256-character admission ceiling and its editor, schema, locale,
+  and typeahead-query mirrors. Keep canonical outer-whitespace spelling,
+  nonblank text, complete credential scanning, exact Source/model pairing, and
+  backend/source eligibility policy.
+- Require newly admitted IDs and unsaved observation IDs to be representable
+  as UTF-8, without replacement, truncation, Unicode normalization, or case
+  folding. This is a transport/storage validity check, not a new length cap.
+  Do not apply new admission rules to legacy persisted identities.
+- Separate OpenCode aggregate loading and whole-list editing from new-ID
+  admission while retaining existing spelling, nonblank, native-protocol,
+  menu, and route-membership invariants.
+- Extend the existing selective parser with a default-empty lossless-string
+  path option. Opt only inventory string-row IDs, object-row IDs, and
+  supported-parameter string values into it. Decide at value-token start;
+  object keys and unrelated values keep the existing bounded behavior.
+  Preserve malformed-JSON rejection, duplicate-member/scope semantics,
+  document completion, spooling, and the discovery deadline.
+- Keep the 200-character ledger head, digest calculation, persisted key
+  reader, stored rows, label joins, and retention unchanged. New admission can
+  safely include folded-looking literals because live derivation folds those
+  literals again; persisted key recognition is intentionally a different owner.
+- Limit shared service/config changes to the diagnosed admission, discovery,
+  typeahead, and load seams. Lane B's projection and lane A's gateway remain
+  independently owned. No new schema revision, dependency, ledger namespace,
+  engine setting, or arbitrary replacement size is approved.
+
+Selected identity/parameter facts necessarily occupy memory proportional to
+their full values. This decision does not remove generic HTTP/resource limits
+or promise arbitrary URI-size support. Consuming tests must cover lexical
+JSON expansion, long credential-shaped tails, exact runtime IDs, key-literal
+closure, reload, and the UI's whole-ID submission.
+
+Known-by-design legacy exceptions: an already loadable long all-whitespace
+identity can be misattributed by the existing persisted-key normalization;
+unencodable historical identities can also fail later encoding. Neither is
+introduced by removing the limit, and blank/unencodable new IDs are refused.
+Historical merged counters cannot identify their original owner, so this PR
+must not rekey or split them speculatively. Preserve the diagnostic evidence
+and record that attribution-policy follow-up separately; do not claim a proof
+over every malformed legacy string.

--- a/tests/scenarios/INDEX.yaml
+++ b/tests/scenarios/INDEX.yaml
@@ -150,6 +150,7 @@ capabilities:
       - tests/test_model_hub_injection.py
       - tests/test_model_hub_runtime.py
       - tests/test_model_hub_inference_wait.py
+      - tests/test_model_hub_request_body_budget.py
       - tests/test_model_hub_l3.py
       - tests/test_model_hub_usage.py
       - tests/test_local_deps.py

--- a/tests/scenarios/model_hub/catalog.yaml
+++ b/tests/scenarios/model_hub/catalog.yaml
@@ -9,6 +9,7 @@ capability:
     - tests/test_model_hub_injection.py
     - tests/test_model_hub_runtime.py
     - tests/test_model_hub_inference_wait.py
+    - tests/test_model_hub_request_body_budget.py
     - tests/test_model_hub_l3.py
     - tests/test_model_hub_usage.py
     - tests/test_local_deps.py
@@ -229,6 +230,24 @@ scenarios:
     kind: compatibility
     layer: e2e
     test: tests/e2e/test_model_hub_routing.py::test_mh_routing_013_legacy_empty_inherits_matching_and_exact_passthrough_through_real_cpa
+  - id: MH-REQUEST-BUDGET-001
+    name: Large multi-image requests retain exact model input through authenticated HTTP ingress
+    status: covered
+    kind: contract
+    layer: unit
+    test: tests/test_model_hub_request_body_budget.py::test_large_multi_image_request_is_forwarded_exactly
+  - id: MH-REQUEST-BUDGET-002
+    name: The inclusive request byte budget returns a local structured error without upstream admission or health mutation
+    status: covered
+    kind: boundary
+    layer: unit
+    test: tests/test_model_hub_request_body_budget.py::test_request_budget_is_inclusive_and_local
+  - id: MH-REQUEST-BUDGET-003
+    name: Invalid gateway authentication cannot parse or admit a request body
+    status: covered
+    kind: security
+    layer: unit
+    test: tests/test_model_hub_request_body_budget.py::test_bad_auth_does_not_parse_or_admit
   - id: MH-PROTOCOL-001
     name: Source protocol is response-observed before persistence with no transient residue
     status: covered

--- a/tests/test_model_hub_request_body_budget.py
+++ b/tests/test_model_hub_request_body_budget.py
@@ -38,6 +38,26 @@ WIRE_CASES = (
 )
 
 
+@pytest.mark.parametrize(("version", "expected_limit"), [
+    ("3.8.0", 4097),
+    ("3.13.3", 4097),
+    ("3.13.5", 4097),
+    ("3.14.0", 4096),
+    ("3.14.3", 4096),
+])
+async def test_aiohttp_request_limit_compatibility(tmp_path, monkeypatch, version, expected_limit):
+    """Map the inclusive budget to each aiohttp reader's comparison semantics."""
+    monkeypatch.setattr(aiohttp, "__version__", version)
+    monkeypatch.setattr(turn_gateway, "_MAX_REQUEST_BYTES", 4096)
+    paths.get_state_dir().relative_to(tmp_path)
+    gateway = turn_gateway.ModelHubTurnGateway(SimpleNamespace())
+    try:
+        await gateway._ensure_started()
+        assert gateway._runner.app._client_max_size == expected_limit
+    finally:
+        await gateway.close()
+
+
 @pytest.fixture
 def budget():
     return None

--- a/tests/test_model_hub_request_body_budget.py
+++ b/tests/test_model_hub_request_body_budget.py
@@ -1,0 +1,359 @@
+"""Real loopback ingress for the authenticated Model Hub request byte budget."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from urllib.parse import urlsplit
+
+import aiohttp
+from aiohttp import web
+import pytest
+
+from config import paths
+from core.handlers.model_hub import turn_gateway
+from core.handlers.model_hub.adapter import RawOutcomeKind
+from core.run_settlement import SETTLED_BY_STOPPED, SETTLED_BY_TERMINAL_RESULT
+from tests.scenario_harness.model_hub import (
+    MemoryModelHubStore,
+    ModelHubScenarioAdapter,
+    ScenarioCallResult,
+    config_with_sources,
+    fixed_model,
+    service_for,
+    source,
+)
+from vibe.i18n import t
+
+
+MIB = 1024 * 1024
+MODEL = "fixture-exact-model"
+TURN = "turn_request_budget"
+TEXT = "请检查这批合成图片的内容吧"
+WIRE_CASES = (
+    ("claude", "messages", "anthropic"),
+    ("codex", "responses", "openai_responses"),
+    ("opencode", "chat/completions", "openai_chat"),
+)
+
+
+@pytest.fixture
+def budget():
+    return None
+
+
+@pytest.fixture(params=WIRE_CASES, ids=["messages", "responses", "chat"])
+async def ingress(request, tmp_path, monkeypatch, budget):
+    if budget is not None:
+        monkeypatch.setattr(turn_gateway, "_MAX_REQUEST_BYTES", budget)
+    backend, endpoint, protocol = request.param
+    first = source("src_budget001", [MODEL], vendor="custom", protocol=protocol)
+    second = source("src_budget002", [MODEL], vendor="custom", protocol=protocol)
+    menu_model = MODEL if backend == "opencode" else fixed_model(backend)
+    store = MemoryModelHubStore(config_with_sources(
+        [first, second], backend=backend, menu_model=menu_model,
+        hops=[(first.id, MODEL), (second.id, MODEL)],
+    ))
+    adapter = ModelHubScenarioAdapter(invoke_results=[
+        ScenarioCallResult(RawOutcomeKind.SUCCESS, status=200),
+    ])
+    service = service_for(tmp_path, store, adapter)
+    gateway = turn_gateway.ModelHubTurnGateway(service)
+    base_url, token = await gateway.endpoint(
+        backend,
+        process_scope="fixture-budget",
+        turn_id=TURN,
+        requested_model_id=menu_model,
+        resolved_model_id=MODEL,
+        source_id=first.id,
+    )
+    # Both explicitly supplied stores and implicit service-owned state are private.
+    paths.get_state_dir().relative_to(tmp_path)
+    before = store.load().to_payload()
+    try:
+        yield SimpleNamespace(
+            gateway=gateway, service=service, store=store, adapter=adapter,
+            before=before, backend=backend, protocol=protocol,
+            url=f"{base_url}/v1/{endpoint}", token=token, first=first,
+            menu_model=menu_model,
+        )
+    finally:
+        await gateway.close()
+
+
+def _payload(protocol: str, *, image_chars: int = 0) -> dict:
+    text_type = "input_text" if protocol == "openai_responses" else "text"
+    content = [{"type": text_type, "text": TEXT}]
+    for index in range(20 if image_chars else 0):
+        # Synthetic base64-shaped content, not images or history from a user.
+        data = "iVBORw0KGgo" + chr(ord("A") + index) * image_chars + "="
+        if protocol == "anthropic":
+            image = {"type": "image", "source": {
+                "type": "base64", "media_type": "image/png", "data": data,
+            }}
+        elif protocol == "openai_responses":
+            image = {"type": "input_image", "image_url": f"data:image/png;base64,{data}"}
+        else:
+            image = {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{data}"}}
+        content.append(image)
+    field = "input" if protocol == "openai_responses" else "messages"
+    return {"model": MODEL, field: [{"role": "user", "content": content}], "stream": False}
+
+
+def _encode(payload: dict) -> bytes:
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+
+
+async def _chunks(body: bytes):
+    # Split a multibyte character deliberately; framing must not change byte semantics.
+    split = body.find(TEXT.encode("utf-8"))
+    split = split + 1 if split >= 0 else 1
+    yield body[:split]
+    for offset in range(split, len(body), 64 * 1024):
+        yield body[offset:offset + 64 * 1024]
+
+
+async def _post(ingress, body: bytes, framing: str, *, token: str | None = None):
+    async with aiohttp.ClientSession(trust_env=False) as client:
+        async with client.post(
+            ingress.url,
+            data=_chunks(body) if framing == "chunked" else body,
+            headers={
+                "Authorization": f"Bearer {ingress.token if token is None else token}",
+                "Content-Type": "application/json; charset=utf-8",
+                "anthropic-version": "2023-06-01",
+                "openai-beta": "fixture",
+            },
+        ) as response:
+            headers = response.request_info.headers
+            if framing == "chunked":
+                assert headers["Transfer-Encoding"] == "chunked"
+                assert "Content-Length" not in headers
+            else:
+                assert int(headers["Content-Length"]) == len(body)
+                assert "Transfer-Encoding" not in headers
+            return response.status, await response.json(), response.headers
+
+
+def _assert_not_admitted(ingress) -> None:
+    assert ingress.adapter.invocations == []
+    assert ingress.adapter.requests == []
+    assert ingress.adapter.synced == []
+    assert len(ingress.adapter.invoke_results) == 1
+    assert ingress.store.saved_payloads == []
+    assert ingress.store.load().to_payload() == ingress.before
+    assert ingress.service.events.list() == []
+    assert ingress.service.usage.window(days=1, now=ingress.service.now()) == []
+    assert ingress.gateway.resource_leak_records == ()
+
+
+def _settle(ingress, *, settled_by=SETTLED_BY_TERMINAL_RESULT):
+    ingress.gateway.correlation.settle(TURN, settled_by=settled_by)
+    return ingress.service.provenance.get(TURN)
+
+
+def _assert_local_failure(ingress) -> None:
+    _assert_not_admitted(ingress)
+    if ingress.backend == "opencode":
+        # Shared OpenCode processes intentionally cannot attribute one HTTP call.
+        assert TURN not in ingress.gateway.correlation._traces
+        assert _settle(ingress) is None
+        return
+    projection = ingress.gateway.correlation._traces[TURN].terminal_outcome
+    assert projection.outcome == "failed_terminal"
+    assert projection.discriminator == "request_nonfallback"
+    record = _settle(ingress)
+    assert record["outcome"] == "failed_terminal"
+    assert record["requested_model_id"] == ingress.menu_model
+    assert record["terminal_error"] == {
+        "source_id": ingress.first.id,
+        "configured_model_id": MODEL,
+        "channel": "hub",
+        "reason": "invalid_parameter",
+        "stream_started": False,
+    }
+    assert record["served"] is None
+    assert record["failed_attempts"] == []
+
+
+@pytest.mark.parametrize("framing", ["content-length", "chunked"])
+async def test_large_multi_image_request_is_forwarded_exactly(ingress, framing):
+    """MH-REQUEST-BUDGET-001: ~42 MiB of synthetic images survive real HTTP ingress."""
+    assert turn_gateway._MAX_REQUEST_BYTES == 128 * MIB
+    assert len(TEXT.encode("utf-8")) == 39
+    payload = _payload(ingress.protocol, image_chars=42 * MIB // 20 // 4 * 4)
+    body = _encode(payload)
+    assert 42 * MIB <= len(body) < 43 * MIB
+    status, _result, _headers = await _post(ingress, body, framing)
+    assert status == 200
+    assert ingress.adapter.invocations == [(ingress.first.id, MODEL, ingress.backend)]
+    forwarded, = ingress.adapter.requests
+    assert forwarded == payload
+    assert _encode(forwarded) == body
+    assert forwarded.protocol == ingress.protocol
+    assert forwarded.headers == {"anthropic-version": "2023-06-01", "openai-beta": "fixture"}
+    record = _settle(ingress)
+    if ingress.backend == "opencode":
+        assert record is None
+    else:
+        assert record["outcome"] == "served"
+        assert record["served"]["configured_model_id"] == MODEL
+
+
+@pytest.mark.parametrize("framing", ["content-length", "chunked"])
+@pytest.mark.parametrize("delta", [-1, 0, 1], ids=["below", "equal", "over"])
+@pytest.mark.parametrize("language", ["en", "zh"])
+@pytest.mark.parametrize("budget", [4096])
+async def test_request_budget_is_inclusive_and_local(ingress, caplog, framing, delta, language):
+    """MH-REQUEST-BUDGET-002: equal bytes pass; +1 is a local 413 without admission."""
+    ingress.gateway._language_provider = lambda: language
+    payload = _payload(ingress.protocol)
+    encoded = _encode(payload)
+    body = encoded + b" " * (4096 + delta - len(encoded))
+    assert len(body) == 4096 + delta
+    assert len(body.decode("utf-8")) < 4096
+    status, result, headers = await _post(ingress, body, framing)
+    if delta <= 0:
+        assert status == 200
+        assert ingress.adapter.requests == [payload]
+        assert ingress.adapter.requests[0].protocol == ingress.protocol
+        return
+    assert status == 413
+    assert result == {"error": {
+        "type": "request_too_large",
+        "code": "request_too_large",
+        "message": t("modelHub.errors.request_too_large", language, limit_mib="0.00390625"),
+    }}
+    assert headers["Cache-Control"] == "no-store"
+    assert headers["X-Content-Type-Options"] == "nosniff"
+    assert "Retry-After" not in headers
+    assert TEXT not in json.dumps(result, ensure_ascii=False) + caplog.text
+    assert ingress.token not in json.dumps(result) + caplog.text
+    _assert_local_failure(ingress)
+
+
+@pytest.mark.parametrize("framing", ["content-length", "chunked"])
+@pytest.mark.parametrize("body", [b"{", b"x" * 4097], ids=["malformed", "oversized"])
+@pytest.mark.parametrize("budget", [4096])
+async def test_bad_auth_does_not_parse_or_admit(ingress, monkeypatch, framing, body):
+    """MH-REQUEST-BUDGET-003: invalid credentials never reach JSON parsing or admission."""
+    async def unexpected_json(*args, **kwargs):
+        pytest.fail("an unauthenticated request reached JSON parsing")
+
+    monkeypatch.setattr(web.Request, "json", unexpected_json)
+    status, result, _headers = await _post(ingress, body, framing, token="invalid-fixture-token")
+    assert status == 401
+    assert result["error"]["code"] == "authentication_error"
+    _assert_not_admitted(ingress)
+
+
+@pytest.mark.parametrize("framing", ["content-length", "chunked"])
+@pytest.mark.parametrize("body", [b"{", b'{"model":"\xff"}', b"[]"], ids=["json", "utf8", "array"])
+async def test_malformed_json_is_a_correlated_local_400(ingress, framing, body):
+    """Malformed JSON remains distinct from the local size boundary."""
+    status, result, _headers = await _post(ingress, body, framing)
+    assert status == 400
+    assert result["error"]["code"] == "invalid_request_error"
+    assert result["error"]["message"] == t("modelHub.launch.request_incompatible", "en")
+    _assert_local_failure(ingress)
+
+
+async def _open_partial_upload(ingress, framing: str, body: bytes, *, token: str | None = None):
+    url = urlsplit(ingress.url)
+    reader, writer = await asyncio.open_connection(url.hostname, url.port)
+    framing_header = "Transfer-Encoding: chunked" if framing == "chunked" else "Content-Length: 8192"
+    headers = (
+        f"POST {url.path} HTTP/1.1\r\n"
+        f"Host: {url.netloc}\r\n"
+        f"Authorization: Bearer {ingress.token if token is None else token}\r\n"
+        f"{framing_header}\r\nContent-Type: application/json\r\n\r\n"
+    ).encode("ascii")
+    # Neither framing completes: the server must respond or cancel mid-upload.
+    prefix = f"{len(body):x}\r\n".encode("ascii") + body + b"\r\n" if framing == "chunked" else body
+    writer.write(headers + prefix)
+    await writer.drain()
+    return reader, writer
+
+
+async def _read_json_response(reader):
+    head = await asyncio.wait_for(reader.readuntil(b"\r\n\r\n"), timeout=2)
+    status = int(head.split(b"\r\n", 1)[0].split()[1])
+    headers = dict(line.split(b": ", 1) for line in head.split(b"\r\n")[1:-2])
+    body = await asyncio.wait_for(reader.readexactly(int(headers[b"Content-Length"])), timeout=2)
+    return status, json.loads(body)
+
+
+@pytest.mark.parametrize("framing", ["content-length", "chunked"])
+@pytest.mark.parametrize("budget", [4096])
+async def test_oversize_rejection_does_not_wait_for_upload_eof(ingress, framing):
+    """MH-REQUEST-BUDGET-002: exceeding the budget rejects an unfinished upload."""
+    reader, writer = await _open_partial_upload(ingress, framing, b" " * 4097)
+    try:
+        status, result = await _read_json_response(reader)
+        assert status == 413
+        assert result["error"]["code"] == "request_too_large"
+        _assert_local_failure(ingress)
+    finally:
+        writer.close()
+        await writer.wait_closed()
+
+
+@pytest.mark.parametrize("framing", ["content-length", "chunked"])
+@pytest.mark.parametrize(
+    ("ingress", "ending"),
+    [(case, ending) for case in WIRE_CASES for ending in ("disconnect", "stop")
+     if case[0] != "opencode" or ending == "disconnect"],
+    indirect=["ingress"],
+)
+async def test_partial_upload_cancellation_releases_turn_without_admission(ingress, monkeypatch, framing, ending):
+    """Cancellation during the real body read leaves no Source or usage facts."""
+    entered = asyncio.Event()
+    left = asyncio.Event()
+    original_json = web.Request.json
+
+    async def observe_read(request, **kwargs):
+        entered.set()
+        try:
+            return await original_json(request, **kwargs)
+        finally:
+            left.set()
+
+    monkeypatch.setattr(web.Request, "json", observe_read)
+    _reader, writer = await _open_partial_upload(ingress, framing, b'{"model":')
+    try:
+        await asyncio.wait_for(entered.wait(), timeout=2)
+        assert not left.is_set()
+        if ending == "disconnect":
+            writer.close()
+            await writer.wait_closed()
+            await asyncio.wait_for(left.wait(), timeout=2)
+            await ingress.gateway._drain_turn_requests(TURN)
+            record = _settle(ingress, settled_by=SETTLED_BY_STOPPED)
+        else:
+            completion = ingress.gateway.finalize_turn(
+                TURN,
+                settled_by=SETTLED_BY_STOPPED,
+                finish=lambda: _settle(ingress, settled_by=SETTLED_BY_STOPPED),
+            )
+            assert completion is not None
+            await asyncio.wait_for(completion, timeout=2)
+            assert left.is_set()
+            record = ingress.service.provenance.get(TURN)
+        _assert_not_admitted(ingress)
+        assert ingress.gateway._turn_requests == {}
+        if ingress.backend == "opencode":
+            assert record is None
+        else:
+            assert record["outcome"] == "canceled"
+            assert record["terminal_error"] is None
+            # Stop freezes the prepared identity before teardown; a disconnect
+            # clears it before settlement. Neither represents adapter admission.
+            assert record["canceled_attempt"] == ({
+                "source_id": ingress.first.id,
+                "configured_model_id": MODEL,
+                "channel": "hub",
+            } if ending == "stop" else None)
+    finally:
+        writer.close()
+        await writer.wait_closed()

--- a/vibe/i18n/en.json
+++ b/vibe/i18n/en.json
@@ -975,6 +975,7 @@
       "candidate_suppliers_changed": "The available suppliers changed. Reload the model choices and confirm again.",
       "models_dev_unavailable": "models.dev is unavailable. Enter the model metadata manually or retry later.",
       "codex_catalog_unavailable": "Codex could not prepare the local Model Hub catalog. Retry this turn.",
+      "request_too_large": "This request exceeds Avibe's local {limit_mib} MiB request limit. Reduce the images or conversation context and retry.",
       "engine_down": "The local model gateway is unavailable.",
       "engine_down_streamed": "The local model gateway is unavailable. This turn's output may be incomplete.",
       "migration_item_conflict": "This migration item conflicts with the current model gateway state.",

--- a/vibe/i18n/zh.json
+++ b/vibe/i18n/zh.json
@@ -975,6 +975,7 @@
       "candidate_suppliers_changed": "可用供应商已发生变化，请刷新模型选项后重新确认。",
       "models_dev_unavailable": "models.dev 当前不可用，请手动填写模型参数或稍后重试。",
       "codex_catalog_unavailable": "Codex 无法准备本地模型网关目录，请重试本回合。",
+      "request_too_large": "请求超过 Avibe 本地网关的 {limit_mib} MiB 大小上限。请减少图片或对话上下文后重试。",
       "engine_down": "本地模型网关不可用。",
       "engine_down_streamed": "本地模型网关不可用。本回合输出可能不完整。",
       "migration_item_conflict": "此迁移项与当前模型网关状态冲突。",


### PR DESCRIPTION
Multi-image conversation context can exceed the gateway's former 16 MiB cap even when the latest user message is small. The authenticated Messages, Responses, and Chat Completions gateway now accepts valid bodies through **128 MiB inclusive**. Larger bodies receive a localized structured `413 request_too_large` before adapter admission.

The gateway continues using aiohttp's byte reader for both Content-Length and chunked requests. Local rejection preserves `request_nonfallback` turn facts and refines copy at the existing commit/render owner without changing Source health, fallback, usage, authentication, or cancellation.

The limit passed to aiohttp compensates for its exclusive threshold before 3.14; 3.14 and later use the inclusive threshold directly. This preserves the same byte budget without replacing `request.json`, changing dependency pins, or introducing a second reader.

## Validation

- 367 focused tests passed at head `a43abedde6c41027df0658d05693356a0f4605b1`, independently with locked aiohttp 3.13.3 and CI's aiohttp 3.14.3 after merging landed master. This includes 88 real-loopback HTTP cases, five threshold-configuration cases, catalog, structure, turn, and inference waiting/cancellation coverage.
- A ~42 MiB synthetic 20-image-shaped body with 39 bytes of non-ASCII text reaches the fake adapter exactly, for all three protocols and both framing shapes.
- Reduced-budget below/equal/+1 cases, malformed JSON/UTF-8, bad auth without parsing, unfinished oversize uploads, disconnects, and owner cancellation.
- Ruff 0.4.9, Model Hub authority closure, scenario registration, and diff checks passed. GitHub's full `lint` workflow remains the delivery gate.
- Scenarios: `MH-REQUEST-BUDGET-001`, `MH-REQUEST-BUDGET-002`, `MH-REQUEST-BUDGET-003`.

## Known-by-design

- Evidence ends at the fake adapter; this PR does not claim actual engine/provider acceptance or replay the original incident's images. Exhaustive thresholds use 4 KiB rather than allocating 128 MiB per case.
- OpenCode's shared-server requests retain their existing untracked-Turn semantics. Other request errors retain generic incompatible-request copy.
- Request buffering, inference deadlines, spooling, wire observation, routing, credentials, and provider-error behavior are unchanged. No new configuration/UI, per-image cap, or unlimited buffering.
- The shared root-owned plan records all four independently delivered lanes and is now on master through #1959. This PR includes only gateway product changes and its three scenario registrations. No unmerged product dependency, engine pin/release, deployment, or local runtime change.
