### PR TITLE
fix(model-hub): preserve complete model identifiers

### DIFF
--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -2636,9 +2636,8 @@ class ModelHubModelConfig:
             )
         # Spelling is settled here, at the one place a payload becomes a model
         # config, so no admission path can invent a second spelling for one
-        # model and split its usage across two ledger rows. The length bound
-        # stays with the admission surfaces: this constructor also reads files
-        # older releases wrote, and rejecting one of those would fail config load.
+        # model and split its usage across two ledger rows. New-admission checks
+        # stay with callers: this constructor also reads older persisted files.
         from core.handlers.model_hub.identifiers import normalized_model_id
 
         return cls(
@@ -3398,10 +3397,10 @@ class ModelHubAgentSupplyConfig:
         if any(_contains_model_hub_credential_material(model_id) for model_id in routes):
             raise ValueError("Config 'model_hub.agents.routes' contains an invalid model id")
         if backend == "opencode":
-            from core.handlers.model_hub.identifiers import canonical_model_id
+            from core.handlers.model_hub.identifiers import normalized_model_id
 
             for identifier in (*routes, *(model.id for model in models)):
-                if canonical_model_id(identifier) != identifier:
+                if not identifier.strip() or normalized_model_id(identifier) != identifier:
                     raise ValueError("Config 'model_hub.agents.models.id' is invalid")
             if any(model.native_protocol is None for model in models):
                 raise ValueError(

--- a/core/handlers/model_hub/identifiers.py
+++ b/core/handlers/model_hub/identifiers.py
@@ -4,23 +4,14 @@ from __future__ import annotations
 
 import hashlib
 
-# The longest model identifier the hub admits at a boundary that can still refuse
-# one: manual add, upstream discovery, and a client-declared model on source
-# creation. It is deliberately not a load rule — per the persisted-shape rule a
-# file an older release wrote must keep loading — so a live, routable identifier
-# is not always within it, and no surface downstream of config may treat this
-# bound as the set of identifiers that exist.
-MODEL_ID_MAX_LENGTH = 256
-
 # Usage rows shipped with a 200-character readable head. Keep that threshold
 # stable even when a later API admits longer model identifiers, or one upgrade
 # would start writing a second key for the same model's historical usage.
 USAGE_LEDGER_VERBATIM_MAX_LENGTH = 200
 
 # The longest key a usage ledger row can carry: the stable readable head, one
-# separator, and one hex digest. At 265 characters it remains outside the model
-# identifier admission namespace, so an admitted literal cannot collide with a
-# folded key.
+# separator, and one hex digest. A literal model ID spelling such a key is
+# itself folded on live derivation, while persisted keys are read unchanged.
 USAGE_LEDGER_KEY_MAX_LENGTH = (
     USAGE_LEDGER_VERBATIM_MAX_LENGTH + 1 + 2 * hashlib.sha256().digest_size
 )
@@ -39,8 +30,8 @@ def normalized_model_id(value: str) -> str:
     identity — accepting both ``"model-x"`` and ``" model-x"`` would put two rows
     in the tab for one model — so every identifier that enters a config object
     goes through here, including one read from a file an older release wrote.
-    The bound below cannot follow it there: rejecting a persisted value would
-    fail config load, and per the persisted-shape rule a legacy file must load.
+    New admission checks cannot follow it there: rejecting a persisted value
+    would fail config load, and per the persisted-shape rule a legacy file must load.
 
     A value that is nothing but padding therefore comes back unchanged rather
     than emptied. A normalization that turns a loadable file into an unloadable
@@ -51,62 +42,40 @@ def normalized_model_id(value: str) -> str:
 
 
 def canonical_model_id(value: object) -> str | None:
-    """Admit one candidate identifier in its canonical form, or reject it.
+    """Admit a new nonblank identity that storage and transport can represent.
 
-    A model ID is an identity: it is compared, stored in config, sent upstream,
-    and used as a usage-ledger key. Those uses only agree if every one of them
-    means the same thing by "the same model", so admission is decided once here
-    and the surfaces that accept a client-declared identifier store what this
-    returns. An identifier past the bound is refused here, at the one moment a
-    request can still be answered with an error instead of carried forever.
-
-    Deliberately not applied when loading persisted config, and not applied by the
-    usage ledger: per the persisted-shape rule a legacy value must disable nothing
-    and fail nothing, and a call already made under one cannot be un-billed by
-    refusing its identifier afterwards. `normalized_model_id` is the half that
-    applies on load; `usage_ledger_key` is how a metered call gets a bounded key
-    without being refused one.
+    Length is not identity policy. Preserve every canonical code point, including
+    case and Unicode composition, but refuse unpaired surrogates that UTF-8
+    storage and metering cannot encode. Credential checks remain with callers.
+    Loading uses `normalized_model_id`; metering derives `usage_ledger_key`.
+    Neither applies this new-admission rule to historical data.
     """
 
     if not isinstance(value, str):
         return None
     canonical = normalized_model_id(value)
-    if not canonical.strip() or len(canonical) > MODEL_ID_MAX_LENGTH:
+    if not canonical.strip():
+        return None
+    try:
+        canonical.encode("utf-8")
+    except UnicodeEncodeError:
         return None
     return canonical
 
 
 def usage_ledger_key(value: object) -> str | None:
-    """Key one metered call by the identity it ran under, whatever its length.
+    """Derive a live call's historical usage key without a length refusal.
 
-    Admission and metering ask different questions about the same identifier, and
-    only admission may answer no. A request naming a 4KB model is refused and
-    nothing is lost; a call that already reached an upstream was already billed,
-    and the only identity it can be attributed to is the one config holds. So
-    `canonical_model_id` is the wrong question here — a legacy model that
-    `ModelHubModelConfig.from_payload` deliberately keeps loadable and routable
-    would have every one of its calls dropped, and the tab would report an
-    upgraded install as quieter than it actually is.
+    Verbatim keys have at most 200 characters; longer identities fold to a
+    265-character head/digest key. A literal spelling another model's folded key
+    is longer than 200 too, so deriving folds it again. Reading a persisted key
+    must instead use `persisted_ledger_key`. The digest includes the entire
+    canonical identity and its historical encoding must not change.
 
-    The bound therefore folds instead of refusing. A value within the ledger's
-    stable verbatim threshold is its own key; anything longer is keyed by its
-    readable head plus a digest of the whole value, which is bounded, identical
-    across restarts, and separated from other identities by that digest rather
-    than by a prefix an adversary can pad.
-
-    Where the fold starts is the whole of why two distinct models cannot share one
-    row. A verbatim key is at most `USAGE_LEDGER_VERBATIM_MAX_LENGTH` and a folded
-    key is always exactly `USAGE_LEDGER_KEY_MAX_LENGTH`: two populations a length
-    test tells apart. The folded length also remains above `MODEL_ID_MAX_LENGTH`,
-    so no newly admitted model can occupy it literally. Fold later and the
-    populations overlap, and the folded form stops being ours — a config may hold
-    any legacy string, including the literal `<head>~<digest>` of another model it
-    also holds, and that second model would then be keyed verbatim onto the first
-    model's row and billed for its calls. No marker can close that gap, because a
-    legacy identifier can carry any marker too.
-
-    Only a value carrying no identity at all — not text, or empty — has no key,
-    and that is exactly the set no config can hold.
+    This is not a guarantee over malformed legacy text. Unencodable surrogates
+    and all-whitespace legacy IDs have existing encoding/attribution defects;
+    see docs/plans/model-hub-identifier-boundary-assessment.md. Do not guess a
+    migration of those rows while changing admission.
     """
 
     if not isinstance(value, str) or not value:
@@ -122,7 +91,7 @@ def persisted_ledger_key(value: object) -> str | None:
     """Accept one key a ledger row already carries, or refuse the row.
 
     The other direction, and the reason deriving a key is not idempotent: a folded
-    key is past the admission bound by construction, so feeding it back through
+    key is past the verbatim threshold by construction, so feeding it back through
     `usage_ledger_key` would fold it a second time and orphan the row it came from.
     The read path must therefore recognize a stored key rather than re-derive it.
 
@@ -133,8 +102,9 @@ def persisted_ledger_key(value: object) -> str | None:
     can produce is a corrupt row, and dropping it loses a claim rather than a call.
 
     Whitespace still normalizes, because a row written by a release that spelled an
-    identity with padding names the same model as one that did not, and two rows for
-    one model would double it in the tab.
+    identity with padding names the same model as one that did not. The historical
+    all-whitespace exception is recorded in the identifier assessment; changing
+    this reader cannot recover attribution from already merged counters.
     """
 
     if not isinstance(value, str) or not value:

--- a/core/handlers/model_hub/json_wire.py
+++ b/core/handlers/model_hub/json_wire.py
@@ -75,18 +75,24 @@ class _Container:
 class SelectiveJSONParser:
     """Parse only selected paths while skipping every unrelated value in place.
 
-    Strings and numbers are bounded lexical tokens. Selected containers retain
-    path state; an unrelated subtree uses a packed grammar stack, so nesting
-    costs bits rather than Python objects without weakening JSON validation.
+    Strings and numbers are bounded lexical tokens by default. Callers may
+    retain complete string values at explicit selected paths for facts such as
+    identifiers. Object keys and unrelated values remain bounded. Selected
+    containers retain path state; an unrelated subtree uses a packed grammar
+    stack without weakening JSON validation.
     """
 
     def __init__(
         self,
         paths: Iterable[JSONPath],
         visitor: JSONVisitor,
+        *,
+        lossless_string_paths: Iterable[JSONPath] = (),
     ) -> None:
-        self._root = _path_tree(paths)
+        selected_paths = frozenset(paths)
+        self._root = _path_tree(selected_paths)
         self._visitor = visitor
+        self._lossless_string_paths = selected_paths.intersection(lossless_string_paths)
         self._stack: list[_Container] = []
         self._root_state = "value"
         self._skip_depth = 0
@@ -97,6 +103,7 @@ class SelectiveJSONParser:
         self._mode: Literal["normal", "string", "number", "literal"] = "normal"
         self._string = bytearray()
         self._string_too_long = False
+        self._string_lossless = False
         self._escaped = False
         self._unicode_escape_digits = 0
         self._string_decoder = codecs.getincrementaldecoder("utf-8")()
@@ -209,6 +216,9 @@ class SelectiveJSONParser:
         if byte in b" \t\r\n":
             return
         if byte == 0x22:
+            # Resolve while the parser still expects a value. Keys and skipped
+            # subtrees have no selected value path and never opt into retention.
+            self._string_lossless = self.next_value_path in self._lossless_string_paths
             self._mode = "string"
             self._string.clear()
             self._string_too_long = False
@@ -317,6 +327,9 @@ class SelectiveJSONParser:
         return offset
 
     def _retain_string_bytes(self, payload: bytes) -> None:
+        if self._string_lossless:
+            self._string.extend(payload)
+            return
         remaining = JSON_STRING_TOKEN_BYTES - len(self._string)
         if remaining > 0:
             self._string.extend(payload[:remaining])
@@ -652,8 +665,10 @@ def project_json_reader(
     reader: BinaryIO,
     paths: Iterable[JSONPath],
     visitor: JSONVisitor,
+    *,
+    lossless_string_paths: Iterable[JSONPath] = (),
 ) -> bool:
-    parser = SelectiveJSONParser(paths, visitor)
+    parser = SelectiveJSONParser(paths, visitor, lossless_string_paths=lossless_string_paths)
     while chunk := reader.read(JSON_IO_CHUNK_BYTES):
         parser.feed(chunk)
     return parser.finish()

--- a/core/handlers/model_hub/migration.py
+++ b/core/handlers/model_hub/migration.py
@@ -23,6 +23,7 @@ from core.handlers.model_hub.adapter import (
     SourceObservation,
 )
 from core.handlers.model_hub.events import contains_credential_material
+from core.handlers.model_hub.identifiers import canonical_model_id
 from core.handlers.model_hub.reasoning_tiers import resolve_reasoning_tiers
 from vibe.backend_model_catalog import (
     backend_model_entries,
@@ -430,11 +431,8 @@ def _opencode_manual_models(
         return ()
     models: list[NativeManualModel] = []
     for model_id, model_config in raw_models.items():
-        if (
-            not isinstance(model_id, str)
-            or not model_id.strip()
-            or contains_credential_material(model_id.strip())
-        ):
+        model_id = canonical_model_id(model_id)
+        if model_id is None or contains_credential_material(model_id):
             continue
         raw_name = model_config.get("name") if isinstance(model_config, dict) else None
         display_name = raw_name.strip() if isinstance(raw_name, str) and raw_name.strip() else None
@@ -442,7 +440,7 @@ def _opencode_manual_models(
             display_name = None
         models.append(
             NativeManualModel(
-                id=model_id.strip(),
+                id=model_id,
                 display_name=display_name,
             )
         )

--- a/core/handlers/model_hub/service.py
+++ b/core/handlers/model_hub/service.py
@@ -1371,6 +1371,14 @@ class ModelHubService:
             validated = validate_source_observation(observation)
         except (TypeError, ValueError):
             raise ModelHubError("discovery_failed", status=502)
+        if any(canonical_model_id(model.id) is None for model in validated.models):
+            raise ModelHubError("discovery_failed", status=502)
+        try:
+            for model in validated.models:
+                for parameter in model.supported_parameters or ():
+                    parameter.encode("utf-8")
+        except UnicodeEncodeError:
+            raise ModelHubError("discovery_failed", status=502) from None
         if contains_credential_material(
             [
                 {
@@ -2738,10 +2746,8 @@ class ModelHubService:
                 model.provenance != "manual"
                 or model.reasoning_efforts_source not in {None, "user"}
                 # The same admission rule the manual-add surface applies. A source
-                # may be created with its models inline, so this is the other way a
-                # client-declared identifier enters config — and a client can still
-                # be told no, which is the one moment an unbounded identifier is
-                # refusable rather than something every later surface must carry.
+                # may be created with its models inline, so these newly supplied
+                # identities must be representable before any credential work.
                 or canonical_model_id(model.id) is None
                 or contains_credential_material(model.id)
                 or contains_credential_material(model.display_name or "")
@@ -3702,7 +3708,7 @@ class ModelHubService:
             if source is None or not self._eligible_for_agent(source, backend):
                 raise ModelHubError("mapping_target_unavailable", status=409)
             # Existing exact targets keep their load-time identity; only a new
-            # source/target identity is subject to the current admission bound.
+            # source/target identity is subject to new-ID admission.
             persisted_target = (hop.source_id, hop.model_id) in old_pairs or any(
                 model.id == hop.model_id for model in source.models
             )
@@ -4206,11 +4212,6 @@ class ModelHubService:
                 raise ModelHubError("backend_model_catalog_invalid")
             if backend != "opencode" and model.native_protocol is not None:
                 raise ModelHubError("backend_model_catalog_invalid")
-            if backend == "opencode" and cls._backend_model_admission_error(
-                "opencode",
-                model.id,
-            ):
-                raise ModelHubError("backend_model_id_invalid")
             rows.append(model)
         if len({model.id for model in rows}) != len(rows):
             raise ModelHubError("backend_model_duplicate")
@@ -4712,7 +4713,7 @@ class ModelHubService:
 
     @staticmethod
     def models_dev_matches(query: object) -> list[dict]:
-        if not isinstance(query, str) or not query.strip() or len(query) > 256:
+        if not isinstance(query, str) or not query.strip():
             raise ModelHubError("mapping_target_unavailable")
         from vibe.models_dev_catalog import search_models_dev
 
@@ -5121,7 +5122,7 @@ class ModelHubService:
             raise ModelHubError("discovery_failed")
         model_id = payload["model"]
         # This selects an existing inventory identity, not a newly admitted ID.
-        # Legacy persisted IDs remain testable even beyond today's input bound.
+        # Legacy persisted IDs retain their load-time spelling.
         if not isinstance(model_id, str) or not model_id.strip():
             raise ModelHubError("discovery_failed")
         model_id = normalized_model_id(model_id)

--- a/docs/plans/model-hub-contracts/agent-supply.schema.json
+++ b/docs/plans/model-hub-contracts/agent-supply.schema.json
@@ -146,7 +146,7 @@
         "checked": {
           "type": "array",
           "description": "Bare canonical model identifiers, stored exactly as the backend emits them.",
-          "items": { "type": "string", "minLength": 1, "maxLength": 256, "pattern": "^\\S(?:[\\s\\S]*\\S)?$" },
+          "items": { "type": "string", "minLength": 1, "pattern": "^\\S(?:[\\s\\S]*\\S)?$" },
           "uniqueItems": true
         }
       }

--- a/docs/plans/model-hub-contracts/backend-model.schema.json
+++ b/docs/plans/model-hub-contracts/backend-model.schema.json
@@ -29,7 +29,7 @@
     "id": {
       "type": "string",
       "minLength": 1,
-      "description": "The exact canonical identifier shown to and emitted by the backend Agent. OpenCode stores this bare id without an overlay provider prefix. Mutation admission limits newly added identifiers to 256 characters."
+      "description": "The exact canonical identifier shown to and emitted by the backend Agent. OpenCode stores this bare id without an overlay provider prefix. New identifiers must be nonblank, credential-free Unicode representable as UTF-8; no model-ID length ceiling applies."
     },
     "display_name": {
       "type": ["string", "null"],

--- a/docs/plans/model-hub-identifier-boundary-assessment.md
+++ b/docs/plans/model-hub-identifier-boundary-assessment.md
@@ -5,7 +5,8 @@
 Implemented locally after the recorded decision from orchestrator Session
 `sesvmgbdub2gp` at integration commit
 `d5adacdba42783f49dc0c40745fa25d5af8fcf7e`. The decision was read directly from
-the integration worktree; the shared plan was not edited or cherry-picked.
+the integration worktree. The later independent-delivery decision authorized
+importing the six root-owned shared-document commits without editing them.
 The boundary inventory below records the diagnosed base; the implementation
 record at the end describes the completed repair and its remaining gates.
 
@@ -308,8 +309,10 @@ After implementation, run the corresponding focused tests and changed-Python
 Ruff first, then relevant Model Hub/authority/scenario checks. UI changes require
 the relevant Vitest cases, test type checking, and `npm run build`. The
 orchestrator owns integrated validation, exact-current-commit Codex review, CI,
-thread inventory, and the single PR. No push, PR, Watch, merge, release, deploy,
-or local service restart is authorized for this lane.
+thread inventory, and final merge. The later independent-delivery authorization
+allows this lane to push its task branch, open its own PR, and retain one durable
+combined PR/CI Watch. It does not authorize lane-executed merge, release, deploy,
+or local service restart.
 
 ## Implementation record
 
@@ -338,13 +341,14 @@ dependency, schema revision, runtime setting, or ledger migration:
 
 ### Consuming evidence
 
-Final focused verification used the lane-local locked Python environment,
+The pre-split implementation verification at
+`6ee16bcd79e0182ac8d85b57dccf9ac58f811f0c` used the lane-local locked Python environment,
 `python -B -m pytest -q -p no:cacheprovider`, and repository HOME/XDG/backend
 store isolation. Runtime transport tests used a test-owned loopback HTTP
 server, not an installed or pinned engine. Native-import tests used fabricated
 credentials and verified the test-owned native tree's byte digest was unchanged.
 
-| Final verification | Result |
+| Pre-split lane verification | Result |
 | --- | --- |
 | Complete JSON-wire, usage, routing-modes, provenance, and migration-scenario files | 384 passed. |
 | API selection covering identity, catalog, producers, canonical/inline admission, observation/inventory, typeahead, and duplicate spelling | 108 passed; 351 deselected. |
@@ -371,10 +375,11 @@ evidence, not proof of a real engine's interpretation.
 keying generations), 75 recorded calls, repeated writer/read reloads, and exact
 full labels. `MH-USAGE-008` also covers 28 Source/model label-join pairs
 including long Unicode and folded-looking model literals after reload.
-Existing scenario IDs/names remain stable; no registry entry was allocated.
-The historical blanket wording of the registry must not be read as a proof
-over malformed legacy text; the test documentation and this assessment
-explicitly retain that exception.
+Existing scenario IDs remain stable; no registry entry was allocated.
+The root-owned integration repair subsequently qualified the names of
+`MH-USAGE-006/007/008` to the tested valid population. The registry, test
+documentation, and this assessment explicitly retain the malformed legacy
+exceptions.
 
 ### Remaining boundaries and integration handoff
 
@@ -392,10 +397,52 @@ explicitly retain that exception.
   already merged.
 - Shared-file edits stay in the approved admission/load/observation/typeahead
   seams. No gateway envelope, `project_opencode_public_model`, launch
-  capability policy, engine config-generation policy, engine pin, or shared
-  scenario registry was changed. Integration must preserve peers' disjoint
-  hunks in service/config/API-test/runtime-test files.
+  capability policy, engine config-generation policy, or engine pin was
+  changed. The additional authorized config test and three usage scenario
+  descriptions are described below. Integration must preserve peers' disjoint
+  hunks in service/config/API-test/runtime-test/catalog files.
 - The orchestrator owns broad integrated validation, real pinned-engine
-  evidence, exact-head Codex review, CI, and the single PR. This lane only
-  commits locally; no push, PR, Watch, release, deploy, or running-local change
-  was performed.
+  evidence, independent gate verification, and merge execution. This lane
+  delivers its own PR, exact-head review/CI inventory, and durable Watch.
+  No release, deploy, or running-local change is authorized.
+
+## Independent PR delivery
+
+The owner changed delivery authority at 2026-09-09 04:11 +08
+(2026-09-08 20:11 UTC), recorded by root commit
+`752c1def8f6c2978bf1a810c4dd48a8522afaa8c`. Lane C retains Session
+`sesm79v4dhm25` and branch `fix/model-hub-identifier-boundary`; root Session
+`sesvmgbdub2gp` independently verifies all gates and performs the merge.
+The six shared-document commits were imported in their authorized order.
+Landed `origin/master` at `4a504f375b73f9e23b058d914398ec76abf8c1a6`
+was merged normally into this task branch; no peer's unmerged product code
+was copied, rebased, or force-pushed.
+
+Root repair `c263f7f5db7856136f87003acdab0b451c5aeac2` was imported
+as `407c52fd1`. It changes only `tests/test_model_hub_config.py` and the three
+usage scenario descriptions. The structural normalization guard now records
+comparison-only spelling checks separately from producing normalization
+owners, with exact owner sets for both and unchanged collapse-owner assertions.
+Twelve consuming OpenCode cases cover ordinary, long, Unicode, legacy-surrogate,
+padded, and blank identities under both repairing modes; no production or
+duplicate-repair policy changed.
+
+The pre-split counts above are historical lane evidence, not a claim about a
+later PR head. Fresh branch-local tests, Ruff, authority/catalog checks, UI test
+types, and production build are recorded with the submitted head in the PR and
+the lane review inventory. Root's combined-tree and browser counts are not
+attributed to this branch.
+
+The lane owns `/tmp/avibe-model-boundaries.9OVz1v/lane-c-review.md` and
+`/tmp/avibe-model-boundaries.9OVz1v/lane-c-pr-watch.json`; root uses its own
+independent Watch state. Initial findings-bearing reviewed heads are zero.
+The same lane Watch/cursor stays live throughout review rounds, with both
+timeouts disabled. A repeated root-cause class on two reviewed heads, or three
+findings-bearing heads following a model rewrite, pauses edits/pushes for
+the same orchestrator's recorded decision.
+
+Readiness requires an exact-current-head Codex pass, no unresolved paginated
+threads, every expected lint job present and successful in every matching run,
+and a CLEAN open non-draft PR. Once ready, the lane stops editing/pushing,
+durably reports readiness, and leaves the original Watch live until root
+reports the verified merge and explicitly authorizes Watch removal.

--- a/docs/plans/model-hub-identifier-boundary-assessment.md
+++ b/docs/plans/model-hub-identifier-boundary-assessment.md
@@ -2,16 +2,21 @@
 
 ## Status and recommendation
 
-Diagnosis only; no product or test code has changed. Implementation requires a
-recorded decision from orchestrator Session `sesvmgbdub2gp`.
+Implemented locally after the recorded decision from orchestrator Session
+`sesvmgbdub2gp` at integration commit
+`d5adacdba42783f49dc0c40745fa25d5af8fcf7e`. The decision was read directly from
+the integration worktree; the shared plan was not edited or cherry-picked.
+The boundary inventory below records the diagnosed base; the implementation
+record at the end describes the completed repair and its remaining gates.
 
 - Inspected product SHA: `76e269c9a9dfd3a6286ce0da81b77316ca4be38a`.
 - Lane: C; Session `sesm79v4dhm25`; Run `ddca032db570`.
 - Assigned branch: `fix/model-hub-identifier-boundary`.
 - Authority: `model-hub-permissive-boundaries.md`, shared invariant 4.
-- Evidence: 128 existing focused tests passed, plus synthetic reproductions
-  described below. No live services, credentials, upstreams, or user state were
-  exercised.
+- Diagnosis evidence: 128 existing focused tests passed, plus synthetic
+  reproductions described below. Implementation evidence: 524 focused Python
+  tests and 64 UI tests passed. No live services, credentials, upstreams, or
+  user state were exercised.
 
 Remove the model-ID admission length ceiling, its UI/schema mirrors, and the
 typeahead query ceiling. Preserve the existing whitespace spelling rule,
@@ -276,12 +281,13 @@ that removing an application field cap removes generic transport/resource
 limits. Add hermetic HTTP/engine consumer evidence at integration where those
 claims are needed; never infer it from a fake-only test.
 
-## Validation actually run
+## Diagnosis validation
 
 All runs used the existing Python environment read-only, `python -B`, pytest
 with its cache provider disabled, and the repository's per-test HOME/XDG/
 Avibe/backend-store isolation. Synthetic ledger files lived in
-`TemporaryDirectory` and were removed automatically. No product files changed.
+`TemporaryDirectory` and were removed automatically. No product files had
+changed during those diagnosis runs.
 
 | Suite selection | Result |
 | --- | --- |
@@ -304,3 +310,92 @@ the relevant Vitest cases, test type checking, and `npm run build`. The
 orchestrator owns integrated validation, exact-current-commit Codex review, CI,
 thread inventory, and the single PR. No push, PR, Watch, merge, release, deploy,
 or local service restart is authorized for this lane.
+
+## Implementation record
+
+The implementation follows the approved ownership table without adding a
+dependency, schema revision, runtime setting, or ledger migration:
+
+- Removed the new-ID length cap, editor/type/schema mirrors, unused localized
+  length error, and models.dev query cap. New identity admission requires
+  nonblank UTF-8-representable canonical text; credential checks remain with
+  the existing admission owners.
+- OpenCode aggregate load and whole-list parsing no longer reuse new-ID
+  admission. Native-protocol, spelling, route membership, Source eligibility,
+  subscription inventory, and retirement rules remain in place.
+- Added default-empty selected-path lossless string retention to the existing
+  parser. Only inventory IDs and supported-parameter values opt in. Tests
+  prove object keys, other selected strings, unselected strings, ignored
+  trees, malformed JSON, duplicate scopes, and the discovery deadline retain
+  their established behavior.
+- Unsaved observations refuse unencodable IDs and parameters before response
+  encoding, while scanning full credential-bearing values. Native manual
+  imports reuse new-ID admission, including when inventory discovery fails.
+- Compared the computational source of both ledger functions with
+  `76e269c9a9dfd3a6286ce0da81b77316ca4be38a`: byte-for-byte unchanged.
+  The entire `core/handlers/model_hub/usage.py` is unchanged. Only misleading
+  identifier-module comments/docstrings were corrected.
+
+### Consuming evidence
+
+Final focused verification used the lane-local locked Python environment,
+`python -B -m pytest -q -p no:cacheprovider`, and repository HOME/XDG/backend
+store isolation. Runtime transport tests used a test-owned loopback HTTP
+server, not an installed or pinned engine. Native-import tests used fabricated
+credentials and verified the test-owned native tree's byte digest was unchanged.
+
+| Final verification | Result |
+| --- | --- |
+| Complete JSON-wire, usage, routing-modes, provenance, and migration-scenario files | 384 passed. |
+| API selection covering identity, catalog, producers, canonical/inline admission, observation/inventory, typeahead, and duplicate spelling | 108 passed; 351 deselected. |
+| Runtime inventory/discovery, provisioning probe, and long-ID HTTP consumers | 32 passed; 270 deselected. |
+| Editor, catalog dialog, and Source-create UI contract tests | 64 passed. |
+| UI test type checking and production build | Passed; build reported dependency annotation/browser-crypto and chunk-size warnings. |
+| Pinned Ruff 0.4.9 on all 13 changed Python files; whitespace diff check | Passed. |
+
+The complete Source lifecycle preserves two long shared-head Unicode IDs,
+composed/decomposed accents, inline and manual IDs, and an admitted
+folded-looking literal through refresh, upsert, API output, runtime binding,
+and reload. All three backend catalogs accept full long IDs; their legacy
+catalogs remain editable/loadable, and malformed legacy surrogate identities
+still load without being newly admitted.
+
+The runtime consumer tests discover escaped long IDs over HTTP, reload
+`SourceRecord`, serialize exact model names/aliases, and invoke every identity
+plus an unlisted route-only identity through each of the three protocol
+endpoints. Captured request bodies carry the exact prefixed IDs, and successful
+outcomes retain the full Source/model pair. This is Avibe-to-mock-engine wire
+evidence, not proof of a real engine's interpretation.
+
+`MH-USAGE-007` now exercises 25 distinct valid identities (11 seeds plus two
+keying generations), 75 recorded calls, repeated writer/read reloads, and exact
+full labels. `MH-USAGE-008` also covers 28 Source/model label-join pairs
+including long Unicode and folded-looking model literals after reload.
+Existing scenario IDs/names remain stable; no registry entry was allocated.
+The historical blanket wording of the registry must not be read as a proof
+over malformed legacy text; the test documentation and this assessment
+explicitly retain that exception.
+
+### Remaining boundaries and integration handoff
+
+- A percent-encoded 18,000-code-point Unicode path exceeded the test client's
+  generic 65,536-character URL budget before reaching Avibe. The full ID
+  succeeds through JSON body submission, service mutation, runtime HTTP bodies,
+  and reload. Encoded path mutation is separately proven with 3,600 Unicode
+  code points, and the real query route with 5,413 code points. No URI budget was
+  raised or endpoint redesigned. Browser/proxy limits are still outside this
+  field-admission repair.
+- Long all-whitespace historical attribution and already persisted unpaired
+  surrogates remain the documented pre-existing exceptions. No historical
+  counter is rekeyed, split, dropped, or assigned a guessed owner by a migration.
+  A future attribution policy must retain ambiguity where counters were
+  already merged.
+- Shared-file edits stay in the approved admission/load/observation/typeahead
+  seams. No gateway envelope, `project_opencode_public_model`, launch
+  capability policy, engine config-generation policy, engine pin, or shared
+  scenario registry was changed. Integration must preserve peers' disjoint
+  hunks in service/config/API-test/runtime-test files.
+- The orchestrator owns broad integrated validation, real pinned-engine
+  evidence, exact-head Codex review, CI, and the single PR. This lane only
+  commits locally; no push, PR, Watch, release, deploy, or running-local change
+  was performed.

--- a/docs/plans/model-hub-identifier-boundary-assessment.md
+++ b/docs/plans/model-hub-identifier-boundary-assessment.md
@@ -1,0 +1,306 @@
+# Model Hub identifier boundary assessment
+
+## Status and recommendation
+
+Diagnosis only; no product or test code has changed. Implementation requires a
+recorded decision from orchestrator Session `sesvmgbdub2gp`.
+
+- Inspected product SHA: `76e269c9a9dfd3a6286ce0da81b77316ca4be38a`.
+- Lane: C; Session `sesm79v4dhm25`; Run `ddca032db570`.
+- Assigned branch: `fix/model-hub-identifier-boundary`.
+- Authority: `model-hub-permissive-boundaries.md`, shared invariant 4.
+- Evidence: 128 existing focused tests passed, plus synthetic reproductions
+  described below. No live services, credentials, upstreams, or user state were
+  exercised.
+
+Remove the model-ID admission length ceiling, its UI/schema mirrors, and the
+typeahead query ceiling. Preserve the existing whitespace spelling rule,
+credential checks, exact Source/model pairing, and backend-specific admission
+rules. Materialize discovery IDs and their supported-parameter declarations
+losslessly at their selected JSON paths. Keep the default observation parser
+budget for other callers and unrelated values.
+
+Keep the usage key algorithm and persisted key reader unchanged. The ledger
+already folds every identity longer than 200 characters, including a literal
+that happens to spell another identity's folded key. Admission need not stop at
+256 for that separation to work. No ledger migration, new key namespace, or
+new numeric ID limit is necessary for valid nonblank Unicode identifiers.
+
+There are two independently reproducible pre-existing exceptions to the
+ledger's broad claims about every loadable string: long all-whitespace legacy
+IDs, and unpaired UTF-16 surrogate code points. They are not caused by the
+256-character limit. Preserve their evidence and do not silently rewrite
+historical usage to guess an attribution; see the explicit scope recommendation
+below.
+
+## Complete boundary inventory
+
+| Boundary and owner | Inspected behavior | Proposed treatment |
+| --- | --- | --- |
+| `identifiers.py`: `normalized_model_id` | `strip() or value`; no case folding, Unicode normalization, shortening, or length check. Preserves historical padding-only strings on load. | Preserve spelling semantics. |
+| `identifiers.py`: `canonical_model_id` | Requires text, nonblank canonical text, and at most 256 Python characters. Does not itself scan for credentials. | Remove length admission. New admission should also require UTF-8-encodable Unicode, because that is what config, routing, and metering can carry. Keep credential policy with its existing callers. |
+| `service.py`: `add_custom_model` | Canonical admission plus full credential scan; stores canonical ID; existing manual ID is an upsert, discovered ID is managed upstream. | Inherit length-free admission; preserve upsert, origin, and tier authority. |
+| `service.py`: `create_source` inline `models` | Parses `ModelHubModelConfig`, then applies canonical admission and credential scans before observation/custody. | Inherit the same admission; preserve provenance, deduplication, and custody ordering. |
+| `service.py`: `_apply_discovered_models` | Canonicalizes each discovered ID, rejects invalid/credential-bearing/canonical-duplicate batches, preserves manual and retired rows. Used by creation, refresh, source edits, OAuth, reauth, and import. | Inherit length-free admission, without partial inventory acceptance or truncation. |
+| Runtime API-key discovery: `client.py::probe_models` and `_project_model_inventory` | Whole response spools with a 256 KiB memory threshold; projection has an absolute request deadline. Both `data` and `models` accept string rows and `{id: ...}` rows. Any selected ID elided by the JSON string budget fails the selected inventory. | Keep spool/deadline ownership; make the four ID paths lossless. |
+| Runtime OAuth discovery: `adapter.py::_discovered_models` | Management JSON already materializes via `ijson`; extracts `id`, then `alias`, then `name`, or a string row. No ID length ceiling at this layer. | No implementation change; consume the common service admission and test parity. |
+| Unsaved observation: `service.py::_validate_observation`, `_observation_payload` | Validates observation shape and scans the complete ID/parameter payload for credentials; publishes both `models` and `model_metadata`. No independent 256 limit. | Preserve full credential scan. Check IDs and parameter strings are representable before returning them through JSON response encoding. |
+| Native-config import: `migration.py::_opencode_manual_models` and import commit | Trims nonblank IDs, scans credentials, constructs source model configs, and reaches shared discovery/application when observation succeeds. Manual import can survive failed discovery. Native bundled inventory also has no independent length ceiling. | Reuse canonical admission for newly imported manual IDs, preserving exact valid long IDs and the existing skip-invalid-entry behavior. Keep the copy-only lifecycle; no persisted import migration needed. |
+| Catalog admission: `catalog_admission.py` | `backend_model_admission_error` uses canonical admission, preserves Claude prefix/builtin exceptions; `admissible_backend_model` also validates the credential-free persisted shape. | Inherit length-free admission; preserve prefixes, locked/native selectors, metadata validation, and origin rules. |
+| Catalog producers: `service.py::agent_model_candidates`, `_apply_builtin_reconcile`; `models_dev_catalog.py::search_models_dev` | Builtin, provider, and models.dev proposals all use `admissible_backend_model`; a valid long source ID is currently omitted from candidates. | Automatically admit long proposals through that owner; test all producer classes without changing capability projection. |
+| Catalog writes: `service.py::_parse_backend_catalog_models`, `set_agent_models` | New IDs use shared admission. OpenCode additionally reapplies admission to the entire parsed baseline/desired list. Claude/Codex allow edits of historical long IDs. | Keep new-ID checks at the common write boundary. Remove the redundant OpenCode whole-list admission check so new admission is not a legacy-read rule. |
+| Persisted source/hop/model loading: `config/v2_config.py` | Source and hop leaves use `normalized_model_id`; backend model leaves trim and scan credentials without a length ceiling. Parent collections preserve their existing repairing-vs-admitting duplicate policies. | No tightening or new rejection of old source/hop/backend leaf shapes. |
+| Persisted OpenCode aggregate: `ModelHubAgentSupplyConfig.from_payload` | Unlike other backends, reapplies `canonical_model_id` to route keys and catalog IDs; currently rejects a 257-character catalog ID on reload. | Replace admission reuse with explicit existing nonblank/canonical-spelling validation. Keep native protocol, route membership, and menu invariants. |
+| Route writes/read/provenance: `service.py`, `resolver.py`, `provenance.py` | Route identities are exact `(source_id, model_id)` pairs. Existing targets retain load-time identities; only new targets use canonical admission. API-key passthrough, subscription inventory, retirement, menu membership, and guards remain distinct. | New long targets follow exactly the existing source policy. Preserve exact identity on route preview/save/reorder/restore and provenance lookup. |
+| Runtime binding/invocation: `SourceBinding`, runtime `state.py`, `config.py`, `client.py::invoke` | Full IDs populate inventory and route-only IDs. YAML entries carry exact `name` and `alias`; invoke sends `source.prefix + "/" + model_id`. No length truncation found. | No implementation change; consuming tests must compare exact long/non-ASCII targets. Actual pinned-engine interpretation remains lane D's boundary. |
+| Backend launch/overlay: `modules/agents/model_hub.py` | Full requested/target/runtime strings are carried into launch and runtime config; OpenCode provider prefix is separate from bare model identity. | Read-only consumer verification; do not edit lane B's projection code. |
+| Web UI: `BackendModelEditorDialog.tsx`, `types.ts` | Add mode caps input at 256 UTF-16 units and refuses longer resolved IDs. Edit mode preserves full read-only legacy IDs. Source-detail manual input has no matching cap. | Remove the constant, HTML `maxLength`, and `tooLong` branch/copy. Preserve duplicate checks, trim, and read-only edits. |
+| Typeahead: `service.py::models_dev_matches` | Independently rejects queries longer than 256 before calling search; the editor sends its full typed ID. Thus removing only the field cap produces a misleading lookup failure. | Remove this query-length check; preserve nonblank/text validation, search result behavior, cache, and fetched-catalog resource budget. |
+| Web/API/IPC: `modelsApi.ts`, `ui_server.py`, `model_hub_client.py`, `rpc.py`, `internal_server.py` | IDs are passed as JSON strings, encoded query parameters, or an encoded path captured as `path:model_id`; RPC passes the values in JSON. No additional model-specific field cap found. | No endpoint redesign. Exercise encoded slashes/non-ASCII and long values in hermetic consumers; generic transport/body/URI limits are not an unlimited-transport guarantee. |
+| Wire schemas/locales | `backend-model.schema.json` describes a 256 admission limit; `agent-supply.schema.json` actually caps OpenCode `menu.checked` items at 256; both locale bundles carry the editor error. | Update these exact mirrors; do not alter unrelated numeric/resource bounds. |
+| Usage live write: `usage.py::record_many` | Converts live Source/model identities with `usage_ledger_key`, then normalizes stored-key rows. Both resolver and forwarded gateway calls report exact configured identities. | Preserve derivation direction and pair/day aggregation. |
+| Usage read/labels: `_normalize_row`, `_keyed_identities`, `summary`, UI `UsageTab`/`usageProjection` | Reads stored keys with `persisted_ledger_key`; derives config identity keys separately for Source-scoped label joins. Deleted identities retain totals with missing labels. | Preserve keys, history, deleted-source semantics, retention, and presentation. |
+| Diagnostic events and protocol observation | Event `model_id` stays whole while rendered human text is bounded at 200. Protocol observers retain finite machine evidence/presence and bounded private error copies, not model routing identities. | Leave harmless display/observation bounds intact. |
+
+## Why the ledger does not need a migration
+
+For a canonical, nonblank, UTF-8-encodable identifier `x`, the existing rule is:
+
+```text
+K(x) = x                                      when len(x) <= 200
+K(x) = x[:200] + "~" + SHA256(UTF8(x)).hexdigest() otherwise
+R(K(x)) = K(x)                                 persisted-key read
+```
+
+The output populations are at most 200 characters and exactly 265 characters.
+Admission at 256 is not what separates them. Take `x = "m" * 300`, and admit
+`y = K(x)` as another literal model ID: `y` is 265 characters, so its live calls
+are keyed by `K(y)`, not by `y`. A persisted row for `x` is read as `R(y) = y`.
+These are intentionally different operations. Do not make live key derivation
+self-idempotent, recognize hash-shaped live IDs as already keyed, fold at 256,
+or extend the readable head.
+
+The existing SHA-256 collision assumption remains; a finite digest is not a
+mathematical proof of injectivity over arbitrary strings. No additional
+structural collision is introduced by admitting a folded-looking literal.
+
+Local history independently confirms the compatibility requirement:
+`6a40b10e592d7b9ae8ab291769c8dbea47a7711e` raised admission from 200 to 256 and
+introduced `USAGE_LEDGER_VERBATIM_MAX_LENGTH = 200` explicitly to keep previously
+written usage keys stable. This proposal changes neither that algorithm nor
+the stored-row reader, including its permissive treatment of historical keys.
+
+Synthetic evidence used eight seeds spanning 200/201/256/257 characters, CJK
+plus emoji, composed and decomposed accents, and 16,385 ASCII characters. The
+set also included each seed's folded literal and its next folded literal:
+22 distinct identities, 44 calls over two writer instances, 22 separate rows
+after another reload, and exact full labels joined from config. All
+`R(K(x)) == K(x)` assertions passed in that population.
+
+## Discovery: required facts versus observations
+
+`JSON_STRING_TOKEN_BYTES = 16 * 1024` currently budgets the JSON lexical token,
+including escape sequences, rather than the decoded identity.
+
+Measured against the inspected SHA:
+
+| Synthetic input | Current outcome |
+| --- | --- |
+| 256 ASCII characters | Admission, source load, catalog admission, and inventory projection accept. |
+| 257, 265, 4,097, or 16,384 ASCII characters | Source load and inventory projection preserve exact ID; new admission/catalog refuse. |
+| 16,385 ASCII characters | Source load preserves ID; inventory projection fails instead of materializing it. |
+| Same 3,000-character CJK ID, raw UTF-8 JSON | Exact projection succeeds; response is 9,022 bytes. |
+| Same CJK ID, JSON Unicode escapes | Projection fails; response is 18,022 bytes. |
+| `supported_parameters = ["reasoning"]` | Consumer chooses upstream reasoning tiers. |
+| `["reasoning", <16,385-character unknown parameter>]` | Projection changes parameters to `None`; consumer loses upstream reasoning evidence. |
+| `<16,385 spaces> + "reasoning"` as a parameter | Projection elides it even though the real tier consumer trims and recognizes it. |
+
+Neither identity nor supported-parameter evidence is harmless diagnostic text.
+The narrow implementation is a default-empty `lossless_string_paths` option on
+`SelectiveJSONParser` and `project_json_reader`, selected only by
+`_project_model_inventory` for:
+
+```text
+data.*                         models.*                 (string-row IDs)
+data.*.id                      models.*.id              (object-row IDs)
+data.*.supported_parameters.*   models.*.supported_parameters.*
+```
+
+Decide retention at the start of a value token, using its already-selected
+path; never treat an object member name or an unrelated nested string as an
+identity. Retain the complete selected lexical string until decoding, and keep
+all existing JSON grammar, UTF-8 validation, duplicate-member replacement,
+array-scope, whole-document completion, and absolute-deadline behavior.
+
+The result inherently costs memory proportional to the inventory facts that
+the application must retain. This is not a claim of constant memory for a
+materialized unbounded ID. Unrelated subtrees and diagnostic strings continue
+to use the existing bounded parser behavior. Replacing the whole projection
+with a full-object JSON load would unnecessarily retain unrelated upstream
+payloads.
+
+## Encoding and legacy exceptions
+
+New admission should accept nonblank Unicode scalar text, trim the existing
+outer whitespace, and retain every remaining code point exactly. Do not apply
+NFC/NFKC, case folding, slash rewriting, digest substitution, or ellipsis to a
+model identity. Python counts code points and browser `length` counts UTF-16
+units: 129 emoji currently pass Python's 256 limit but exceed the UI's limit.
+Removing both ceilings eliminates that disagreement.
+
+The following exceptions were reproduced at the base SHA and must remain
+visible in the orchestrator's scope decision:
+
+1. **Unpaired surrogates.** A 200-character string ending in `\ud800` passes
+   current admission but cannot be written as UTF-8; at 201 characters, usage
+   hashing raises `UnicodeEncodeError` directly. This is a representability
+   failure, not a meaningful model-name length. Prefer rejecting it at new
+   admission and unsaved observation, while removing admission reuse from
+   persisted OpenCode loading and whole-list catalog parsing. Do not silently
+   replace it with U+FFFD, ignore it, or introduce a new spelling of old IDs.
+   Repairing already persisted malformed strings is separate from admission.
+2. **All-whitespace legacy IDs beyond 200 characters.** A source model of 201
+   spaces still loads, as intended by the historical loader. Its live key is
+   200 spaces plus `~<digest>`, but `persisted_ledger_key` strips that head to
+   a 65-character key. A second legitimate literal ID equal to that shortened
+   key shares its usage row. Actual reproduction: two different identities
+   produced one row with two requests. The label join also derives a key
+   different from the persisted row. Existing `MH-USAGE-006` covers only three
+   spaces and misses this population.
+
+Preferred scope: block newly admitted unencodable identities, preserve loading,
+and leave the existing key format/read behavior intact in this repair.
+Explicitly record the whitespace-only historical collision as a separate
+attribution defect, not a passing invariant or a new limitation on legitimate
+IDs. Blank IDs remain rejected on every new admission path.
+
+This separation has a real compatibility reason: already merged historical
+counters contain no fact that can distinguish a whitespace identity from the
+65-character literal. Rekeying or assigning that total to either model can
+invent attribution or split historical usage. If the orchestrator elects to
+repair this pre-existing class now, it needs a separately recorded
+ambiguous-history policy and expanded ledger ownership before implementation;
+the lane should not guess. No owner escalation is required merely to choose
+the narrow, reversible admission scope.
+
+Synthetic credential-shaped text at both the head and tail of a 17 KB ID was
+detected by the existing full-value credential scanner, and refused by both
+source and backend config validators. These are fabricated fixtures, not keys.
+Retain those scans after full materialization, including parameter metadata;
+never validate only the readable ledger head or a shortened diagnostic copy.
+
+## Concrete implementation ownership
+
+Proposed product files, limited to these symbols/concerns:
+
+| File | Lane C change |
+| --- | --- |
+| `core/handlers/model_hub/identifiers.py` | Delete admission length constant/check; representability at new admission; correct comments claiming 256 protects folded keys. Preserve both ledger algorithms byte-for-byte. |
+| `core/handlers/model_hub/json_wire.py` | Default-empty selected-path lossless string retention, with unchanged default behavior. |
+| `vibe/model_hub_runtime/client.py` | Opt inventory identity/parameter paths into lossless retention only. |
+| `core/handlers/model_hub/service.py` | Observation ID/parameter representability; remove redundant OpenCode whole-list admission and typeahead query ceiling; update directly misleading identity-bound comments. |
+| `core/handlers/model_hub/migration.py` | Reuse canonical admission in `_opencode_manual_models`, so a failed discovery cannot bypass the representability rule for newly imported IDs. |
+| `config/v2_config.py` | OpenCode aggregate uses load-time spelling checks, not new admission; update directly misleading length-bound comments. |
+| `ui/src/components/settings/models/BackendModelEditorDialog.tsx` | Remove add-mode ID length check and HTML cap. |
+| `ui/src/components/settings/models/types.ts` | Remove `BACKEND_MODEL_ID_MAX_LENGTH`. |
+| `ui/src/i18n/en.json`, `ui/src/i18n/zh.json` | Remove the unused model-editor `tooLong` entry only. |
+| `docs/plans/model-hub-contracts/backend-model.schema.json` | Correct ID description. |
+| `docs/plans/model-hub-contracts/agent-supply.schema.json` | Remove only the model-ID `menu.checked` maximum. |
+
+Focused test ownership:
+
+- `tests/test_model_hub_api.py`: all admission producers, credential refusal,
+  candidate producers, catalog writes, API round trips, long-query typeahead.
+- `tests/test_model_hub_routing_modes.py`: replace length refusals with
+  source-policy assertions; include OpenCode in long catalog reload coverage.
+- `tests/test_model_hub_provenance.py`: replace removed-constant fixtures with
+  explicit historical lengths; preserve membership-only refusal.
+- `tests/test_model_hub_usage.py`: retain `MH-USAGE-006/007/008` consuming
+  assertions, add long valid Unicode/fold-closure/reload cases; remove
+  dependency on the admission constant without changing expected ledger keys.
+- `tests/test_model_hub_json_wire.py`, `tests/test_model_hub_runtime.py`:
+  lossless selected paths versus bounded unrelated text; inventory shape and
+  duplicate semantics; supported-parameter consumer evidence.
+- `tests/scenarios/model_hub/test_model_hub_migration_scenarios.py`: existing
+  native-provider import harness with long/invalid manual IDs and failed
+  discovery, without changing import/custody authority.
+- `ui/src/components/settings/models/BackendModelEditorDialog.test.tsx`:
+  long paste/submit, Unicode, duplicate and existing-row behavior.
+
+The existing scenario IDs cover loadability, usage separation, and label joins;
+keep those test names and IDs stable. If integration needs a new scenario ID or
+catalog entry, coordinate its allocation with the orchestrator. This diagnosis
+does not edit the shared plan or scenario catalog.
+
+Lane A owns gateway request envelopes and their locale keys; C does not edit
+`turn_gateway.py`. Lane B owns capability/limit projection; shared
+`service.py`, config, or API-test file changes must be integrated by disjoint
+functions, with no edits to projection policy. Lane D owns the pinned engine,
+runtime reasoning policy, build/release plan, and engine-wire evidence; C does
+not edit engine config generation, manifest, or adapter execution. C's runtime
+client change is restricted to inventory projection and uses the unchanged
+discovery deadline.
+
+The admission/load distinction and opt-in parser argument are local contracts.
+They require no new dependency, schema revision, allocated key namespace,
+cross-lane runtime flag, or engine release. Reverting them leaves existing
+ledger bytes untouched; an older build's existing OpenCode long-ID loader
+restriction still applies if new long catalog rows are taken back to it. Do
+not describe reverting source code as a promise of downgrade compatibility for
+newly supported data.
+
+## Acceptance matrix after approval
+
+| Population or boundary | Required result |
+| --- | --- |
+| 200/201, 256/257, 264/265/266, 4,097, 16,384/16,385-character IDs | Admit and preserve full identity where source/backend policy allows; no new fixed ceiling. |
+| Two names sharing a head but differing arbitrarily far into the tail | Distinct routes, runtime targets, usage rows, and labels. |
+| Literal `K(x)`, `K(K(x))`, and their source/model Cartesian pairs | Live key derivation remains separate from persisted key read; no structural collision. |
+| CJK, supplementary-plane emoji, composed/decomposed accents, encoded slash | Same exact canonical ID through UI/API, config, runtime binding, provenance, usage, and reload; distinct accents remain distinct. |
+| Raw UTF-8 versus JSON `\u` escapes, all inventory shapes | Same decoded ID and metadata, independent of lexical expansion. |
+| Large unrelated string/tree beside inventory | Required IDs/parameters survive; ignored data and default parser diagnostics remain bounded. |
+| Duplicate JSON members/IDs and padded equivalent identities | Preserve current last-member/first-complete-record semantics at the parser and canonical-batch rejection at service admission. |
+| Long `supported_parameters` alongside or containing recognized reasoning evidence | Lossless materialization reaches the existing tier consumer; malformed non-string metadata still degrades as currently specified. |
+| Empty/nontext/blank or newly supplied unpaired surrogate | Structured non-secret refusal before persistence/observation response encoding; native inventory import retains its existing skip-invalid-entry behavior. |
+| Credential-shaped prefix/tail/metadata beyond former budgets | Full-value scan rejects; nothing leaks into config, API output, events, or ledger. |
+| Source manual add, inline create, discovery/refresh/import, builtin/provider/models.dev proposals | Same ID spelling/admission owner, with existing per-surface authority intact. |
+| Catalog reload/edit and route preview/save/restore for all three backends | Long existing IDs remain usable; no admission rule reintroduced into loading. |
+| Unknown API-key target versus subscription target; retired model | Existing source eligibility and retirement policy unchanged. |
+| Old ordinary/folded ledger rows followed by new calls and multiple reloads | Exact same key and aggregate; no silent row drop, double fold, duplicate counting, or label loss. |
+| Deleted Source/model with retained usage | Historical totals remain, labels absent for the removed pair. |
+| Long model pasted into editor | Submit whole ID, no `maxLength`/`tooLong`; lookup does not fail solely because query exceeds 256. |
+
+No claim is made that in-process UI tests prove arbitrary URI sizes through a
+real browser/proxy, that Python binding tests prove pinned-engine behavior, or
+that removing an application field cap removes generic transport/resource
+limits. Add hermetic HTTP/engine consumer evidence at integration where those
+claims are needed; never infer it from a fake-only test.
+
+## Validation actually run
+
+All runs used the existing Python environment read-only, `python -B`, pytest
+with its cache provider disabled, and the repository's per-test HOME/XDG/
+Avibe/backend-store isolation. Synthetic ledger files lived in
+`TemporaryDirectory` and were removed automatically. No product files changed.
+
+| Suite selection | Result |
+| --- | --- |
+| Usage: config-key equivalence, historical long reload, shared head, folded-literal closure, row reads, label joins | 23 passed; 77 deselected. |
+| Runtime: `model_inventory` projection tests | 12 passed; 293 deselected across the collected selection. |
+| Routing/provenance: legacy catalog/target, new-target admission, OpenCode loader | 66 passed; 122 deselected. |
+| API: canonical manual/discovered/inline input, legacy load, secret/duplicate discovery, candidate and catalog length boundaries | 9 passed; 415 deselected. |
+| Selective JSON parser and string rewriter | 18 passed. |
+
+These are baseline tests, including tests that intentionally enforce today's
+undesired length refusals. They prove the inspected consuming behavior, not
+completion of the proposed repair. Synthetic probes additionally reproduced
+the encoding-dependent inventory failure, lost parameter evidence, existing
+OpenCode loader refusal, typeahead refusal before search, the two legacy
+exceptions, full-length credential scanning, and the 22-identity ledger closure.
+
+After implementation, run the corresponding focused tests and changed-Python
+Ruff first, then relevant Model Hub/authority/scenario checks. UI changes require
+the relevant Vitest cases, test type checking, and `npm run build`. The
+orchestrator owns integrated validation, exact-current-commit Codex review, CI,
+thread inventory, and the single PR. No push, PR, Watch, merge, release, deploy,
+or local service restart is authorized for this lane.

--- a/docs/plans/model-hub-permissive-boundaries.md
+++ b/docs/plans/model-hub-permissive-boundaries.md
@@ -131,3 +131,42 @@ any contract decision required. A callback is evidence to inspect, not approval.
 - Initial decision: implement the 128 MiB compatibility boundary, not unlimited
   buffering; investigate the identifier and engine seams before choosing edits.
 - Initial findings-bearing review heads: zero. No PR has been submitted yet.
+
+### Capability and launch-limit decision (2026-09-09)
+
+The orchestrator independently inspected catalog projection, Claude environment
+construction, its SessionHandler call site, and injection/CLI-path consuming
+tests at the shared contract base. The current Hub path both tombstones limit
+variables as though they were credentials and promotes catalog limits into
+highest-priority launch settings. Native CLI launches also overwrite explicit
+environment limits. These are competing owners, not evidence that a persisted
+provenance system is needed.
+
+Approved scope:
+
+- Keep existing BackendModel storage and the requested alias's metadata
+  authority. A saved non-null limit remains that selected model's planning
+  description; do not infer field provenance from row-level `origin`.
+- For Claude, leave credential/connection tombstones intact but remove the
+  two context/output limit variables from that boundary. Catalog limits fill
+  only absent subprocess variables. Empty explicit values are not permission
+  to invent another override. Do not inject model limits in the Hub connection
+  settings override; preserve native project/local settings precedence.
+- Verify the real launch consumer as well as pure environment helpers: parent
+  environment, explicit settings, absent limits, selected aliases, and both Hub
+  and native CLI paths. Do not broaden the enabled native setting sources.
+- Codex keeps its native configuration precedence if consumer evidence
+  confirms it. Custom capability absence must allow supplied images/reasoning
+  without importing a different model's private features or expensive default
+  effort. Explicit negatives and nonempty lists retain their meanings.
+- OpenCode retains the selected BackendModel as owner of the managed Hub
+  provider's planning metadata. Preserve separate native providers; do not merge
+  arbitrary native provider objects into a managed authentication definition.
+- No new persisted schema, UI policy, engine policy, credential flow, routing
+  policy, or output cap is approved by this decision.
+
+The remaining uncertainty is the native CLI consumer's treatment of absent
+capabilities and conflicting settings. Hermetic consumer evidence must confirm
+the representation and precedence before integration; a schema requirement or
+unexpected consumer override calls for another bounded decision, not a fallback
+to silent filtering.

--- a/docs/plans/model-hub-permissive-boundaries.md
+++ b/docs/plans/model-hub-permissive-boundaries.md
@@ -300,3 +300,41 @@ An upstream acceptance/release or a separately authorized Avibe source/
 provenance release contract is required before shipping this engine change.
 The Avibe PR may carry the reviewed inactive patch, but must explicitly state
 that its current engine pin and installed behavior remain unchanged.
+
+### xAI post-translation capability gate
+
+The orchestrator independently inspected the exact pinned source's
+`prepareResponsesRequestTo` chain, `sanitizeXAIResponsesBody`,
+`xaiSupportsReasoningEffort`, both existing catalog-strip tests, and the new
+fake-OAuth executor consumer and failing wire record. A whole-source search
+found one production caller of the capability helper: the sanitizer removes
+`reasoning.effort` after shared thinking and payload rules when registry
+thinking levels are absent. This is another catalog policy owner, not a
+Responses representation constraint. Shared passthrough alone cannot satisfy
+the accepted intent contract.
+
+Approve this additional source-only scope:
+
+- Remove only the catalog-conditioned reasoning deletion from
+  `sanitizeXAIResponsesBody`. Keep its `stop` removal and every other xAI
+  schema, tool-choice, replay, image, normalizer, and payload-rule constraint.
+  Preserve the current prepared target fields; do not restore the whole
+  original request or override configured payload rules.
+- Remove the now-unconsumed private `xaiSupportsReasoningEffort` helper,
+  its obsolete assertion-only test, unused imports, and the sanitizer's
+  now-unused model argument. No registry or registration policy change.
+- Replace catalog-strip assertions with actual executor evidence for unknown,
+  known-nil, empty/narrow, and supported metadata populations; native future
+  effort and explicit disable remain present, missing native intent remains
+  absent, and `stop` still does not reach Responses. Cover cross-protocol
+  conversion and stream/non-stream paths without claiming upstream support.
+- Reconcile the complete manager/credential-replacement and Kimi fixture
+  failures from the same test run independently of this xAI defect. A passing
+  xAI case alone is not source acceptance. Check the final egress preparation
+  of the other supported executor paths for an equivalent downstream
+  catalog-only gate; report another boundary before expanding changes.
+
+This narrowly supersedes the earlier blanket preservation of normalizers
+only for the identified catalog deletion. All changes stay in the inactive
+exact-base source/test patch. Avibe runtime/config/manifest, release guards,
+publication authority, and the installed engine remain unchanged.

--- a/docs/plans/model-hub-permissive-boundaries.md
+++ b/docs/plans/model-hub-permissive-boundaries.md
@@ -1,0 +1,133 @@
+# Model Hub permissive request boundaries
+
+## Ownership and authorization
+
+Owner approval on 2026-09-09 authorizes implementation and parallel Codex
+delegation following the preceding request-path audit. The user-started Session
+remains the orchestrator and final reviewer. This is not authorization to merge,
+publish an engine or application release, deploy, update/restart the running
+local Avibe, mutate user configuration, or advance the primary checkout.
+
+Implementation starts from default-branch commit
+`e4924db41bcbf37581cda08cf1376a899e70906c`. Independent lanes share this committed
+contract before they branch. Avibe changes integrate into one task branch and
+one normally reviewed PR; no lane stacks a PR on an unmerged peer.
+
+## Evidence and goal
+
+A Codex Blender Session failed at the authenticated Avibe gateway's 16 MiB
+request boundary. Reconstructing its latest persisted context checkpoint and
+subsequent model items found 20 inline PNG images totaling approximately 42 MiB.
+This was not a capture of the rejected wire request. The new user text was
+39 UTF-8 bytes. A hermetic 18 MiB aiohttp request passed with the boundary
+disabled, but the read/parse/reserialize fixture recorded about 76.5 MiB of peak
+Python allocations, excluding the engine. Removing every resource bound is
+therefore not the immediate remedy.
+
+The product should accept legitimate multi-image requests, preserve explicit
+model intent, and never equate absent capability knowledge with demonstrated
+non-support. Resource ownership, authentication, cancellation, routing, and
+persisted identity remain real constraints.
+
+## Shared invariants
+
+1. **Request envelope.** The common authenticated gateway accepts valid request
+   bodies through 128 MiB for Messages, Responses, and Chat Completions, with
+   consistent byte semantics for Content-Length and chunked bodies. Oversize
+   input returns a structured, non-secret 413 describing the local boundary,
+   before upstream admission. It does not mark a provider unhealthy, consume an
+   alternative provider, or silently truncate history. Do not add image-count,
+   turn-count, output-length, or normal-inference-duration caps.
+2. **Capabilities.** An absent override remains distinct from an explicit
+   negative or an explicit user selection. Custom model projection must not
+   silently strip supplied images or force reasoning to `none` solely because
+   catalog metadata is absent. Do not inherit a different model's provider-only
+   features, context size, tools, or expensive defaults. Preserve native known
+   rows, explicit negatives, persisted shapes, and model-selection ownership.
+3. **Limit authority.** Catalog context/output metadata assists planning; it
+   must not silently replace explicit user configuration with a stale default.
+   Preserve useful automatic compaction and backend schema requirements.
+   Determine authority from existing fields/owners where possible. A new
+   persisted provenance model requires an orchestrator decision before editing.
+4. **Model identity.** Reassess the 256-character admission bound across manual
+   input, discovery, routing, UI/API, metering, and load. Do not replace it with
+   another arbitrary number or remove it without checking downstream identity
+   and usage-key behavior. No truncation, identity merging, secret admission,
+   startup breakage, or silent loss of historical usage is permitted. The lane
+   reports its smallest complete proposal before implementation.
+5. **Engine intent.** Inspect the exact pinned CLIProxyAPI v7.2.149 source
+   `2a6b87aca083a5bf498ac1f68a1b636c500d7aaa`. Same-protocol explicit reasoning
+   intent must not be removed or downgraded solely by incomplete capability
+   metadata. Preserve required cross-protocol translation, OAuth lifetimes,
+   credential replacement, Source/model identity, and all routing policy.
+   Do not remove registration metadata as a shortcut: it can worsen stripping.
+   Report the source/build/release plan before implementing engine policy.
+   Never point a shipped manifest at missing assets or claim wire preservation
+   from a fake-adapter-only test.
+6. **Non-goals.** Keep bounded observation copies, temporary-file spill
+   thresholds, chunk sizes, authentication, cancellation cleanup, real upstream
+   failures, and existing retry ownership. Do not weaken CI, migrate unrelated
+   state, add a detection save gate, replay live credentials, or change unrelated
+   pending PRs.
+
+## Boundary ownership
+
+| Boundary | Producer | Consumer | Contract owner |
+| --- | --- | --- | --- |
+| Native model request | Claude/Codex/OpenCode | authenticated turn gateway | gateway lane |
+| Request model/protocol/header envelope | gateway | resolver and managed adapter | existing shared request owner, unchanged |
+| Backend model capability/limit projection | selected backend model catalog | CLI launch/catalog consumers | capability lane |
+| Model ID admission and durable usage identity | setup/discovery | config, routes, ledger, UI | identity lane, orchestrator approval |
+| Reasoning wire conversion | managed engine | exact selected mock upstream | engine lane, orchestrator approval |
+| Integration, authority/scenario inventory, PR gates | all lanes | owner | orchestrator |
+
+No new signature or credential field is introduced. Existing local bearer
+authentication and exact Source/model binding must remain unchanged.
+
+## Parallel delivery
+
+- **Gateway lane:** owns gateway request-size/error handling and focused tests
+  plus only the locale/catalog entries required for its new error surface.
+- **Capability lane:** owns backend catalog projection, CLI limit precedence,
+  and their consuming tests. Report cross-lane changes rather than editing
+  gateway/engine/identity code.
+- **Identity lane:** owns the complete identifier/ledger boundary diagnosis
+  first; implementation is gated on the orchestrator's recorded decision.
+- **Engine lane:** owns exact-pinned-source diagnosis and a reproducible
+  hermetic wire/build proposal first; policy edits, publication, and a manifest
+  change are separate decisions.
+- **Orchestrator:** owns this plan, integration branch, final review, combined
+  validation, PR submission, durable PR/CI observation, and close-out.
+
+Lane commits remain local until integrated. Lanes must not push, open PRs,
+merge, create release tags/assets, deploy, or edit a peer's worktree. Each lane
+returns a stable Session/Run ID, commit SHA, tests actually run, known gaps, and
+any contract decision required. A callback is evidence to inspect, not approval.
+
+## Acceptance
+
+- Exercise real hermetic HTTP ingress with a multi-image-size payload exceeding
+  16 MiB; compare exact input reaching the fake upstream/adapter, including
+  non-ASCII text and image data. Check both body framing shapes, threshold
+  boundaries, bad credentials, malformed JSON, cancellation, and no provider
+  health mutation for a local 413.
+- Cover unknown custom models, known built-ins, explicit supported/unsupported
+  choices, aliases, user-selected reasoning, and context/output precedence in
+  consuming launch/catalog paths.
+- For any identifier change, cover every admission surface and legacy persisted
+  IDs, non-ASCII names, collision-shaped names, reload and usage stability.
+- For engine policy, require actual pinned engine-to-mock-upstream wire evidence
+  for applicable same- and cross-protocol paths; distinguish source proof,
+  built artifacts, published availability, and installed behavior.
+- Run focused Python checks and pinned Ruff, then relevant Model Hub suites,
+  authority closure and scenario/catalog checks. UI changes require UI tests,
+  TypeScript and build. Use only isolated fixtures/local regression targets.
+- Require current-head Codex pass, all expected CI jobs, and zero unresolved
+  paginated threads. Record findings-bearing heads/root causes before edits;
+  enforce the review circuit breaker. No automatic merge authorization exists.
+
+## Decisions and status
+
+- Initial decision: implement the 128 MiB compatibility boundary, not unlimited
+  buffering; investigate the identifier and engine seams before choosing edits.
+- Initial findings-bearing review heads: zero. No PR has been submitted yet.

--- a/docs/plans/model-hub-permissive-boundaries.md
+++ b/docs/plans/model-hub-permissive-boundaries.md
@@ -224,3 +224,79 @@ Historical merged counters cannot identify their original owner, so this PR
 must not rekey or split them speculatively. Preserve the diagnostic evidence
 and record that attribution-policy follow-up separately; do not claim a proof
 over every malformed legacy string.
+
+### Native consumer follow-up
+
+The orchestrator inspected Codex 0.153.2's
+`models-manager/src/model_info.rs::with_config_overrides` and lane B's actual
+app-server consumer test. Codex takes the minimum of explicit
+`model_context_window` and catalog `max_context_window`; Avibe currently
+synthesizes both catalog fields from one BackendModel planning value.
+
+Approve removing `max_context_window` only when applying an explicit saved
+BackendModel `context_window` override. Retain `context_window` as the planning
+fallback and remove its obsolete catalog compaction threshold as before.
+Native rows without that override and native-CLI launches remain unchanged.
+The consumer test must prove both the fallback and an explicit larger context,
+alongside the native compaction setting. No Codex output cap is introduced.
+
+Claude's bundled CLI consumer honors explicit output limits, but its normal
+context planner does not necessarily consume `CLAUDE_CODE_MAX_CONTEXT_TOKENS`;
+the diagnosed context branch checks it only with compaction disabled. Retain
+the approved environment/settings preservation, prove actual output and
+Avibe-to-SDK context delivery, and document this native planner limitation.
+Do not disable compaction or claim end-to-end context control from environment
+injection alone.
+
+### Engine source-only decision
+
+Lane D's complete assessment is at
+`2a756b4b19a1478d06e1cc2a382aad0a9268acb5`. The orchestrator independently
+verified the clean exact upstream SHA, read the shared thinking entry point,
+validation and configured-model consuming tests, inspected the HTTP fixture,
+and verified the baseline artifact digest and all 380 result records. The
+recorded native disable-to-positive outcomes agree with the inspected
+capability clamp. These are baseline defects, not patched acceptance results.
+
+Approve a maintained, inactive candidate source/test patch series under
+`patches/cliproxyapi/`, against upstream
+`2a6b87aca083a5bf498ac1f68a1b636c500d7aaa`, with a small apply/test recipe
+and frozen input receipt. This is a local source-maintenance decision only,
+not authorization for a public fork, upstream contribution, release assets,
+manifest changes, installation, or runtime replacement.
+
+Source scope:
+
+- Distinguish identical reasoning wire representations from broad provider
+  families at the shared thinking entry point. Without an explicit suffix,
+  preserve the already prepared native target payload instead of performing
+  catalog-driven strip/map/validate/reapply. Recognize verified Responses
+  aliases; do not conflate Chat/Responses or Kimi's different dialect.
+- Extract explicit disable before capability gating, retain suffix priority,
+  reuse native disable writers before their support guards, and never turn
+  disable into a positive level or reactivate it through summary handling.
+- For genuine conversion with missing thinking metadata, use the existing
+  capability-free conversion responsibility, supplying original source
+  payload/format instead of extracting source fields from translated data.
+  Preserve positive conversion with known metadata and real protocol
+  constraints, normalizer/payload-rule ownership, and forced tool choice.
+- Preserve all registration metadata, including the existing Chat conversion
+  hint, exact selected credential snapshot, aliases/prefixes, routing, OAuth,
+  replacement, and refresh lifetimes. No fabricated UserDefined/capability
+  claim, broad validator deletion, new user setting, or runtime config change.
+
+Acceptance must include the maintained policy tests, patched HTTP matrix
+through real registration/execution, source/auth identity and replacement,
+stream/cancellation, and fake-auth subscription HTTP/WebSocket/dialect tests
+with external egress rejected. Keep source execution isolated and concurrency
+bounded. Use the committed engine catalogs, locked Go modules and exact
+toolchain; no catalog refresh from a moving branch.
+
+Release/packaging is deliberately separate. The existing manifest guard only
+accepts a truthful upstream identity and verified available four-platform
+assets. Do not weaken it or label locally patched bytes as upstream. Local
+diagnostic builds are not four-platform production reproducibility evidence.
+An upstream acceptance/release or a separately authorized Avibe source/
+provenance release contract is required before shipping this engine change.
+The Avibe PR may carry the reviewed inactive patch, but must explicitly state
+that its current engine pin and installed behavior remain unchanged.

--- a/docs/plans/model-hub-permissive-boundaries.md
+++ b/docs/plans/model-hub-permissive-boundaries.md
@@ -338,3 +338,36 @@ This narrowly supersedes the earlier blanket preservation of normalizers
 only for the identified catalog deletion. All changes stay in the inactive
 exact-base source/test patch. Avibe runtime/config/manifest, release guards,
 publication authority, and the installed engine remain unchanged.
+
+### Kimi native representation clarification
+
+The orchestrator inspected the pinned Kimi executor's original/prepared payload
+flow, the original Kimi applier and extraction precedence, the current shared
+native-format gate, and the failing actual OAuth executor test. An OpenAI Chat
+transport can already carry Kimi's native `thinking` object. Treating every
+`openai` to `kimi` pair as conversion rejects a native future effort using
+catalog levels, although extraction already gives the native object priority.
+This is the same representation-identity defect, not evidence to remove
+genuine cross-protocol validation.
+
+Approve this bounded source-only clarification:
+
+- With no model suffix, recognize `openai` to `kimi` as native only when the
+  original source contains `thinking.type` or `thinking.effort`. A `keep`-only
+  object and a legacy `reasoning_effort` input do not establish native intent.
+- Preserve the prepared target payload and its native object without restoring
+  source fields or interpreting unknown effort/type values. Remove only the
+  legacy `reasoning_effort` alias, consistent with the existing Kimi wire writer.
+  Native disabled input must not be re-enabled or replaced by the legacy alias.
+- Preserve suffix priority and the existing conversion owner for legacy-only,
+  keep-only, and genuine cross-protocol inputs. No new interface, metadata,
+  configuration, registration, routing, or authentication policy is needed.
+- Verify native enabled/future/disabled/type-only input, conflicting legacy
+  input, keep-only conversion, suffix priority, and prepared-target authority
+  through policy tests and actual streaming/non-streaming executor captures.
+
+The expected result is exact prepared native intent reaching the loopback
+upstream, with the legacy alias absent; it is not a claim that a real upstream
+supports an arbitrary future value. Any target normalization or another
+protocol constraint that makes this preservation unsafe requires evidence and
+a new scope decision. The patch remains inactive and the engine pin unchanged.

--- a/docs/plans/model-hub-permissive-boundaries.md
+++ b/docs/plans/model-hub-permissive-boundaries.md
@@ -4,14 +4,19 @@
 
 Owner approval on 2026-09-09 authorizes implementation and parallel Codex
 delegation following the preceding request-path audit. The user-started Session
-remains the orchestrator and final reviewer. This is not authorization to merge,
-publish an engine or application release, deploy, update/restart the running
-local Avibe, mutate user configuration, or advance the primary checkout.
+remains the orchestrator and final reviewer. On 2026-09-09 at 04:11 +08
+(2026-09-08 at 20:11 UTC), the owner superseded the initial combined-PR plan:
+each lane must submit its own PR and merge after its delivery gates pass.
+The orchestrator owns final gate verification and merge execution. This does
+not authorize publishing an engine or application release, deploying,
+updating/restarting the running local Avibe, mutating user configuration, or
+advancing the primary checkout.
 
 Implementation starts from default-branch commit
 `e4924db41bcbf37581cda08cf1376a899e70906c`. Independent lanes share this committed
-contract before they branch. Avibe changes integrate into one task branch and
-one normally reviewed PR; no lane stacks a PR on an unmerged peer.
+contract before they branch. Each lane now delivers one independent Avibe PR
+against the current default branch; no lane stacks a PR on an unmerged peer.
+The combined task branch is retained only as integration-test evidence.
 
 ## Evidence and goal
 
@@ -96,13 +101,16 @@ authentication and exact Source/model binding must remain unchanged.
 - **Engine lane:** owns exact-pinned-source diagnosis and a reproducible
   hermetic wire/build proposal first; policy edits, publication, and a manifest
   change are separate decisions.
-- **Orchestrator:** owns this plan, integration branch, final review, combined
-  validation, PR submission, durable PR/CI observation, and close-out.
+- **Orchestrator:** owns this plan, cross-lane validation, independent PR/CI
+  observation, final review, guarded merge execution, and user-facing close-out.
 
-Lane commits remain local until integrated. Lanes must not push, open PRs,
-merge, create release tags/assets, deploy, or edit a peer's worktree. Each lane
-returns a stable Session/Run ID, commit SHA, tests actually run, known gaps, and
-any contract decision required. A callback is evidence to inspect, not approval.
+Each lane may push its assigned branch, open its own non-draft PR, and follow
+review/CI with one durable combined Watch. It must immediately return the PR,
+exact head, Watch/state, review inventory, tests, and known gaps to the
+orchestrator, who arms a separate gate Watch and independently inspects evidence.
+Lanes must not merge, create release tags/assets, deploy, or edit peers. The
+orchestrator executes the owner's gated merge authorization after all checks
+hold together. A callback is evidence to inspect, not proof of readiness.
 
 ## Acceptance
 
@@ -124,13 +132,41 @@ any contract decision required. A callback is evidence to inspect, not approval.
   TypeScript and build. Use only isolated fixtures/local regression targets.
 - Require current-head Codex pass, all expected CI jobs, and zero unresolved
   paginated threads. Record findings-bearing heads/root causes before edits;
-  enforce the review circuit breaker. No automatic merge authorization exists.
+  enforce the review circuit breaker. Before merging, the orchestrator must
+  also verify an open non-draft PR, CLEAN merge state, no running/queued lane
+  edits, and every merge gate in one fail-closed conditional, using the exact
+  validated head. Authorization does not permit skipping a gate.
 
 ## Decisions and status
 
 - Initial decision: implement the 128 MiB compatibility boundary, not unlimited
   buffering; investigate the identifier and engine seams before choosing edits.
 - Initial findings-bearing review heads: zero. No PR has been submitted yet.
+
+### Independent delivery allocation
+
+The four PRs own disjoint product concerns: A owns the gateway and request-budget
+scenario registration; B owns capability/limit projection and its CLI scenario
+registration; C owns identifier admission/discovery/UI plus the integration
+guard correction and qualified usage scenario descriptions; D owns the inactive
+exact-base engine patch, recipe, and consuming evidence. Each carries the same
+orchestrator-owned shared contract. Lane-specific assessments must describe
+independent delivery rather than the superseded combined-PR plan.
+
+Merge landed default-branch changes normally into each task branch before
+submission. Do not cherry-pick another lane's product changes or count the
+combined branch's tests as exact-head PR evidence. Recheck shared scenario IDs
+and catalog entries after each earlier PR lands. Subsequent gate evaluations
+remain exact-head and must inspect all paginated reviews/threads and every lint
+run, including old unresolved findings. Repeated root-cause classes are escalated
+to this same orchestrator before another edit/push; they do not automatically
+require another owner decision.
+
+Keep separate original durable lane and orchestrator gate Watch states across
+all rounds. Do not merge or remove a lane Watch merely because a callback reports
+green tests. After GitHub confirms a guarded merge, report that PR's result to
+the owner before removing its observation. Completed historical PR authority
+and Watches are not reused.
 
 ### Capability and launch-limit decision (2026-09-09)
 

--- a/docs/plans/model-hub-permissive-boundaries.md
+++ b/docs/plans/model-hub-permissive-boundaries.md
@@ -170,3 +170,57 @@ capabilities and conflicting settings. Hermetic consumer evidence must confirm
 the representation and precedence before integration; a schema requirement or
 unexpected consumer override calls for another bounded decision, not a fallback
 to silent filtering.
+
+### Identifier decision (2026-09-09, local +08)
+
+Lane C's diagnosis is committed as
+`e3f3628230333b141449684ba2f9af90ad0e3d1a`. The orchestrator independently
+inspected live and persisted ledger key owners, their consuming closure test,
+the selective parser and inventory projection, new-ID admission, OpenCode
+aggregate loading, and the typeahead refusal. A separate read-only synthetic
+run confirmed 12 valid long/Unicode/folded-literal identities remain distinct
+with stable read-back keys. It also reproduced the pre-existing whitespace
+normalization exception and admission of unencodable surrogate text.
+
+Approved smallest complete scope:
+
+- Remove the 256-character admission ceiling and its editor, schema, locale,
+  and typeahead-query mirrors. Keep canonical outer-whitespace spelling,
+  nonblank text, complete credential scanning, exact Source/model pairing, and
+  backend/source eligibility policy.
+- Require newly admitted IDs and unsaved observation IDs to be representable
+  as UTF-8, without replacement, truncation, Unicode normalization, or case
+  folding. This is a transport/storage validity check, not a new length cap.
+  Do not apply new admission rules to legacy persisted identities.
+- Separate OpenCode aggregate loading and whole-list editing from new-ID
+  admission while retaining existing spelling, nonblank, native-protocol,
+  menu, and route-membership invariants.
+- Extend the existing selective parser with a default-empty lossless-string
+  path option. Opt only inventory string-row IDs, object-row IDs, and
+  supported-parameter string values into it. Decide at value-token start;
+  object keys and unrelated values keep the existing bounded behavior.
+  Preserve malformed-JSON rejection, duplicate-member/scope semantics,
+  document completion, spooling, and the discovery deadline.
+- Keep the 200-character ledger head, digest calculation, persisted key
+  reader, stored rows, label joins, and retention unchanged. New admission can
+  safely include folded-looking literals because live derivation folds those
+  literals again; persisted key recognition is intentionally a different owner.
+- Limit shared service/config changes to the diagnosed admission, discovery,
+  typeahead, and load seams. Lane B's projection and lane A's gateway remain
+  independently owned. No new schema revision, dependency, ledger namespace,
+  engine setting, or arbitrary replacement size is approved.
+
+Selected identity/parameter facts necessarily occupy memory proportional to
+their full values. This decision does not remove generic HTTP/resource limits
+or promise arbitrary URI-size support. Consuming tests must cover lexical
+JSON expansion, long credential-shaped tails, exact runtime IDs, key-literal
+closure, reload, and the UI's whole-ID submission.
+
+Known-by-design legacy exceptions: an already loadable long all-whitespace
+identity can be misattributed by the existing persisted-key normalization;
+unencodable historical identities can also fail later encoding. Neither is
+introduced by removing the limit, and blank/unencodable new IDs are refused.
+Historical merged counters cannot identify their original owner, so this PR
+must not rekey or split them speculatively. Preserve the diagnostic evidence
+and record that attribution-policy follow-up separately; do not claim a proof
+over every malformed legacy string.

--- a/tests/scenarios/model_hub/catalog.yaml
+++ b/tests/scenarios/model_hub/catalog.yaml
@@ -364,19 +364,22 @@ scenarios:
     layer: unit
     test: tests/test_model_hub_runtime.py::test_a_prelude_that_dies_after_reporting_tokens_carries_them_to_the_resolver
   - id: MH-USAGE-006
-    name: Every model identifier a persisted config still loads is one the ledger can key
+    # Malformed historical whitespace/surrogate exceptions remain documented in
+    # docs/plans/model-hub-identifier-boundary-assessment.md; these rows do not
+    # claim that every arbitrary loadable legacy string is correctly attributed.
+    name: Supported persisted model identities remain meterable across reload
     status: covered
     kind: compatibility
     layer: unit
     test: tests/test_model_hub_usage.py::test_metering_can_key_exactly_the_identities_a_config_can_hold
   - id: MH-USAGE-007
-    name: Two model identifiers a config holds are never metered onto one ledger row
+    name: Distinct nonblank UTF-8 model identities and folded literals retain separate usage rows
     status: covered
     kind: persistence
     layer: unit
     test: tests/test_model_hub_usage.py::test_no_two_identities_a_config_holds_can_share_one_row
   - id: MH-USAGE-008
-    name: Every metered row is labelled under the identity it was metered for, however it was keyed
+    name: Configured nonblank UTF-8 identities label their verbatim and folded ledger rows
     status: covered
     kind: compatibility
     layer: unit

--- a/tests/scenarios/model_hub/test_model_hub_migration_scenarios.py
+++ b/tests/scenarios/model_hub/test_model_hub_migration_scenarios.py
@@ -645,6 +645,50 @@ def test_mh_mig_001_api_apply_keeps_native_tree_byte_identical(
         assert secret not in serialized
 
 
+@pytest.mark.parametrize("discovery", (ObservationDiscovery.SUCCEEDED, ObservationDiscovery.FAILED))
+def test_mh_mig_001_long_manual_inventory_is_copy_only_even_when_discovery_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, discovery: ObservationDiscovery,
+) -> None:
+    """MH-MIG-001: new manual imports share admission without rewriting native files."""
+    native_home = tmp_path / "native-home"
+    _isolate_native_home(monkeypatch, native_home)
+    identity = "模型🧪/e\u0301" * 3000
+    invalid = (" " * 17000, "m" * 17000 + "\ud800", "m" * 17000 + " sk-fabricated-never-persist-this")
+    _write(
+        native_home / ".config" / "opencode" / "opencode.json",
+        json.dumps({"provider": {"openrouter": {
+            "options": {"apiKey": "sk-openrouter-123456", "baseURL": "https://openrouter.example/v1"},
+            "models": {
+                "  " + identity + "  ": {"name": "Long manual"},
+                **{model_id: {} for model_id in invalid},
+            },
+        }}}),
+    )
+    before = _tree_digest(native_home)
+    service, store, adapter = _service(tmp_path)
+    _assert_sources_validated_before_commit(monkeypatch, service)
+
+    async def observe(*_args):
+        return SourceObservation(
+            outcome=ObservationOutcome.OBSERVED, reachable=True, authenticated=True,
+            protocol="openai_chat", discovery=discovery,
+            models=(DiscoveredModel(id=identity + "-discovered"),) if discovery is ObservationDiscovery.SUCCEEDED else (),
+        )
+
+    adapter.observe_source = observe
+    [item] = service.migration_scan()["items"]
+    result = asyncio.run(service.migration_apply([item["id"]]))
+    assert result["applied"] == 1
+    [source] = _assert_canonical_round_trip(store.config).sources
+    manual = [model for model in source.models if model.provenance == "manual"]
+    assert [(model.id, model.display_name) for model in manual] == [(identity, "Long manual")]
+    assert all(model.id not in invalid for model in source.models)
+    assert source.state.status == ("error" if discovery is ObservationDiscovery.FAILED else "standby")
+    assert _tree_digest(native_home) == before
+    assert adapter.transient_revoked == adapter.transient_refs
+    assert "sk-fabricated-never-persist-this" not in json.dumps(result)
+
+
 def test_mh_mig_002_oauth_defaults_to_native_sources(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_model_hub_api.py
+++ b/tests/test_model_hub_api.py
@@ -4,12 +4,14 @@ import ast
 import asyncio
 import copy
 import inspect
+import io
 import json
 import re
 import textwrap
 import threading
 from datetime import datetime, timezone
 from pathlib import Path
+from urllib.parse import quote
 
 import pytest
 from jsonschema import Draft7Validator, FormatChecker
@@ -43,7 +45,7 @@ from core.handlers.model_hub.adapter import (
 )
 from core.handlers.model_hub.catalog_admission import admissible_backend_model
 from core.handlers.model_hub.errors import ModelDiscoveryError
-from core.handlers.model_hub.identifiers import MODEL_ID_MAX_LENGTH
+from core.handlers.model_hub.identifiers import canonical_model_id, usage_ledger_key
 from core.handlers.model_hub.events import BoundedEventLog, ResolutionEvent
 from core.handlers.model_hub.oauth import (
     NativeOAuthSourceStatus,
@@ -2313,7 +2315,7 @@ def test_backend_catalog_candidates_project_builtin_provider_and_current_rows(
             display_name="Saved label",
         )
     )
-    legacy_overlong_id = "x" * (MODEL_ID_MAX_LENGTH + 1)
+    legacy_overlong_id = "x" * (256 + 1)
     agent.models.append(
         ModelHubBackendModelConfig(
             id=legacy_overlong_id,
@@ -2506,7 +2508,7 @@ def test_candidate_protocol_projection_is_total_only_for_opencode(tmp_path):
 def test_candidates_exclude_ids_the_backend_write_would_reject(monkeypatch, tmp_path):
     service, store, _adapter = _service(tmp_path)
     invalid_claude_id = "not-a-claude-family"
-    too_long = "x" * (MODEL_ID_MAX_LENGTH + 1)
+    unencodable = "claude-invalid\ud800"
     source = ModelHubSourceConfig(
         id="src_invalid001",
         kind="api_key",
@@ -2518,7 +2520,7 @@ def test_candidates_exclude_ids_the_backend_write_would_reject(monkeypatch, tmp_
         state=ModelHubSourceStateConfig(status="standby"),
         models=[
             ModelHubModelConfig(id=invalid_claude_id, provenance="manual"),
-            ModelHubModelConfig(id=too_long, provenance="discovered"),
+            ModelHubModelConfig(id=unencodable, provenance="discovered"),
         ],
         credential_ref="cred_invalid001",
     )
@@ -2532,7 +2534,7 @@ def test_candidates_exclude_ids_the_backend_write_would_reject(monkeypatch, tmp_
                 "generation": "invalid-candidate-snapshot",
                 "models": [
                     {"id": invalid_claude_id},
-                    {"id": too_long},
+                    {"id": unencodable},
                 ],
             }
         },
@@ -2542,7 +2544,7 @@ def test_candidates_exclude_ids_the_backend_write_would_reject(monkeypatch, tmp_
 
     ids = {item["id"] for group in candidates.values() for item in group}
     assert invalid_claude_id not in ids
-    assert too_long not in ids
+    assert unencodable not in ids
 
 
 def test_backend_catalog_add_validates_supplier_echo_and_stores_draft_literally(
@@ -2742,7 +2744,7 @@ def test_builtin_reconcile_inserts_in_snapshot_order_and_preserves_every_other_r
         },
         {"id": "gpt-omega"},
         {"id": "gpt-hidden"},
-        {"id": "x" * (MODEL_ID_MAX_LENGTH + 1)},
+        {"id": "invalid\ud800"},
     ]
     unchanged = {model.id: model.to_payload() for model in agent.models}
     monkeypatch.setattr(
@@ -2770,7 +2772,7 @@ def test_builtin_reconcile_inserts_in_snapshot_order_and_preserves_every_other_r
     assert "gpt-new" not in agent.routes
     assert service.agent_chain("codex", "gpt-new")["current"] == {"source_id": source.id, "model_id": "gpt-new"}
     assert "gpt-hidden" not in {model.id for model in agent.models}
-    assert "x" * (MODEL_ID_MAX_LENGTH + 1) not in {model.id for model in agent.models}
+    assert "invalid\ud800" not in {model.id for model in agent.models}
     assert {model.id: model.to_payload() for model in agent.models if model.id in unchanged} == unchanged
     assert refreshed == ["codex"]
 
@@ -2820,7 +2822,8 @@ def test_model_producers_emit_admissible_backend_payloads(
     tmp_path,
     producer,
 ):
-    rejected_id = "x" * (MODEL_ID_MAX_LENGTH + 1)
+    rejected_id = "gpt-metadata-invalid\ud800"
+    admitted_id = "gpt-metadata-" + "模型🧪" * 1800
     long_display_name = "Model " + "x" * 80
     if producer == "candidates_read":
         producer_backend = "codex"
@@ -2836,7 +2839,7 @@ def test_model_producers_emit_admissible_backend_payloads(
             state=ModelHubSourceStateConfig(status="standby"),
             models=[
                 ModelHubModelConfig(
-                    id="gpt-metadata-candidate",
+                    id=admitted_id,
                     provenance="manual",
                     display_name=long_display_name,
                     reasoning_efforts=[" high "],
@@ -2863,7 +2866,7 @@ def test_model_producers_emit_admissible_backend_payloads(
         candidate = next(
             candidate
             for candidate in candidates
-            if candidate["id"] == "gpt-metadata-candidate"
+            if candidate["id"] == admitted_id
         )
         payload = {
             "id": candidate["id"],
@@ -2882,7 +2885,7 @@ def test_model_producers_emit_admissible_backend_payloads(
                     "complete": True,
                     "models": [
                         {
-                            "id": "gpt-metadata-reconcile",
+                            "id": admitted_id,
                             "display_name": long_display_name,
                             "reasoning_efforts": [" high "],
                         },
@@ -2895,7 +2898,7 @@ def test_model_producers_emit_admissible_backend_payloads(
         payload = next(
             model.to_payload()
             for model in store.config.agents["codex"].models
-            if model.id == "gpt-metadata-reconcile"
+            if model.id == admitted_id
         )
         assert rejected_id not in {
             model.id for model in store.config.agents["codex"].models
@@ -2911,7 +2914,7 @@ def test_model_producers_emit_admissible_backend_payloads(
                 "openai": {
                     "name": "OpenAI",
                     "models": {
-                        "gpt-metadata-typeahead": {
+                        admitted_id: {
                             "name": long_display_name,
                             "reasoning_options": [
                                 {"type": "effort", "values": [" high "]}
@@ -2922,12 +2925,20 @@ def test_model_producers_emit_admissible_backend_payloads(
                 }
             },
         )
-        matches = models_dev_catalog.search_models_dev("metadata")
+        matches = ModelHubService.models_dev_matches(admitted_id)
+        service, _store, _adapter = _service(tmp_path)
+        monkeypatch.setattr(ui_server, "_model_hub_service", lambda: service)
+        response = app.test_client().get(
+            f"/api/models/catalog/models-dev?query={quote(admitted_id, safe='')}",
+            base_url="http://127.0.0.1:15131",
+        )
+        assert response.status_code == 200
+        assert response.get_json()["matches"] == matches
         assert rejected_id not in {match["model_id"] for match in matches}
         match = next(
             match
             for match in matches
-            if match["model_id"] == "gpt-metadata-typeahead"
+            if match["model_id"] == admitted_id
         )
         payload = {
             "id": match["model_id"],
@@ -2944,6 +2955,7 @@ def test_model_producers_emit_admissible_backend_payloads(
         }
 
     parsed = ModelHubBackendModelConfig.from_payload(payload)
+    assert parsed.id == admitted_id
     assert parsed.display_name == long_display_name
     assert (
         admissible_backend_model(
@@ -3330,25 +3342,33 @@ def test_backend_catalog_preserves_requested_insertion_position_for_a_new_model(
     ]
 
 
-def test_backend_catalog_allows_editing_a_persisted_legacy_long_id(tmp_path):
+@pytest.mark.parametrize("backend", ("claude", "codex", "opencode"))
+def test_backend_catalog_allows_editing_a_persisted_legacy_long_id(tmp_path, backend):
     service, store, _adapter = _service(tmp_path)
-    legacy_id = "x" * (MODEL_ID_MAX_LENGTH + 1)
-    agent = store.config.agents["codex"]
-    agent.models.append(ModelHubBackendModelConfig(id=legacy_id, origin="manual"))
+    legacy_id = "legacy-" + "模型🧪/e\u0301" * 3000
+    agent = store.config.agents[backend]
+    agent.models.append(ModelHubBackendModelConfig(
+        id=legacy_id, origin="manual",
+        native_protocol="anthropic" if backend == "opencode" else None,
+    ))
     agent.routes[legacy_id] = ModelHubRouteConfig()
+    if agent.menu is not None:
+        agent.menu.checked.append(legacy_id)
+    store.config = ModelHubConfig.from_payload(store.config.to_payload())
     baseline = next(
-        projected["catalog_models"] for projected in service.list_agents() if projected["backend"] == "codex"
+        projected["catalog_models"] for projected in service.list_agents() if projected["backend"] == backend
     )
     desired = copy.deepcopy(baseline)
     next(model for model in desired if model["id"] == legacy_id)["display_name"] = "Persisted legacy model"
 
-    response = asyncio.run(service.set_agent_models("codex", baseline, desired))
+    response = asyncio.run(service.set_agent_models(backend, baseline, desired))
 
     assert (
         next(model for model in response["agent"]["catalog_models"] if model["id"] == legacy_id)["display_name"]
         == "Persisted legacy model"
     )
     _assert_valid("agent-supply.schema.json", response["agent"])
+    assert ModelHubConfig.from_payload(store.config.to_payload()).to_payload() == store.config.to_payload()
 
 
 def test_backend_catalog_allows_a_persisted_legacy_claude_alias_to_round_trip(
@@ -3371,34 +3391,44 @@ def test_backend_catalog_allows_a_persisted_legacy_claude_alias_to_round_trip(
     assert response["agent"]["catalog_models"][1]["display_name"] == "Unrelated edit"
 
 
-def test_backend_catalog_rejects_a_new_id_past_the_admission_bound(tmp_path):
+@pytest.mark.parametrize("backend", ("claude", "codex", "opencode"))
+def test_backend_catalog_rejects_a_new_unencodable_id(tmp_path, backend):
     service, _store, _adapter = _service(tmp_path)
-    baseline = next(agent["catalog_models"] for agent in service.list_agents() if agent["backend"] == "codex")
+    baseline = service.backend_catalog_models(backend)
     added = {
-        **baseline[0],
-        "id": "x" * (MODEL_ID_MAX_LENGTH + 1),
+        "id": "claude-" + "x" * 17000 + "\ud800",
         "origin": "manual",
+        **({"native_protocol": "anthropic"} if backend == "opencode" else {}),
     }
 
     with pytest.raises(ModelHubError) as raised:
-        asyncio.run(service.set_agent_models("codex", baseline, [*baseline, added]))
+        asyncio.run(service.set_agent_models(backend, baseline, [*baseline, added]))
 
     assert raised.value.code == "backend_model_id_invalid"
 
 
-def test_backend_catalog_accepts_a_new_id_at_the_contract_bound(tmp_path):
+@pytest.mark.parametrize("backend", ("claude", "codex", "opencode"))
+@pytest.mark.parametrize(
+    "identifier", ["x" * 257, "模型🧪/e\u0301" * 3000, "x" * 17000],
+    ids=("past-former-bound", "long-unicode", "past-lexical-budget"),
+)
+def test_backend_catalog_accepts_complete_long_ids_and_reloads(tmp_path, backend, identifier):
     service, _store, _adapter = _service(tmp_path)
-    baseline = next(agent["catalog_models"] for agent in service.list_agents() if agent["backend"] == "codex")
-    model_id = "x" * MODEL_ID_MAX_LENGTH
+    baseline = service.backend_catalog_models(backend)
+    model_id = "claude-" + identifier
     added = {
-        **baseline[0],
         "id": model_id,
         "origin": "manual",
+        **({"native_protocol": "anthropic"} if backend == "opencode" else {}),
     }
 
-    response = asyncio.run(service.set_agent_models("codex", baseline, [*baseline, added]))
+    response = asyncio.run(service.set_agent_models(backend, baseline, [*baseline, added]))
 
     assert response["agent"]["catalog_models"][-1]["id"] == model_id
+    _assert_valid("agent-supply.schema.json", response["agent"])
+    loaded = ModelHubConfig.from_payload(_store.config.to_payload())
+    assert loaded.agents[backend].models[-1].id == model_id
+    assert loaded.to_payload() == _store.config.to_payload()
 
 
 def test_backend_catalog_merges_an_unrelated_concurrent_edit(tmp_path):
@@ -8740,14 +8770,155 @@ def test_admitted_model_ids_are_stored_in_their_canonical_form(tmp_path):
     ]
 
 
+@pytest.mark.parametrize("length", (200, 201, 256, 257, 264, 265, 266, 4097, 16384, 16385))
+def test_new_identity_admission_has_no_length_boundary(length):
+    identity = "m" * length
+    assert canonical_model_id("  " + identity + "  ") == identity
+
+
+def test_long_identity_source_lifecycle_preserves_api_binding_and_reload(monkeypatch, tmp_path):
+    service, store, adapter = _service(tmp_path)
+    head = "模型🧪/e\u0301" * 3000
+    discovered = [head + "-one", head + "-two", "é", "e\u0301"]
+
+    async def models(*_args):
+        return tuple(DiscoveredModel(id="  " + identity + "  ") for identity in discovered)
+
+    adapter.discover_models = models
+    source = asyncio.run(_create_source(service, {
+        "kind": "api_key", "vendor": "custom", "display_name": "Long identities",
+        "base_url": "https://relay.example/v1", "key": "sk-test-transient-only",
+        "models": [{"id": head + "-inline", "origin": "manual", "reasoning_efforts": []}],
+    }))
+    monkeypatch.setattr(ui_server, "_model_hub_service", lambda: service)
+    client = app.test_client()
+    base_url = "http://127.0.0.1:15131"
+    headers = csrf_headers(client, base_url)
+    manual = head + "-manual"
+    # Exercise encoded path semantics within the HTTP client's generic URL
+    # budget. The full inventory/body IDs above deliberately exceed that budget.
+    path_identity = "模型🧪/e\u0301" * 600
+    folded_literal = usage_ledger_key(discovered[0])
+    for identity in (manual, path_identity, folded_literal, " " + manual + " "):
+        response = client.post(
+            f"/api/models/sources/{source['id']}/models",
+            json={"model_id": identity, "reasoning_efforts": []},
+            headers=headers, base_url=base_url,
+        )
+        assert response.status_code == 201
+    expected = {*discovered, head + "-inline", manual, path_identity, folded_literal}
+    config_ids = [model.id for model in store.config.sources[0].models]
+    assert len(config_ids) == len(expected)
+    assert set(config_ids) == expected
+
+    response = client.patch(
+        f"/api/models/sources/{source['id']}/models/{quote(path_identity, safe='')}",
+        json={"reasoning_efforts": ["low"]}, headers=headers, base_url=base_url,
+    )
+    assert response.status_code == 200
+    assert next(model for model in response.get_json()["source"]["models"] if model["id"] == path_identity)[
+        "reasoning_efforts"
+    ] == ["low"]
+    asyncio.run(service.update_model_reasoning_efforts(source["id"], manual, {"reasoning_efforts": ["low"]}))
+    asyncio.run(service.refresh_source(source["id"]))
+    snapshot = store.config.to_payload()
+    asyncio.run(service.refresh_source(source["id"]))
+    assert store.config.to_payload() == snapshot
+    reloaded = ModelHubConfig.from_payload(json.loads(json.dumps(snapshot, ensure_ascii=False)))
+    assert {model.id for model in reloaded.sources[0].models} == expected
+    binding = next(binding for binding in adapter.synced[-1] if binding.source_id == source["id"])
+    assert set(binding.model_ids) == expected
+    assert reloaded.to_payload() == snapshot
+
+
+@pytest.mark.parametrize(
+    "invalid",
+    (None, 7, "", " " * 17000, "模型" * 9000 + "\ud800",
+     "m" * 17000 + " sk-fabricated-never-persist-this"),
+    ids=("none", "number", "empty", "blank", "surrogate-tail", "credential-tail"),
+)
+def test_new_manual_identity_refusal_is_atomic(tmp_path, invalid):
+    service, store, adapter = _service(tmp_path)
+    source = asyncio.run(_create_source(service, {
+        "kind": "api_key", "vendor": "anthropic", "display_name": "Safe source",
+        "key": "sk-test-transient-only",
+    }))
+    previous = store.config.to_payload()
+    syncs = len(adapter.synced)
+    with pytest.raises(ModelHubError) as error:
+        asyncio.run(service.add_custom_model(source["id"], {"model_id": invalid, "reasoning_efforts": []}))
+    assert error.value.code == "mapping_target_unavailable"
+    assert store.config.to_payload() == previous
+    assert len(adapter.synced) == syncs
+
+
+@pytest.mark.parametrize("field", ("id", "supported_parameters"))
+@pytest.mark.parametrize("tail", ("sk-fabricated-never-persist-this", "\ud800"))
+def test_unsaved_inventory_refuses_invalid_material_beyond_old_string_budget(monkeypatch, tmp_path, field, tail):
+    from vibe.model_hub_runtime.client import _project_model_inventory
+
+    service, store, adapter = _service(tmp_path)
+    invalid = "模型🧪" * 6000 + " " + tail
+    model = {"id": "safe-model", "supported_parameters": ["reasoning"]}
+    model[field] = invalid if field == "id" else ["reasoning", invalid]
+    projected = _project_model_inventory(io.BytesIO(json.dumps({"data": [model]}).encode()))
+    assert projected is not None
+    adapter.observation = SourceObservation(
+        outcome=ObservationOutcome.OBSERVED, reachable=True, authenticated=True,
+        protocol="anthropic", discovery=ObservationDiscovery.SUCCEEDED, models=tuple(projected[2]),
+    )
+    monkeypatch.setattr(ui_server, "_model_hub_service", lambda: service)
+    client = app.test_client()
+    base_url = "http://127.0.0.1:15131"
+    response = client.post(
+        "/api/models/sources/observe",
+        json={"vendor": "anthropic", "key": "sk-test-transient-only"},
+        headers=csrf_headers(client, base_url), base_url=base_url,
+    )
+    assert response.status_code == 502
+    assert response.get_json()["error"] == "discovery_failed"
+    assert store.config.sources == []
+    assert adapter.revoked == ["cred_test001"]
+    assert tail not in json.dumps(response.get_json(), ensure_ascii=False)
+    assert invalid not in json.dumps(store.config.to_payload(), ensure_ascii=False)
+
+
+def test_unsaved_inventory_publishes_full_id_and_parameter_facts(monkeypatch, tmp_path):
+    from vibe.model_hub_runtime.client import _project_model_inventory
+
+    identity, parameter = "模型🧪/e\u0301" * 3000, "unknown-" + "x" * 17000
+    projected = _project_model_inventory(io.BytesIO(json.dumps({
+        "data": [{"id": identity, "supported_parameters": ["reasoning", parameter]}],
+    }).encode()))
+    assert projected is not None
+    service, store, adapter = _service(tmp_path)
+    adapter.observation = SourceObservation(
+        outcome=ObservationOutcome.OBSERVED, reachable=True, authenticated=True,
+        protocol="anthropic", discovery=ObservationDiscovery.SUCCEEDED, models=tuple(projected[2]),
+    )
+    monkeypatch.setattr(ui_server, "_model_hub_service", lambda: service)
+    client = app.test_client()
+    base_url = "http://127.0.0.1:15131"
+    response = client.post(
+        "/api/models/sources/observe",
+        json={"vendor": "anthropic", "key": "sk-test-transient-only"},
+        headers=csrf_headers(client, base_url), base_url=base_url,
+    )
+    assert response.status_code == 200
+    observation = response.get_json()["observation"]
+    assert observation["models"] == [identity]
+    assert observation["model_metadata"] == [{"id": identity, "supported_parameters": ["reasoning", parameter]}]
+    assert store.config.sources == []
+    assert adapter.revoked == ["cred_test001"]
+
+
 def test_models_declared_inline_at_source_creation_are_admitted_the_same_way(tmp_path):
     """Review 4960570946: the third admission path obeyed neither half.
 
     A source may be created with its models inline, so this is the other way a
     client-declared identifier enters config. Spelling is now settled by the
-    config validator, which every path goes through; the length bound stays with
-    the admission surfaces, because that same validator also loads files older
-    releases wrote and rejecting one of those would fail config load.
+    config validator, which every path goes through. New-admission checks stay
+    with the request rather than the validator that loads historical files.
     """
 
     service, store, _ = _service(tmp_path)
@@ -8780,7 +8951,7 @@ def test_models_declared_inline_at_source_creation_are_admitted_the_same_way(tmp
                 creation(
                     [
                         {
-                            "id": "m" * (MODEL_ID_MAX_LENGTH + 1),
+                            "id": "m" * 17000 + "\ud800",
                             "origin": "manual",
                             "reasoning_efforts": [],
                         }
@@ -8794,25 +8965,26 @@ def test_models_declared_inline_at_source_creation_are_admitted_the_same_way(tmp
 
 
 def test_a_persisted_model_id_past_the_bound_still_loads(tmp_path):
-    """The bound is an admission rule, not a load rule.
+    """An older admission limit was never a persisted Source load rule.
 
-    Nothing stops a file written before the bound existed from holding a longer
+    Nothing stops a file written before that limit existed from holding a longer
     identifier, and per the persisted-shape rule that file must still load. It
     keeps its length and gains only the canonical spelling.
     """
 
     model = ModelHubModelConfig.from_payload(
         {
-            "id": "  " + "m" * (MODEL_ID_MAX_LENGTH + 1) + "  ",
+            "id": "  " + "m" * (256 + 1) + "  ",
             "origin": "manual",
             "reasoning_efforts": [],
         }
     )
 
-    assert model.id == "m" * (MODEL_ID_MAX_LENGTH + 1)
+    assert model.id == "m" * (256 + 1)
 
 
-def test_source_patch_rejects_one_discovered_model_under_two_spellings(tmp_path):
+@pytest.mark.parametrize("identity", ("relay-model", "模型🧪/e\u0301" * 3000), ids=("ordinary", "long-unicode"))
+def test_source_patch_rejects_one_discovered_model_under_two_spellings(tmp_path, identity):
     """Two spellings of one identity are a failed listing, not two models."""
 
     service, store, adapter = _service(tmp_path)
@@ -8831,8 +9003,8 @@ def test_source_patch_rejects_one_discovered_model_under_two_spellings(tmp_path)
 
     async def duplicate_spellings(vendor, protocol, base_url, credential_ref):
         return (
-            DiscoveredModel(id="relay-model"),
-            DiscoveredModel(id=" relay-model"),
+            DiscoveredModel(id=identity),
+            DiscoveredModel(id=" " + identity),
         )
 
     adapter.discover_models = duplicate_spellings

--- a/tests/test_model_hub_config.py
+++ b/tests/test_model_hub_config.py
@@ -1961,7 +1961,9 @@ def test_every_normalized_identifier_collection_collapses_through_one_owner():
     # without its collapse fails here instead of arriving as a finding.
     source = Path("config/v2_config.py").read_text(encoding="utf-8")
     tree = ast.parse(source)
+    parents = {child: parent for parent in ast.walk(tree) for child in ast.iter_child_nodes(parent)}
     normalizing = set()
+    validating = set()
     collapsing = set()
     for node in ast.walk(tree):
         if not isinstance(node, ast.ClassDef):
@@ -1970,12 +1972,49 @@ def test_every_normalized_identifier_collection_collapses_through_one_owner():
             if not isinstance(call, ast.Call) or not isinstance(call.func, ast.Name):
                 continue
             if call.func.id == "normalized_model_id":
-                normalizing.add(node.name)
+                # A comparison rejects an unsettled spelling; it does not
+                # produce a normalized identity or require a collapse owner.
+                owner_set = validating if isinstance(parents[call], ast.Compare) else normalizing
+                owner_set.add(node.name)
             elif call.func.id == "_collapse_settled_duplicates":
                 collapsing.add(node.name)
     assert normalizing == {"ModelHubModelConfig", "ModelHubRouteHopConfig"}
+    assert validating == {"ModelHubAgentSupplyConfig"}
     assert collapsing == {"ModelHubSourceConfig", "ModelHubRouteConfig"}
     assert len(collapsing) == len(normalizing)
+
+
+@pytest.mark.parametrize("repairing", (False, True))
+@pytest.mark.parametrize(
+    "identifier,valid",
+    [
+        ("model", True),
+        ("m" * 257, True),
+        ("模型🧪/e\u0301" * 3000, True),
+        ("legacy\ud800", True),
+        (" model ", False),
+        (" " * 257, False),
+    ],
+    ids=("ordinary", "long", "unicode", "legacy-surrogate", "padded-route", "blank-route"),
+)
+def test_opencode_aggregate_checks_spelling_without_rewriting_identity(identifier, valid, repairing):
+    payload = ModelHubAgentSupplyConfig.default("opencode", mode="hub").to_payload()
+    payload["models"] = [{"id": identifier, "origin": "manual", "native_protocol": "anthropic"}]
+    payload["routes"] = {
+        identifier: {"hops": [{"source_id": "src_test0001", "model_id": "upstream"}]},
+    }
+    before = copy.deepcopy(payload)
+
+    if not valid:
+        with pytest.raises(ValueError, match="models.id"):
+            ModelHubAgentSupplyConfig.from_payload(payload, repairing=repairing)
+    else:
+        loaded = ModelHubAgentSupplyConfig.from_payload(payload, repairing=repairing)
+        assert list(loaded.routes) == [identifier]
+        assert [model.id for model in loaded.models] == [identifier]
+        assert loaded.menu.checked == [identifier]
+        assert ModelHubAgentSupplyConfig.from_payload(loaded.to_payload()).to_payload() == loaded.to_payload()
+    assert payload == before
 
 
 def test_collapsing_a_settled_duplicate_is_a_repair_no_caller_gets_by_default():

--- a/tests/test_model_hub_json_wire.py
+++ b/tests/test_model_hub_json_wire.py
@@ -6,10 +6,77 @@ import json
 import pytest
 
 from core.handlers.model_hub.json_wire import (
+    JSON_STRING_TOKEN_BYTES,
     SelectiveJSONParser,
     project_json_reader,
     rewrite_json_strings,
 )
+
+
+@pytest.mark.parametrize("ensure_ascii", (True, False))
+@pytest.mark.parametrize("chunk_size", (1, 4093))
+def test_lossless_string_values_preserve_unicode_across_lexical_chunks(
+    ensure_ascii: bool, chunk_size: int,
+) -> None:
+    identity = '模型🧪/e\u0301"\\' * 2000
+    payload = json.dumps({"id": identity}, ensure_ascii=ensure_ascii).encode()
+    observed = []
+    parser = SelectiveJSONParser(
+        {(), ("id",)},
+        lambda path, event, value, scope: observed.append((path, event, value, scope)),
+        lossless_string_paths={("id",)},
+    )
+    for offset in range(0, len(payload), chunk_size):
+        parser.feed(payload[offset : offset + chunk_size])
+    assert parser.finish() is True
+    assert (("id",), "scalar", identity, ()) in observed
+
+
+def test_lossless_opt_in_never_unbounds_keys_or_unselected_values() -> None:
+    oversized = "x" * (JSON_STRING_TOKEN_BYTES * 2)
+    observed = []
+    parser = SelectiveJSONParser(
+        {(), ("id",), ("diagnostic",), (oversized,)},
+        lambda path, event, value, _scope: observed.append((path, event, value)),
+        lossless_string_paths={("id",), (oversized,), ("unselected",)},
+    )
+    parser.feed(b'{"')
+    parser.feed(oversized.encode())
+    assert parser.retained_bytes < JSON_STRING_TOKEN_BYTES + 1024
+    parser.feed(b'":"not a selected key","unselected":"')
+    parser.feed(oversized.encode())
+    assert parser.retained_bytes < JSON_STRING_TOKEN_BYTES + 1024
+    parser.feed(b'","diagnostic":"')
+    parser.feed(oversized.encode())
+    assert parser.retained_bytes < JSON_STRING_TOKEN_BYTES + 1024
+    parser.feed(b'","id":' + json.dumps(oversized).encode() + b"}")
+    assert parser.finish() is True
+    assert (("id",), "scalar", oversized) in observed
+    assert not any(path == (oversized,) for path, _, _ in observed)
+    assert not any(
+        event == "scalar" and value == oversized
+        for path, event, value in observed if path != ("id",)
+    )
+
+
+def test_selected_strings_remain_bounded_without_lossless_opt_in() -> None:
+    observed = []
+    assert project_json_reader(
+        io.BytesIO(json.dumps({"id": "x" * (JSON_STRING_TOKEN_BYTES + 1)}).encode()),
+        {(), ("id",)},
+        lambda path, event, value, _scope: observed.append((path, event, value)),
+    )
+    assert (("id",), "elided_string", None) in observed
+
+
+@pytest.mark.parametrize("suffix", (b'\\q"}', b'\\u000"}', b'\xff"}', b'"', b'"},', b'","other":[,]}'))
+def test_lossless_retention_does_not_relax_json_completion_or_grammar(suffix: bytes) -> None:
+    assert not project_json_reader(
+        io.BytesIO(b'{"id":"' + b"x" * (JSON_STRING_TOKEN_BYTES + 1) + suffix),
+        {(), ("id",)},
+        lambda *_args: None,
+        lossless_string_paths={("id",)},
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_model_hub_provenance.py
+++ b/tests/test_model_hub_provenance.py
@@ -8,7 +8,6 @@ import pytest
 
 from core.handlers.model_hub.adapter import RawCallOutcome, RawOutcomeKind
 from core.handlers.model_hub.classification import UPSTREAM_MACHINE_ERROR_CODES, classify_outcome
-from core.handlers.model_hub.identifiers import MODEL_ID_MAX_LENGTH
 from core.handlers.model_hub.provenance import BoundedProvenanceStore, TurnCorrelationRegistry
 from core.handlers.model_hub.rpc import dispatch_model_hub_rpc
 from core.handlers.model_hub.service import ModelHubError
@@ -179,9 +178,9 @@ def test_model_history_validates_backend_and_canonical_catalog_id(tmp_path, back
         service.get_model_provenance(backend, model)
 
 
-@pytest.mark.parametrize("backend", ["claude", "codex"])
+@pytest.mark.parametrize("backend", ["claude", "codex", "opencode"])
 def test_latest_history_reads_exact_persisted_legacy_catalog_identity(tmp_path, backend):
-    legacy = "legacy-" + "x" * MODEL_ID_MAX_LENGTH
+    legacy = "legacy-" + "模型🧪" * 3000
     service, store, adapter = _service(tmp_path, _loaded_catalog_config(backend, legacy))
     before = store.config.to_payload()
     assert service.get_model_provenance(backend, legacy) is None
@@ -191,7 +190,7 @@ def test_latest_history_reads_exact_persisted_legacy_catalog_identity(tmp_path, 
     with pytest.raises(ModelHubError):
         service.get_model_provenance(backend, f" {legacy} ")
     with pytest.raises(ModelHubError):
-        service.get_model_provenance(backend, "new-" + "x" * MODEL_ID_MAX_LENGTH)
+        service.get_model_provenance(backend, "new-" + "x" * 256)
     assert store.config.to_payload() == before
     assert adapter.synced == []
 

--- a/tests/test_model_hub_routing_modes.py
+++ b/tests/test_model_hub_routing_modes.py
@@ -17,7 +17,6 @@ from config.v2_config import (
     ModelHubSourceStateConfig,
 )
 from core.handlers.model_hub.adapter import RawCallOutcome, RawOutcomeKind, SourceBinding
-from core.handlers.model_hub.identifiers import MODEL_ID_MAX_LENGTH
 from core.handlers.model_hub.resolver import effective_model_route, resolve_model_hub_turn
 from core.handlers.model_hub.service import ModelHubError
 from scripts.check_model_hub_authorities import AuthorityInput, _typescript_string_union
@@ -521,7 +520,7 @@ def test_normalization_preserves_nonempty_intent_and_other_config_through_refres
     agent = config.agents[backend]
     shapes = {
         "exact": [(api.id, MODEL)],
-        "unknown-long": [(api.id, "legacy-" + "x" * MODEL_ID_MAX_LENGTH)],
+        "unknown-long": [(api.id, "legacy-" + "x" * 256)],
         "retired": [(retired.id, "retired")],
         "subscription-stale": [(subscription.id, "stale")],
         "ordered": [(subscription.id, "known"), (api.id, "mapped")],
@@ -671,11 +670,11 @@ def test_refresh_preserves_guard_for_disappearing_inventory_matches(tmp_path, ba
     assert result["interrupted"] == []
 
 
-@pytest.mark.parametrize("backend", ["claude", "codex"])
+@pytest.mark.parametrize("backend", ["claude", "codex", "opencode"])
 @pytest.mark.parametrize("state", ["automatic", "manual", "empty"])
 @pytest.mark.parametrize("operation", ["put", "preview", "restore_preview", "restore_save"])
 def test_persisted_legacy_catalog_identity_survives_route_consumers(tmp_path, backend, state, operation):
-    requested = "legacy-" + "x" * MODEL_ID_MAX_LENGTH
+    requested = "legacy-" + "模型🧪/" * 3000
     source = _source("src_legacy001", (requested,))
     config = _loaded_catalog_config(backend, requested, source)
     route = {"hops": [] if state == "empty" else [{"source_id": source.id, "model_id": "mapped-target"}]}
@@ -729,16 +728,19 @@ def test_persisted_legacy_catalog_identity_survives_route_consumers(tmp_path, ba
         assert adapter.synced == []
 
 
-def test_opencode_existing_loader_still_rejects_overlength_catalog_identity():
-    with pytest.raises(ValueError, match="models.id"):
-        _loaded_catalog_config("opencode", "x" * (MODEL_ID_MAX_LENGTH + 1))
+@pytest.mark.parametrize("backend", ["claude", "codex", "opencode"])
+def test_persisted_unencodable_catalog_identity_still_loads(backend):
+    identifier = "legacy\ud800"
+    loaded = _loaded_catalog_config(backend, identifier)
+    assert loaded.agents[backend].models[0].id == identifier
+    assert ModelHubConfig.from_payload(loaded.to_payload()).to_payload() == loaded.to_payload()
 
 
 @pytest.mark.parametrize("backend", ["claude", "codex", "opencode"])
 @pytest.mark.parametrize("kind", ["api_key", "subscription"])
 @pytest.mark.parametrize("evidence", ["override", "inventory"])
 def test_existing_long_target_identity_can_be_saved_and_reordered(tmp_path, backend, kind, evidence):
-    target = "legacy-target-" + "x" * MODEL_ID_MAX_LENGTH
+    target = "legacy-target-" + "x" * 256
     source = _source("src_legacy001", (target,) if evidence == "inventory" else (), kind=kind)
     other = _source("src_legacy002", ("other",), kind=kind)
     config = _loaded_catalog_config(backend, MODEL, source, other)
@@ -759,11 +761,12 @@ def test_existing_long_target_identity_can_be_saved_and_reordered(tmp_path, back
 
 
 @pytest.mark.parametrize("backend", ["claude", "codex", "opencode"])
-@pytest.mark.parametrize("target_kind", ["new_long", "padded_known", "padded_long", "other_source_long"])
-def test_new_target_admission_cannot_reuse_legacy_identity_exceptions(tmp_path, backend, target_kind):
-    legacy = "legacy-" + "x" * MODEL_ID_MAX_LENGTH
-    source = _source("src_legacy001", ("known", legacy))
-    other = _source("src_legacy002", ())
+@pytest.mark.parametrize("kind", ["api_key", "subscription"])
+@pytest.mark.parametrize("target_kind", ["new_long", "padded_known", "padded_long", "other_source_long", "unencodable"])
+def test_new_target_admission_keeps_spelling_and_source_policy(tmp_path, backend, kind, target_kind):
+    legacy = "legacy-" + "x" * 256
+    source = _source("src_legacy001", ("known", legacy), kind=kind)
+    other = _source("src_legacy002", (), kind=kind)
     config = _loaded_catalog_config(backend, MODEL, source, other)
     config.agents[backend].routes[MODEL] = ModelHubRouteConfig.from_payload(
         {
@@ -772,13 +775,19 @@ def test_new_target_admission_cannot_reuse_legacy_identity_exceptions(tmp_path, 
     )
     service, store, adapter = _service(tmp_path, ModelHubConfig.from_payload(config.to_payload()))
     target = {
-        "new_long": "new-" + "x" * MODEL_ID_MAX_LENGTH,
+        "new_long": "new-" + "x" * 256,
         "padded_known": " known ",
         "padded_long": f" {legacy} ",
         "other_source_long": legacy,
+        "unencodable": "new-" + "x" * 17000 + "\ud800",
     }[target_kind]
     route = {"hops": [{"source_id": other.id if target_kind == "other_source_long" else source.id, "model_id": target}]}
     before = store.config.to_payload()
+    if kind == "api_key" and target_kind in {"new_long", "other_source_long"}:
+        assert service.preview_agent_chain(backend, MODEL, {"manual_override": route})["manual_override"] == route
+        assert asyncio.run(service.set_agent_chain(backend, MODEL, route))["chain"]["manual_override"] == route
+        assert ModelHubConfig.from_payload(store.config.to_payload()).to_payload() == store.config.to_payload()
+        return
     with pytest.raises(ModelHubError):
         service.preview_agent_chain(backend, MODEL, {"manual_override": route})
     with pytest.raises(ModelHubError):
@@ -798,7 +807,7 @@ def test_new_target_admission_cannot_reuse_legacy_identity_exceptions(tmp_path, 
     ],
 )
 def test_legacy_target_retirement_keeps_existing_source_policy(tmp_path, backend, kind, existing, allowed):
-    target = "retired-" + "x" * MODEL_ID_MAX_LENGTH
+    target = "retired-" + "x" * 256
     source = _source("src_legacy001", (target,), kind=kind)
     source.models[0].retired = True
     config = _loaded_catalog_config(backend, MODEL, source)

--- a/tests/test_model_hub_runtime.py
+++ b/tests/test_model_hub_runtime.py
@@ -2208,16 +2208,17 @@ def test_oauth_source_bindings_are_scoped_and_follow_reauthentication(tmp_path: 
 
 
 @contextmanager
-def _models_endpoint():
+def _models_endpoint(model_ids=("model-a", "model-b")):
     class Handler(BaseHTTPRequestHandler):
         authorization: str | None = None
+        invocations: list[tuple[str, dict]] = []
 
         def log_message(self, *args):
             pass
 
         def do_GET(self):
             Handler.authorization = self.headers.get("Authorization")
-            body = json.dumps({"data": [{"id": "model-a"}, {"id": "model-b"}]}).encode()
+            body = json.dumps({"data": [{"id": model_id} for model_id in model_ids]}).encode()
             self.send_response(200)
             self.send_header("Content-Type", "application/json")
             self.send_header("Content-Length", str(len(body)))
@@ -2227,6 +2228,34 @@ def _models_endpoint():
             self.wfile.flush()
             time.sleep(0.05)
             self.wfile.write(body[midpoint:])
+
+        def do_POST(self):
+            payload = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+            Handler.invocations.append((self.path, payload))
+            if self.path == "/v1/messages":
+                result = {
+                    "id": "msg-fixture", "type": "message", "role": "assistant",
+                    "content": [{"type": "text", "text": "ok"}], "stop_reason": "end_turn",
+                    "usage": {"input_tokens": 1, "output_tokens": 1},
+                }
+            elif self.path == "/v1/responses":
+                result = {
+                    "id": "resp-fixture", "object": "response", "status": "completed",
+                    "output": [{"type": "message", "content": [{"type": "output_text", "text": "ok"}]}],
+                    "usage": {"input_tokens": 1, "output_tokens": 1},
+                }
+            else:
+                result = {
+                    "id": "chat-fixture", "object": "chat.completion",
+                    "choices": [{"message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}],
+                    "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+                }
+            body = json.dumps(result).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
 
     server = HTTPServer(("127.0.0.1", 0), Handler)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
@@ -2238,6 +2267,63 @@ def _models_endpoint():
         server.shutdown()
         server.server_close()
         thread.join(timeout=2)
+
+
+@pytest.mark.parametrize(
+    ("protocol", "config_key", "endpoint"),
+    (("anthropic", "claude-api-key", "/v1/messages"),
+     ("openai_responses", "codex-api-key", "/v1/responses"),
+     ("openai_chat", "openai-compatibility", "/v1/chat/completions")),
+)
+def test_long_inventory_identity_reaches_runtime_config_and_http_consumer(
+    tmp_path: Path, protocol: str, config_key: str, endpoint: str,
+) -> None:
+    head = "模型🧪/e\u0301" * 3000
+    identities = (head + "-one", head + "-two")
+    route_only = head + "-unlisted"
+
+    async def run(base_url, handler):
+        discovered = await client_module.probe_models(
+            vendor="custom", protocol=protocol, base_url=base_url, secret=None,
+        )
+        assert tuple(model.id for model in discovered) == identities
+        store = EngineStateStore(tmp_path / "state")
+        instance_dir, secrets = store.prepare_instance("install-1")
+        credential_ref = store.store_api_key("synthetic-secret", base_url=base_url, protocol=protocol)
+        binding = _binding(
+            credential_ref, protocol=protocol, base_url=base_url,
+            model_ids=identities, route_model_ids=(route_only,),
+        )
+        store.sync_sources([binding])
+        source = EngineStateStore(tmp_path / "state").get_source(binding.source_id)
+        assert source is not None
+        assert source.model_ids == identities
+        assert source.route_model_ids == (route_only,)
+        config_path = instance_dir / "config.yaml"
+        write_engine_config(
+            config_path, host="127.0.0.1", port=18231, auth_dir=store.auth_dir,
+            runtime_secrets=secrets, sources=[source], state_store=store,
+        )
+        config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert config[config_key][0]["models"] == [
+            {"name": identity, "alias": identity} for identity in (*identities, route_only)
+        ]
+        client = EngineClient(EngineConnection(base_url.removesuffix("/v1"), "management", "gateway"))
+        for identity in (*identities, route_only):
+            handle = await client.invoke(source, identity, {}, stream=False)
+            try:
+                outcome = await handle.outcome()
+                assert outcome.kind is RawOutcomeKind.SUCCESS
+                assert outcome.model_id == identity
+                assert outcome.source_id == source.source_id
+            finally:
+                await handle.close_stream()
+        assert [(path, body["model"]) for path, body in handler.invocations] == [
+            (endpoint, f"{source.prefix}/{identity}") for identity in (*identities, route_only)
+        ]
+
+    with _models_endpoint(identities) as (base_url, handler):
+        asyncio.run(run(base_url, handler))
 
 
 def test_model_inventory_duplicate_top_level_members_replace_earlier_values() -> None:
@@ -2388,14 +2474,66 @@ def test_model_inventory_duplicate_ids_keep_the_first_complete_record() -> None:
     ]
 
 
-def test_model_inventory_rejects_an_elided_model_identifier() -> None:
-    oversized = b"x" * (16 * 1024 + 1)
+@pytest.mark.parametrize(("member", "result_index"), (("data", 2), ("models", 5)))
+@pytest.mark.parametrize("object_rows", (True, False))
+@pytest.mark.parametrize("ensure_ascii", (True, False))
+def test_model_inventory_preserves_complete_long_unicode_identities(
+    member: str, result_index: int, object_rows: bool, ensure_ascii: bool,
+) -> None:
+    head = "模型🧪/e\u0301" * 3000
+    ids = [f"{head}-one", f"{head}-two", "é", "e\u0301", "x" * 16385]
+    rows = [{"id": model_id} for model_id in ids] if object_rows else ids
+    projected = client_module._project_model_inventory(
+        io.BytesIO(json.dumps({member: rows, "ignored": "x" * 100_000}, ensure_ascii=ensure_ascii).encode())
+    )
+    assert projected is not None
+    assert projected[result_index] == [DiscoveredModel(id=model_id) for model_id in ids]
+
+
+@pytest.mark.parametrize(("member", "result_index"), (("data", 2), ("models", 5)))
+@pytest.mark.parametrize(
+    "parameters", (("reasoning", "模型🧪" * 6000), (" " * 16385 + "reasoning",)),
+    ids=("reasoning-with-long-unknown", "long-padded-reasoning"),
+)
+def test_model_inventory_retains_reasoning_evidence_past_diagnostic_budget(
+    member: str, result_index: int, parameters: tuple[str, ...],
+) -> None:
+    from core.handlers.model_hub.reasoning_tiers import resolve_reasoning_tiers
 
     projected = client_module._project_model_inventory(
-        io.BytesIO(b'{"data":[{"id":"valid"},{"id":"' + oversized + b'"}]}')
+        io.BytesIO(json.dumps({member: [{"id": "unknown-model", "supported_parameters": parameters}]}).encode())
     )
+    assert projected is not None
+    model = projected[result_index][0]
+    assert model.supported_parameters == parameters
+    resolution = resolve_reasoning_tiers(
+        protocol="openai_chat", model_id=model.id,
+        supported_parameters=model.supported_parameters, catalog_efforts_by_model={},
+    )
+    assert resolution.source == "upstream"
+    assert resolution.efforts
 
-    assert projected is None
+
+def test_model_inventory_lossless_values_keep_duplicate_member_and_id_scope() -> None:
+    first, second = "模型🧪" * 6000, "m" * 17000
+    quoted_first, quoted_second = json.dumps(first), json.dumps(second)
+    projected = client_module._project_model_inventory(
+        io.BytesIO(
+            (
+                '{"data":[{"id":"stale"}],"data":['
+                f'{{"id":"stale","id":{quoted_first},"supported_parameters":["stale"],'
+                f'"supported_parameters":[{quoted_second},"reasoning"]}},'
+                f'{{"id":{quoted_first},"supported_parameters":["temperature"]}},'
+                f'{{"id":{quoted_second},"supported_parameters":["tools"]}}'
+                ']}'
+            ).encode()
+        )
+    )
+    assert projected is not None
+    assert projected[2] == [
+        DiscoveredModel(id=first, supported_parameters=(second, "reasoning")),
+        DiscoveredModel(id=second, supported_parameters=("tools",)),
+    ]
 
 
 def test_adapter_provisions_probes_and_revokes_credential(tmp_path: Path) -> None:

--- a/tests/test_model_hub_usage.py
+++ b/tests/test_model_hub_usage.py
@@ -29,9 +29,9 @@ import pytest
 
 from config.v2_config import ModelHubModelConfig
 from core.handlers.model_hub.identifiers import (
-    MODEL_ID_MAX_LENGTH,
     USAGE_LEDGER_KEY_MAX_LENGTH,
     USAGE_LEDGER_VERBATIM_MAX_LENGTH,
+    canonical_model_id,
     persisted_ledger_key,
     usage_ledger_key,
 )
@@ -1174,27 +1174,27 @@ def test_an_unusable_identifier_is_never_persisted(
             "m" * (USAGE_LEDGER_VERBATIM_MAX_LENGTH + 1),
             id="one-past-the-ledger-verbatim-bound",
         ),
-        pytest.param("m" * MODEL_ID_MAX_LENGTH, id="at-the-admission-bound"),
-        pytest.param("m" * (MODEL_ID_MAX_LENGTH + 1), id="one-past-it"),
+        pytest.param("m" * 256, id="at-the-former-admission-bound"),
+        pytest.param("m" * 257, id="past-the-former-admission-bound"),
         pytest.param("m" * (USAGE_LEDGER_KEY_MAX_LENGTH * 4), id="far-past-it"),
+        pytest.param("模型🧪/e\u0301" * 3000, id="long-unicode"),
         pytest.param("", id="empty"),
         pytest.param(None, id="not-text"),
     ],
 )
 def test_metering_can_key_exactly_the_identities_a_config_can_hold(identifier: object) -> None:
-    """MH-USAGE-006, review 4965885614: two bounds, and only one of them may refuse.
+    """MH-USAGE-006: loading and metering do not reapply new-ID admission.
 
-    The admission bound is not a load rule, so `from_payload` keeps a longer
-    persisted identifier loadable and routable on purpose. Asking the admission
-    question again at the ledger made that population unmeterable — a turn served
-    without a trace in the tab. So the config constructor, not a list written here,
-    decides which identities exist, and this asserts the ledger can key every one
-    of them: the two halves cannot drift apart without failing.
+    This population covers ordinary, long, padded, and short blank historical
+    text. It is not a proof over every loadable legacy value: long all-whitespace
+    and unencodable historical IDs have known exceptions recorded in the
+    identifier-boundary assessment.
 
     Keying the loaded value and the raw payload alike stops one model from occupying
     two rows. The length assertion is the review-4966041599 property: a key is either
     within the stable verbatim bound or exactly a folded key's length, never in
-    between, so no admitted identifier can occupy the folded form. And the read path
+    between. A literal occupying the folded form is folded again on live derivation.
+    The separate read path
     returns a derived key unchanged, so a row read back after a restart is the row
     that was written — the guarantee that used to be spelled as self-idempotence,
     which is what forced the fold to start too late.
@@ -1231,9 +1231,10 @@ def test_metering_can_key_exactly_the_identities_a_config_can_hold(identifier: o
             "m" * (USAGE_LEDGER_VERBATIM_MAX_LENGTH + 1),
             id="one-past-the-ledger-verbatim-bound",
         ),
-        pytest.param("m" * MODEL_ID_MAX_LENGTH, id="at-the-admission-bound"),
-        pytest.param("m" * (MODEL_ID_MAX_LENGTH + 1), id="one-past-it"),
+        pytest.param("m" * 256, id="at-the-former-admission-bound"),
+        pytest.param("m" * 257, id="past-the-former-admission-bound"),
         pytest.param("m" * (USAGE_LEDGER_KEY_MAX_LENGTH * 4), id="far-past-it"),
+        pytest.param("模型🧪/e\u0301" * 3000, id="long-unicode"),
     ],
 )
 def test_a_model_a_legacy_file_still_routes_accumulates_one_row_across_restarts(
@@ -1280,31 +1281,37 @@ def test_two_identities_sharing_a_bounded_head_are_metered_apart(tmp_path: Path)
 
 
 def test_no_two_identities_a_config_holds_can_share_one_row(tmp_path: Path) -> None:
-    """MH-USAGE-007, review 4966041599: a key this ledger derives is itself a legal ID.
+    """MH-USAGE-007: folded-looking live literals are not persisted-key reads.
 
-    Nothing stops a config from holding, as one model's literal ID, the exact string
-    the ledger derives for another — `from_payload` accepts any non-empty text, and
-    the assertion below checks that rather than assuming it. So the identities under
-    test are closed under keying: every seed, plus the key that seed folds to. If
-    keying is not injective over that closure, two models a user configured
-    separately are one row and one is billed for the other's calls.
-
-    Stated as the closure rather than as the pair that exposed it, because the pair
-    is only reachable while some legal identifier can occupy a derived key's shape —
-    and any rule that leaves such a shape reachable fails here without being named.
+    Every seed and two generations of its derived keys are admitted as distinct
+    model identities. Live derivation, repeated reloads, aggregation, and full
+    label joins must agree for this nonblank UTF-8 population. This is regression
+    evidence, not a mathematical injectivity claim or a guarantee for malformed
+    legacy text.
     """
 
     seeds = (
         "model-x",
         "m" * USAGE_LEDGER_VERBATIM_MAX_LENGTH,
         "m" * (USAGE_LEDGER_VERBATIM_MAX_LENGTH + 1),
-        "n" * MODEL_ID_MAX_LENGTH,
+        "n" * 256,
+        "n" * 257,
         "z" * (USAGE_LEDGER_KEY_MAX_LENGTH * 3),
+        "模型🧪/e\u0301" * 3000 + "-one",
+        "模型🧪/e\u0301" * 3000 + "-two",
+        "é",
+        "e\u0301",
+        "x" * 16385,
     )
-    identities = sorted({*seeds, *(usage_ledger_key(seed) for seed in seeds)})
+    first_generation = {usage_ledger_key(seed) for seed in seeds}
+    identities = sorted({
+        *seeds, *first_generation, *(usage_ledger_key(key) for key in first_generation),
+    })
 
     ledger = _ledger(tmp_path)
     for identity in identities:
+        assert canonical_model_id(identity) == identity
+        assert persisted_ledger_key(usage_ledger_key(identity)) == usage_ledger_key(identity)
         assert (
             ModelHubModelConfig.from_payload(
                 {"id": identity, "origin": "manual", "reasoning_efforts": []}
@@ -1317,6 +1324,21 @@ def test_no_two_identities_a_config_holds_can_share_one_row(tmp_path: Path) -> N
 
     assert len({usage_ledger_key(identity) for identity in identities}) == len(identities)
     assert [row["requests"] for row in rows] == [1] * len(identities)
+    original_keys = {row["model_id"] for row in rows}
+    for expected_requests in (2, 3):
+        ledger = _ledger(tmp_path)
+        for identity in identities:
+            ledger.record(source_id="src_a", model_id=identity, usage=None, at=NOW)
+        rows = _ledger(tmp_path).window(days=30, now=NOW)
+        assert {row["model_id"] for row in rows} == original_keys
+        assert [row["requests"] for row in rows] == [expected_requests] * len(identities)
+    summary = _ledger(tmp_path).summary(
+        days=30, now=NOW,
+        identities=[SourceIdentity(source_id="src_a", label="source", model_ids=identities)],
+    )
+    assert {model["model_id"]: model["label"] for model in summary["sources"][0]["models"]} == {
+        usage_ledger_key(identity): identity for identity in identities
+    }
 
 
 @pytest.mark.parametrize(
@@ -1487,7 +1509,9 @@ def test_a_label_reaches_the_row_of_every_identity_the_ledger_can_key(tmp_path: 
     """
 
     sources = _keying_populations("src_")
-    models = _keying_populations("model-")
+    long_model = "模型🧪/e\u0301" * 3000
+    folded_literal = usage_ledger_key(long_model)
+    models = (*_keying_populations("model-"), long_model, folded_literal, usage_ledger_key(folded_literal))
     # The test is only the test while the seeds span both populations: an all-verbatim
     # set would pass against a read that never keyed anything.
     assert {identity == usage_ledger_key(identity) for identity in (*sources, *models)} == {
@@ -1499,6 +1523,7 @@ def test_a_label_reaches_the_row_of_every_identity_the_ledger_can_key(tmp_path: 
     for source_id in sources:
         for model_id in models:
             ledger.record(source_id=source_id, model_id=model_id, usage=None, at=NOW)
+    ledger = _ledger(tmp_path)
 
     def summarize(naming: str) -> dict:
         return ledger.summary(

--- a/ui/src/components/settings/models/BackendModelEditorDialog.test.tsx
+++ b/ui/src/components/settings/models/BackendModelEditorDialog.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { act, cleanup, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { I18nextProvider } from 'react-i18next';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -85,7 +85,7 @@ afterEach(() => {
 });
 
 describe('BackendModelEditorDialog', () => {
-  it('refuses an empty, overlong, or already-taken model ID', async () => {
+  it('refuses an empty or already-taken model ID', async () => {
     const user = userEvent.setup();
     const { onCommit } = renderEditor({ takenIds: new Set(['taken']) });
 
@@ -108,18 +108,19 @@ describe('BackendModelEditorDialog', () => {
     });
   });
 
-  it('caps the ID at the contract length while it can still be typed', async () => {
+  it.each(['x'.repeat(257), '模型🧪/e\u0301'.repeat(3000)])('submits a long pasted ID without shortening it (%#)', async (identifier) => {
     const user = userEvent.setup();
-    const { onCommit } = renderEditor();
+    const { onCommit } = renderEditor({ backend: 'opencode' });
 
-    expect(modelField().getAttribute('maxlength')).toBe('256');
-    // The browser stops at the cap, so reaching the error needs a value the
-    // field never lets a keystroke produce.
-    fireEvent.change(modelField(), { target: { value: 'x'.repeat(257) } });
+    expect(modelField().getAttribute('maxlength')).toBeNull();
+    await user.click(modelField());
+    await user.paste(`  ${identifier}  `);
+    await waitFor(() => expect(search).toHaveBeenCalledWith(
+      expect.stringContaining(identifier), expect.any(AbortSignal),
+    ));
     await user.click(screen.getByRole('button', { name: 'Add model' }));
 
-    expect(onCommit).not.toHaveBeenCalled();
-    expect(screen.getByText('A model ID may be at most 256 characters.')).toBeTruthy();
+    expect(onCommit).toHaveBeenCalledWith(expect.objectContaining({ id: identifier }));
   });
 
   it('edits a persisted ID that predates the length cap', async () => {
@@ -135,10 +136,9 @@ describe('BackendModelEditorDialog', () => {
     };
     const { onCommit } = renderEditor({ model: legacy, takenIds: new Set([legacy.id]) });
 
-    // Shown in full, not clipped: the cap belongs to what can be typed.
+    // The full persisted ID remains read-only while its metadata is editable.
     expect(modelField().value).toBe(legacy.id);
     expect(modelField().getAttribute('maxlength')).toBeNull();
-    expect(screen.queryByText('A model ID may be at most 256 characters.')).toBeNull();
 
     await user.type(screen.getByLabelText('Display name'), 'Legacy house model');
     await user.clear(screen.getByLabelText('Maximum output'));

--- a/ui/src/components/settings/models/BackendModelEditorDialog.tsx
+++ b/ui/src/components/settings/models/BackendModelEditorDialog.tsx
@@ -26,7 +26,6 @@ import { apiFailure, modelsApi } from './modelsApi';
 import { modelsDevFillFailureKey } from './serverCopy';
 import {
   BACKEND_MODEL_EFFORT_MAX_LENGTH,
-  BACKEND_MODEL_ID_MAX_LENGTH,
   BACKEND_MODEL_INPUT_MODALITIES,
   BACKEND_MODEL_OUTPUT_MODALITIES,
   NATIVE_PROTOCOLS,
@@ -250,20 +249,14 @@ export const BackendModelEditorDialog: React.FC<{
    * resolving it again would rename a saved row whose id predates the rule.
    */
   const resolved = creating ? draftWithId(draft, trimmedId, backend) : draft;
-  // Every id rule is a rule about what the user may type, and only add mode lets
-  // them type it — an edit shows the id read-only. Judging a value the dialog
-  // itself locks is what made a persisted row whose id predates the length
-  // ceiling uneditable: its metadata is the part the backend still accepts, yet
-  // Save refused it and pointed at the one field nobody could shorten.
+  // Existing IDs are read-only; only a newly entered identity needs these checks.
   const idError = !creating
     ? null
     : trimmedId === ''
       ? 'required'
-      : resolved.id.length > BACKEND_MODEL_ID_MAX_LENGTH
-        ? 'tooLong'
-        : takenIds.has(resolved.id)
-          ? 'duplicate'
-          : null;
+      : takenIds.has(resolved.id)
+        ? 'duplicate'
+        : null;
   const valid = idError === null && context.ok && output.ok;
 
   const patch = (next: Partial<BackendModel>) => setDraft((current) => ({ ...current, ...next }));
@@ -447,9 +440,6 @@ export const BackendModelEditorDialog: React.FC<{
                     aria-autocomplete="list"
                     aria-activedescendant={lookupOpen ? `${listId}-${activeRow}` : undefined}
                     aria-invalid={Boolean(idHint)}
-                    // The ceiling belongs to the field that can still be typed
-                    // into; a read-only legacy id is shown in full, not clipped.
-                    maxLength={creating ? BACKEND_MODEL_ID_MAX_LENGTH : undefined}
                     spellCheck={false}
                     autoComplete="off"
                     onChange={(event) => changeId(event.target.value)}

--- a/ui/src/components/settings/models/types.ts
+++ b/ui/src/components/settings/models/types.ts
@@ -173,7 +173,6 @@ export type BackendModelInputModality = (typeof BACKEND_MODEL_INPUT_MODALITIES)[
  *  future divergence is a contract edit and not a UI condition. */
 export const BACKEND_MODEL_OUTPUT_MODALITIES = ['text', 'image', 'audio', 'video'] as const;
 export type BackendModelOutputModality = (typeof BACKEND_MODEL_OUTPUT_MODALITIES)[number];
-export const BACKEND_MODEL_ID_MAX_LENGTH = 256 as const;
 export const BACKEND_MODEL_EFFORT_MAX_LENGTH = 64 as const;
 export const NATIVE_PROTOCOLS = ['openai_responses', 'anthropic'] as const;
 export type NativeProtocol = (typeof NATIVE_PROTOCOLS)[number];

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -1039,7 +1039,6 @@
             "label": "Model",
             "placeholder": "Search models.dev or enter a model ID",
             "required": "Enter a backend model ID.",
-            "tooLong": "A model ID may be at most 256 characters.",
             "duplicate": "This list already has a model with this ID."
           },
           "displayName": {

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -1039,7 +1039,6 @@
             "label": "模型",
             "placeholder": "搜索 models.dev 或输入模型 ID",
             "required": "请填写 Backend 模型 ID。",
-            "tooLong": "模型 ID 最多 256 个字符。",
             "duplicate": "列表中已存在相同 ID 的模型。"
           },
           "displayName": {

--- a/vibe/model_hub_runtime/client.py
+++ b/vibe/model_hub_runtime/client.py
@@ -959,7 +959,16 @@ def _project_model_inventory(
             )
         return result
 
-    if not project_json_reader(reader, paths, visit) or not root_is_map:
+    # IDs select routes; supported parameters feed the reasoning-tier consumer.
+    # Neither is a diagnostic copy that can be elided without changing behavior.
+    lossless_paths = {
+        (member, *suffix)
+        for member in ("data", "models")
+        for suffix in (("*",), ("*", "id"), ("*", "supported_parameters", "*"))
+    }
+    if not project_json_reader(
+        reader, paths, visit, lossless_string_paths=lossless_paths
+    ) or not root_is_map:
         return None
     if (data_seen and invalid_data_models) or (
         not data_seen and fallback_seen and invalid_fallback_models


### PR DESCRIPTION
## Outcome and scope

Remove Model Hub's arbitrary 256-character model-ID admission limit without
shortening identities or changing historical usage keys. This is the independent
lane C PR; the shared plan also records other lanes' decisions, but their product
changes are not included and this PR has no unmerged peer dependency.

- New IDs retain their complete canonical spelling and must be nonblank,
  credential-free UTF-8-representable text. Legacy loading does not reapply
  new-ID admission.
- Discovery materializes only inventory ID and supported-parameter string
  values losslessly. Other strings/object keys remain bounded; parser grammar,
  duplicate scopes, document completion, spooling, and deadlines remain intact.
- Remove editor/type/schema/query length mirrors; retain duplicate checks,
  Source/backend eligibility, retirement policy, credential scanning, and exact
  Source/model identity.
- Separate OpenCode aggregate spelling checks and whole-list edits from new-ID
  admission. The root's test-only integration repair distinguishes validating
  versus producing normalization owners and adds 12 consuming load cases.
- Both usage-key executable bodies and all of `usage.py` are byte-identical to
  shared base `76e269c9a9dfd3a6286ce0da81b77316ca4be38a`. No ledger migration,
  new dependency, runtime flag, engine pin, or workflow change.

## Exact-head local validation

Head: `4ef0c7e4d76e32394299bec26bed721480886a11`.
Landed `master` merged normally: `4a504f375b73f9e23b058d914398ec76abf8c1a6`.

- 1315 Python tests passed: complete API/config/runtime/parser/usage/routing/
  provenance/migration/catalog files relevant to this boundary.
- 64 UI tests passed: model editor, catalog dialog, and Source-create contract.
- UI test type checking, production build, lint-baseline, authority closure,
  changed-Python Ruff 0.4.9, and whitespace checks passed.
- Long Unicode and escaped inventory, parameter reasoning evidence, credential
  tails, full UI submission/query/path consumers, and all three protocol HTTP
  request bodies are covered with isolated fixtures.
- 25 valid identities including two folded-literal generations retain separate
  usage across 75 calls and reloads. 28 Source/model label pairs also round-trip.

No combined-integration or other lane's browser counts are credited here.
SQLAlchemy index-reflection and UI dependency/chunk warnings were non-fatal.

## Scenarios and boundaries

Existing `MH-USAGE-006`, `MH-USAGE-007`, `MH-USAGE-008`, and `MH-MIG-001`
coverage is extended; no scenario namespace is allocated. The three usage
scenario descriptions are qualified to the tested valid population.
The full boundary inventory and evidence are in
`docs/plans/model-hub-identifier-boundary-assessment.md`.

## Known-by-design ledger

- Historical long all-whitespace IDs can already have ambiguous attribution,
  and persisted unpaired surrogates can already fail later encoding. New IDs
  reject these malformed cases; this PR does not guess, split, or rekey history.
- A model-ID field has no numeric admission ceiling, but generic body/URI and
  transport/resource limits still exist. The test client's 65,536-character URL
  budget is unchanged. Full long IDs pass JSON body, service, runtime body, and
  reload consumers; encoded path/query behavior is tested within transport limits.
- Lossless inventory facts necessarily require memory proportional to their
  values. Unrelated observations remain bounded.
- Runtime HTTP evidence uses a hermetic mock engine/upstream. It does not prove
  the pinned engine's interpretation or arbitrary browser/proxy URI support.
- An older OpenCode loader can still reject newly supported long catalog data
  after a code downgrade; no downgrade-compatibility promise is made.
- Gateway envelopes, capability/launch policy, engine source/pin/config policy,
  credentials, and running local services are not changed.

## Delivery

Root Session `sesvmgbdub2gp` independently verifies exact-head Codex, all 17
expected lint jobs in every matching run, zero unresolved paginated threads,
and CLEAN merge state, then performs the authorized merge. Lane C keeps its
original durable PR/CI Watch live until root explicitly authorizes removal.
No release, deploy, running-local restart, or primary-checkout update is authorized.
