### PR TITLE
feat(ui): make memory profile entries independently collapsible

### DIFF
--- a/docs/plans/memory-profile-collapsible-details.md
+++ b/docs/plans/memory-profile-collapsible-details.md
@@ -1,0 +1,108 @@
+# Memory profile: progressive disclosure for explicit-info / implicit-trait rows
+
+## Background
+
+Owner session `sesehz3dgw5ua` approved a displayed interaction mockup on
+2026-09-09 ("按这个样式实现"). This document is the copied product contract for
+the resulting frontend-only PR. Delivered by a delegated implementation lane;
+the dispatching PM session (`sesehz3dgw5ua`) owns integration, merge, and
+deploy decisions.
+
+`StructuredMemoryProfile` (in
+`ui/src/components/settings/memory/MemoryProfilePanel.tsx`) renders a memory
+profile's `summary`, `explicit_info` (category/description/evidence) and
+`implicit_traits` (trait/description/basis/evidence). Every entry currently
+renders fully expanded; this task adds independent progressive disclosure per
+entry, entirely on the frontend.
+
+## Goal
+
+Each explicit-info and implicit-trait entry becomes independently collapsible,
+initially closed, without any backend/API/EverOS change, new dependency, or
+global/persisted state.
+
+## Approved UI contract
+
+1. Each explicit-info and implicit-trait entry is independently collapsible,
+   initially closed. Closed row shows ONLY the existing category/trait label
+   styled consistently with the existing `Badge`, plus an expansion chevron.
+   The full row is the clickable/keyboard target, with a visible focus ring
+   and correct disclosure semantics (`aria-expanded` on the trigger). Long
+   Unicode titles remain usable on mobile with no horizontal overflow.
+2. Expanding a row reveals the unchanged description and existing basis, then
+   an independently initially-collapsed evidence disclosure labeled with the
+   existing localized evidence key (`memory.profile.evidence`, i.e. 相关证据 in
+   zh). Opening a row must NOT auto-expand its evidence. Evidence
+   absent/empty ⇒ no evidence toggle at all. No nested
+   button-inside-button/invalid `<summary>` controls.
+3. Multiple entries may be open simultaneously; toggling one entry or its
+   evidence must not affect siblings. Implemented with local component state
+   (`useState` per row) — the smallest existing/native disclosure primitive,
+   matching the button+chevron+`aria-expanded` idiom already used in
+   `ui/src/components/workbench/WorkbenchSidebar.tsx`. No new dependency, no
+   global state, no persistence. State lives only for the mounted entry;
+   remounting (e.g. after a profile reload) initializes closed again.
+4. Missing or whitespace-only `category`/`trait` gets a localized numbered
+   fallback (`memory.profile.entryFallback`, "Profile entry {{number}}" /
+   "画像条目 {{number}}"), numbered deterministically 1..N within its own
+   section (explicit-info numbering is independent from implicit-traits
+   numbering) so every entry stays discoverable. Provider data is never
+   mutated — the fallback is display-only.
+5. Overall profile `summary` stays expanded and unchanged. Card
+   metadata/date/origin and section headers are unchanged. Legacy
+   unstructured `item.text` rendering is unchanged (no parsing of arbitrary
+   text into sections). Provider strings remain inert text (never
+   markdown/HTML). No truncation of descriptions/evidence, no ID/date
+   rewriting.
+
+## Non-goals / explicit exclusions
+
+- No backend, API, or EverOS changes.
+- No new UI dependency, no accordion library.
+- No persisted/global expand state (no localStorage, no context).
+- No redesign — reuse existing Badge, existing button/chevron disclosure
+  idiom, and existing Tailwind tokens already validated against
+  `avibe-docs/design.pen`.
+
+## Scenario catalog note
+
+`tests/scenarios/memory_search/catalog.yaml` covers backend admission/store/
+session-lifecycle behavior (`tests/test_memory_admission.py`,
+`test_memory_store.py`, etc.). It has no scenario IDs for frontend rendering
+and is not the applicable catalog for this change. No scenario IDs are added
+there; coverage for this task lives in focused component tests colocated with
+the component, per existing precedent in this directory
+(`MemoryProfilePanel.test.tsx`, `MemoryProcessingRecordPanel.test.tsx`).
+
+## Implementation notes
+
+- New collapsible row component(s) local to `MemoryProfilePanel.tsx`, built
+  from a plain `<button type="button" aria-expanded=... onClick=...>` +
+  `ChevronDown`/rotate idiom (same as `WorkbenchSidebar.tsx`), not a new
+  primitive under `ui/src/components/ui/`.
+- Evidence sub-disclosure reuses the same idiom, independently keyed per row.
+- Fallback label copy added to `ui/src/i18n/en.json` / `zh.json` under
+  `memory.profile.entryFallback`.
+
+## Test plan
+
+- Initial collapsed state (label only, no description/basis/evidence
+  visible).
+- Title-trigger open/close (click + keyboard).
+- Evidence independently closed/open after row expands; opening a row does
+  not auto-open evidence.
+- Siblings independence (two entries toggled independently).
+- Category and trait sections both covered.
+- Fallback numbering, including whitespace-only category/trait and long
+  Unicode titles.
+- Empty/absent evidence ⇒ no evidence toggle rendered.
+- Basis rendering preserved (implicit traits).
+- Summary and legacy `item.text` rendering preserved.
+- Hostile/text-inertness preserved (existing XSS-inert assertion kept).
+
+## Residuals
+
+- Lightweight browser verification (synthetic long Chinese content, desktop +
+  mobile widths) reported separately in the PR/final report using sanctioned
+  hermetic tooling only — no host service install/restart, no production
+  state.

--- a/ui/src/components/settings/memory/MemoryProfilePanel.test.tsx
+++ b/ui/src/components/settings/memory/MemoryProfilePanel.test.tsx
@@ -282,6 +282,26 @@ describe('MemoryProfilePanel structured text', () => {
     expect(screen.getByText('Available user profile')).toBeTruthy();
   });
 
+  it('resets a refreshed entry to closed even when the reloaded profile is byte-identical', async () => {
+    const profileItems = [{ kind: 'profile' as const, text: '', date: null, profile: PROFILE }];
+    // Two structurally distinct arrays with identical content: a real refetch
+    // never hands back the same object identity, and content-derived entry
+    // keys alone must not let React reuse the previous (opened) instance.
+    getMemoryProfile.mockResolvedValue({ status: 'ok', items: [...profileItems], warnings: [] });
+
+    render(<MemoryProfilePanel enabled />);
+    const trigger = await screen.findByRole('button', { name: 'communication' });
+    await userEvent.click(trigger);
+    expect(screen.getByText('Prefers written updates.')).toBeTruthy();
+
+    getMemoryProfile.mockResolvedValue({ status: 'ok', items: [...profileItems], warnings: [] });
+    await userEvent.click(screen.getByRole('button', { name: 'memory.profile.refresh' }));
+
+    const refreshedTrigger = await screen.findByRole('button', { name: 'communication' });
+    expect(refreshedTrigger.getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByText('Prefers written updates.')).toBeNull();
+  });
+
   it('does not call a partially unread empty profile ungenerated', async () => {
     getMemoryProfile.mockResolvedValue({
       status: 'ok',

--- a/ui/src/components/settings/memory/MemoryProfilePanel.test.tsx
+++ b/ui/src/components/settings/memory/MemoryProfilePanel.test.tsx
@@ -2,19 +2,23 @@
 
 import { renderToStaticMarkup } from 'react-dom/server';
 import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { MemoryProfile } from '../../../context/ApiContext';
 import { MemoryProfileItemBlock, MemoryProfilePanel, StructuredMemoryProfile } from './MemoryProfilePanel';
 import { structuredProfileFromItems } from './memoryProfile';
 
-const t = (key: string) => key;
-const getMemoryProfile = vi.hoisted(() => vi.fn());
+const t = (key: string, options?: Record<string, unknown>) => {
+  if (key === 'memory.profile.entryFallback') return `Profile entry ${options?.number}`;
+  return key;
+};
+const api = vi.hoisted(() => ({ getMemoryProfile: vi.fn() }));
+const { getMemoryProfile } = api;
 
-vi.mock('../../../context/ApiContext', async (loadOriginal) => {
-  const original = await loadOriginal<typeof import('../../../context/ApiContext')>();
-  return { ...original, useApi: () => ({ getMemoryProfile }) };
-});
+vi.mock('../../../context/ApiContext', () => ({
+  useApi: () => api,
+}));
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t }),
@@ -50,16 +54,157 @@ afterEach(() => {
 });
 
 describe('MemoryProfilePanel structured text', () => {
-  it('renders structured sections and keeps basis distinct from evidence', () => {
-    const html = renderToStaticMarkup(<StructuredMemoryProfile profile={PROFILE} t={t} />);
+  it('renders headers and summary eagerly, but keeps entries collapsed until opened', async () => {
+    render(<StructuredMemoryProfile profile={PROFILE} t={t} />);
 
-    expect(html).toContain('memory.profile.summary');
-    expect(html).toContain('memory.profile.explicitInfo');
-    expect(html).toContain('memory.profile.implicitTraits');
-    expect(html).toContain('Repeatedly requested checklists.');
-    expect(html).toContain('Several planning discussions.');
-    expect(html).toContain('memory.profile.basis');
-    expect(html).toContain('memory.profile.evidence');
+    expect(screen.getByText('memory.profile.summary')).toBeTruthy();
+    expect(screen.getByText('Prefers concise technical updates.')).toBeTruthy();
+    expect(screen.getByText('memory.profile.explicitInfo')).toBeTruthy();
+    expect(screen.getByText('memory.profile.implicitTraits')).toBeTruthy();
+
+    // Closed by default: labels are visible, but body content is not rendered at all.
+    expect(screen.getByRole('button', { name: 'communication' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'methodical' })).toBeTruthy();
+    expect(screen.queryByText('Prefers written updates.')).toBeNull();
+    expect(screen.queryByText('May prefer a clear sequence of steps.')).toBeNull();
+    expect(screen.queryByText('Repeatedly requested checklists.')).toBeNull();
+    expect(screen.queryByText('Asked for a written summary.')).toBeNull();
+    expect(screen.queryByText('Several planning discussions.')).toBeNull();
+
+    // Expanding the trait row reveals description and basis, but not evidence yet
+    // (opening a row must not auto-open its evidence disclosure).
+    await userEvent.click(screen.getByRole('button', { name: 'methodical' }));
+    expect(screen.getByText('May prefer a clear sequence of steps.')).toBeTruthy();
+    expect(screen.getByText(/memory\.profile\.basis/)).toBeTruthy();
+    expect(screen.getByText('Repeatedly requested checklists.')).toBeTruthy();
+    expect(screen.queryByText('Several planning discussions.')).toBeNull();
+
+    // Its evidence disclosure is independent and stays basis-distinct once opened.
+    await userEvent.click(screen.getByRole('button', { name: 'memory.profile.evidence' }));
+    expect(screen.getByText('Several planning discussions.')).toBeTruthy();
+    expect(screen.getByText('Repeatedly requested checklists.')).toBeTruthy();
+  });
+
+  it('toggles an entry open and closed via its title trigger, with correct aria-expanded', async () => {
+    render(<StructuredMemoryProfile profile={PROFILE} t={t} />);
+    const trigger = screen.getByRole('button', { name: 'communication' });
+
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+    await userEvent.click(trigger);
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    expect(screen.getByText('Prefers written updates.')).toBeTruthy();
+
+    await userEvent.click(trigger);
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByText('Prefers written updates.')).toBeNull();
+  });
+
+  it('is keyboard accessible: Enter and Space both activate the disclosure trigger', async () => {
+    render(<StructuredMemoryProfile profile={PROFILE} t={t} />);
+    const trigger = screen.getByRole('button', { name: 'communication' });
+    trigger.focus();
+
+    await userEvent.keyboard('{Enter}');
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+
+    await userEvent.keyboard(' ');
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('keeps evidence independently collapsed after its entry opens, and closing evidence keeps the entry open', async () => {
+    render(<StructuredMemoryProfile profile={PROFILE} t={t} />);
+    await userEvent.click(screen.getByRole('button', { name: 'communication' }));
+    expect(screen.queryByText('Asked for a written summary.')).toBeNull();
+
+    const evidenceTrigger = screen.getByRole('button', { name: 'memory.profile.evidence' });
+    await userEvent.click(evidenceTrigger);
+    expect(screen.getByText('Asked for a written summary.')).toBeTruthy();
+
+    await userEvent.click(evidenceTrigger);
+    expect(screen.queryByText('Asked for a written summary.')).toBeNull();
+    expect(screen.getByText('Prefers written updates.')).toBeTruthy();
+  });
+
+  it('toggles sibling entries independently', async () => {
+    const twoEntryProfile: MemoryProfile = {
+      summary: null,
+      explicit_info: [
+        { category: 'communication', description: 'Desc A', evidence: null },
+        { category: 'timezone', description: 'Desc B', evidence: null },
+      ],
+      implicit_traits: [],
+      updated_at: null,
+    };
+    render(<StructuredMemoryProfile profile={twoEntryProfile} t={t} />);
+
+    const first = screen.getByRole('button', { name: 'communication' });
+    const second = screen.getByRole('button', { name: 'timezone' });
+
+    await userEvent.click(first);
+    expect(screen.getByText('Desc A')).toBeTruthy();
+    expect(screen.queryByText('Desc B')).toBeNull();
+
+    await userEvent.click(second);
+    expect(screen.getByText('Desc A')).toBeTruthy();
+    expect(screen.getByText('Desc B')).toBeTruthy();
+
+    await userEvent.click(first);
+    expect(screen.queryByText('Desc A')).toBeNull();
+    expect(screen.getByText('Desc B')).toBeTruthy();
+  });
+
+  it('gives blank category/trait a deterministic numbered fallback, numbered independently per section', () => {
+    const fallbackProfile: MemoryProfile = {
+      summary: null,
+      explicit_info: [
+        { category: '   ', description: 'Desc A', evidence: null },
+        { category: null, description: 'Desc B', evidence: null },
+      ],
+      implicit_traits: [{ trait: '', description: 'Trait A', basis: null, evidence: null }],
+      updated_at: null,
+    };
+    render(<StructuredMemoryProfile profile={fallbackProfile} t={t} />);
+
+    // Both sections start their own numbering at 1: explicit-info's first entry
+    // and implicit-traits' only entry both fall back to "Profile entry 1".
+    expect(screen.getAllByRole('button', { name: 'Profile entry 1' })).toHaveLength(2);
+    expect(screen.getAllByRole('button', { name: 'Profile entry 2' })).toHaveLength(1);
+  });
+
+  it('keeps a long Unicode title fully intact and wrappable, with no horizontal overflow styling', () => {
+    const longTitle =
+      '很长很长很长很长很长很长很长很长很长很长很长很长很长很长很长很长很长很长很长很长很长很长很长很长的分类标题不应该发生横向溢出';
+    const longTitleProfile: MemoryProfile = {
+      summary: null,
+      explicit_info: [{ category: longTitle, description: 'Desc', evidence: null }],
+      implicit_traits: [],
+      updated_at: null,
+    };
+    render(<StructuredMemoryProfile profile={longTitleProfile} t={t} />);
+
+    const trigger = screen.getByRole('button', { name: longTitle });
+    expect(trigger.textContent).toBe(longTitle);
+    const badge = trigger.querySelector('span');
+    expect(badge?.className).toContain('whitespace-normal');
+    expect(badge?.className).toContain('break-words');
+  });
+
+  it('renders no evidence toggle when evidence is absent or empty', async () => {
+    const noEvidenceProfile: MemoryProfile = {
+      summary: null,
+      explicit_info: [
+        { category: 'no-evidence-null', description: 'Desc A', evidence: null },
+        { category: 'no-evidence-empty', description: 'Desc B', evidence: '' },
+      ],
+      implicit_traits: [],
+      updated_at: null,
+    };
+    render(<StructuredMemoryProfile profile={noEvidenceProfile} t={t} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'no-evidence-null' }));
+    await userEvent.click(screen.getByRole('button', { name: 'no-evidence-empty' }));
+
+    expect(screen.queryByRole('button', { name: 'memory.profile.evidence' })).toBeNull();
   });
 
   it('falls back only when a profile item has no structured profile field', () => {
@@ -84,6 +229,30 @@ describe('MemoryProfilePanel structured text', () => {
 
     expect(html).toContain('&lt;img src=x onerror=alert(1)&gt;');
     expect(html).not.toContain('<img src=x');
+  });
+
+  it('keeps a hostile category/trait label and evidence value inert once expanded', async () => {
+    const hostileProfile: MemoryProfile = {
+      summary: null,
+      explicit_info: [
+        {
+          category: '<img src=x onerror=alert(1)>',
+          description: 'Desc',
+          evidence: '<script>alert(2)</script>',
+        },
+      ],
+      implicit_traits: [],
+      updated_at: null,
+    };
+    render(<StructuredMemoryProfile profile={hostileProfile} t={t} />);
+
+    expect(document.querySelector('img')).toBeNull();
+    const trigger = screen.getByText('<img src=x onerror=alert(1)>');
+    await userEvent.click(trigger);
+    await userEvent.click(screen.getByRole('button', { name: 'memory.profile.evidence' }));
+
+    expect(screen.getByText('<script>alert(2)</script>')).toBeTruthy();
+    expect(document.querySelector('script[src]')).toBeNull();
   });
 
   it('labels user and Agent profile blocks while legacy blocks still render', () => {

--- a/ui/src/components/settings/memory/MemoryProfilePanel.tsx
+++ b/ui/src/components/settings/memory/MemoryProfilePanel.tsx
@@ -1,6 +1,7 @@
-import { useEffect } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Loader2, RefreshCw } from 'lucide-react';
+import { ChevronDown, Loader2, RefreshCw } from 'lucide-react';
+import clsx from 'clsx';
 
 import { Badge } from '../../ui/badge';
 import { Button } from '../../ui/button';
@@ -10,7 +11,10 @@ import { useMemoryResource } from './useMemoryResource';
 import { memoryOriginLabelKey } from './memoryOrigin';
 
 type MemoryItemsOk = Extract<MemoryItemsResult, { status: 'ok' }>;
-type Translate = (key: string) => string;
+type Translate = (key: string, options?: Record<string, unknown>) => string;
+
+const DISCLOSURE_TRIGGER_CLASSES =
+  'flex min-w-0 items-center gap-1.5 rounded text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring';
 
 const ProfileDetail: React.FC<{ label: string; value: string }> = ({ label, value }) => (
   <p className="mt-1 whitespace-pre-wrap text-[12px] leading-relaxed text-muted">
@@ -18,6 +22,69 @@ const ProfileDetail: React.FC<{ label: string; value: string }> = ({ label, valu
     {value}
   </p>
 );
+
+/** Independently collapsed evidence disclosure nested inside an already-expanded entry. */
+const CollapsibleEvidence: React.FC<{ label: string; value: string }> = ({ label, value }) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="mt-2">
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        aria-expanded={open}
+        className={clsx(DISCLOSURE_TRIGGER_CLASSES, 'text-[11px] font-medium text-muted hover:text-foreground')}
+      >
+        <ChevronDown className={clsx('size-3 shrink-0 transition-transform', !open && '-rotate-90')} />
+        <span>{label}</span>
+      </button>
+      {open ? <p className="mt-1 whitespace-pre-wrap text-[12px] leading-relaxed text-muted">{value}</p> : null}
+    </div>
+  );
+};
+
+/**
+ * One explicit-info or implicit-trait row. Closed shows only the label badge
+ * plus chevron; the whole row is the disclosure trigger. Expanding never
+ * auto-opens the nested evidence disclosure.
+ */
+const ProfileEntry: React.FC<{
+  label: ReactNode;
+  description: string;
+  basisLabel?: string;
+  basisValue?: string | null;
+  evidenceLabel: string;
+  evidenceValue?: string | null;
+}> = ({ label, description, basisLabel, basisValue, evidenceLabel, evidenceValue }) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="border-l-2 border-border pl-3">
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        aria-expanded={open}
+        className={clsx(DISCLOSURE_TRIGGER_CLASSES, 'w-full py-0.5')}
+      >
+        <Badge variant="secondary" className="min-w-0 flex-1 whitespace-normal break-words text-left">
+          {label}
+        </Badge>
+        <ChevronDown className={clsx('size-3.5 shrink-0 text-muted transition-transform', !open && '-rotate-90')} />
+      </button>
+      {open ? (
+        <div className="mt-1">
+          <p className="whitespace-pre-wrap text-[13px] leading-relaxed text-foreground">{description}</p>
+          {basisValue ? <ProfileDetail label={basisLabel ?? ''} value={basisValue} /> : null}
+          {evidenceValue ? <CollapsibleEvidence label={evidenceLabel} value={evidenceValue} /> : null}
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+/** A blank/whitespace-only category or trait still needs a discoverable, deterministic label. */
+const resolveEntryLabel = (t: Translate, raw: string | null, index: number): string => {
+  const trimmed = raw?.trim();
+  return trimmed ? trimmed : t('memory.profile.entryFallback', { number: index + 1 });
+};
 
 /** Render provider values as inert text nodes, never as Markdown or HTML. */
 export const StructuredMemoryProfile: React.FC<{ profile: MemoryProfile; t: Translate }> = ({ profile, t }) => (
@@ -33,11 +100,13 @@ export const StructuredMemoryProfile: React.FC<{ profile: MemoryProfile; t: Tran
         <h3 className="text-[12px] font-semibold text-foreground">{t('memory.profile.explicitInfo')}</h3>
         <div className="mt-2 flex flex-col gap-3">
           {profile.explicit_info.map((info, index) => (
-            <div key={`${info.description}:${index}`} className="border-l-2 border-border pl-3">
-              {info.category ? <Badge variant="secondary">{info.category}</Badge> : null}
-              <p className="mt-1 whitespace-pre-wrap text-[13px] leading-relaxed text-foreground">{info.description}</p>
-              {info.evidence ? <ProfileDetail label={t('memory.profile.evidence')} value={info.evidence} /> : null}
-            </div>
+            <ProfileEntry
+              key={`${info.description}:${index}`}
+              label={resolveEntryLabel(t, info.category, index)}
+              description={info.description}
+              evidenceLabel={t('memory.profile.evidence')}
+              evidenceValue={info.evidence}
+            />
           ))}
         </div>
       </section>
@@ -47,12 +116,15 @@ export const StructuredMemoryProfile: React.FC<{ profile: MemoryProfile; t: Tran
         <h3 className="text-[12px] font-semibold text-foreground">{t('memory.profile.implicitTraits')}</h3>
         <div className="mt-2 flex flex-col gap-3">
           {profile.implicit_traits.map((trait, index) => (
-            <div key={`${trait.description}:${index}`} className="border-l-2 border-border pl-3">
-              {trait.trait ? <Badge variant="secondary">{trait.trait}</Badge> : null}
-              <p className="mt-1 whitespace-pre-wrap text-[13px] leading-relaxed text-foreground">{trait.description}</p>
-              {trait.basis ? <ProfileDetail label={t('memory.profile.basis')} value={trait.basis} /> : null}
-              {trait.evidence ? <ProfileDetail label={t('memory.profile.evidence')} value={trait.evidence} /> : null}
-            </div>
+            <ProfileEntry
+              key={`${trait.description}:${index}`}
+              label={resolveEntryLabel(t, trait.trait, index)}
+              description={trait.description}
+              basisLabel={t('memory.profile.basis')}
+              basisValue={trait.basis}
+              evidenceLabel={t('memory.profile.evidence')}
+              evidenceValue={trait.evidence}
+            />
           ))}
         </div>
       </section>

--- a/ui/src/components/settings/memory/MemoryProfilePanel.tsx
+++ b/ui/src/components/settings/memory/MemoryProfilePanel.tsx
@@ -64,7 +64,9 @@ const ProfileEntry: React.FC<{
         aria-expanded={open}
         className={clsx(DISCLOSURE_TRIGGER_CLASSES, 'w-full py-0.5')}
       >
-        <Badge variant="secondary" className="min-w-0 flex-1 whitespace-normal break-words text-left">
+        {/* No flex-grow: hug short labels like the app's other badges; min-w-0 + shrink
+            let a long label give up space to the chevron and wrap instead of overflowing. */}
+        <Badge variant="secondary" className="min-w-0 shrink whitespace-normal break-words text-left">
           {label}
         </Badge>
         <ChevronDown className={clsx('size-3.5 shrink-0 text-muted transition-transform', !open && '-rotate-90')} />

--- a/ui/src/components/settings/memory/MemoryProfilePanel.tsx
+++ b/ui/src/components/settings/memory/MemoryProfilePanel.tsx
@@ -169,6 +169,24 @@ export const MemoryProfilePanel: React.FC<{ enabled: boolean }> = ({ enabled }) 
     void reload();
   }, [reload]);
 
+  // `data` is a fresh object on every successful load, even when its contents are
+  // unchanged. Entry keys below are content-derived (kind/date/index), so an
+  // unchanged reload would otherwise reuse the same mounted entries and keep
+  // their disclosure state open. Bumping this on every reload that *replaces*
+  // an already-loaded profile forces a full remount, matching the
+  // initially-closed contract — but only from the second load onward, so the
+  // very first successful paint (no previous profile to replace) stays a
+  // single render. Adjusted during render (React's sanctioned "derived state"
+  // idiom), not in an effect, so there is no extra committed render in between.
+  const [previousData, setPreviousData] = useState<MemoryItemsOk | null>(null);
+  const [profileGeneration, setProfileGeneration] = useState(0);
+  if (data && previousData && previousData !== data) {
+    setPreviousData(data);
+    setProfileGeneration((prev) => prev + 1);
+  } else if (data !== previousData) {
+    setPreviousData(data);
+  }
+
   if (!enabled) {
     return <div className="rounded-2xl border border-dashed border-border bg-surface p-8 text-center text-sm text-muted">{t('memory.profile.disabledHint')}</div>;
   }
@@ -210,7 +228,7 @@ export const MemoryProfilePanel: React.FC<{ enabled: boolean }> = ({ enabled }) 
         <div className="flex flex-col gap-2">
           {items.map((item, index) => (
             <MemoryProfileItemBlock
-              key={`${item.kind}:${item.date ?? ''}:${index}`}
+              key={`${profileGeneration}:${item.kind}:${item.date ?? ''}:${index}`}
               item={item}
               t={t}
             />

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -4896,6 +4896,7 @@
       "implicitTraits": "Inferred traits",
       "basis": "Basis",
       "evidence": "Evidence",
+      "entryFallback": "Profile entry {{number}}",
       "sourceNote": "Distilled from your conversation history, plus any notes your Agent recorded."
     },
     "search": {

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -4896,6 +4896,7 @@
       "implicitTraits": "推断特征",
       "basis": "推断依据",
       "evidence": "相关证据",
+      "entryFallback": "画像条目 {{number}}",
       "sourceNote": "由你的对话历史，以及 Agent 记录的内容（如有）提炼而来。"
     },
     "search": {


### PR DESCRIPTION
## Summary
- Approved UI contract (owner session `sesehz3dgw5ua`, approved 2026-09-09, "按这个样式实现"): each `explicit_info`/`implicit_traits` entry in the memory profile is now independently collapsible, initially closed, showing only its category/trait label (existing `Badge` styling) plus a chevron; the full row is the disclosure trigger with `aria-expanded` and a visible focus ring.
- Expanding a row reveals the unchanged description/basis, then an independently-collapsed evidence disclosure (opening the row never auto-opens evidence); evidence absent/empty renders no toggle at all.
- Blank/whitespace-only `category`/`trait` falls back to a deterministic numbered label (`memory.profile.entryFallback`, "Profile entry {{number}}" / "画像条目 {{number}}"), numbered independently per section. Provider data itself is never mutated.
- Overall `summary`, card metadata/date/origin, section headers, and legacy unstructured `item.text` rendering are all unchanged. Provider strings remain inert text (no markdown/HTML parsing). No backend/API/EverOS changes, no new dependency, no persisted/global expand state.
- Full product contract copied into `docs/plans/memory-profile-collapsible-details.md` before implementation, including a note on why `tests/scenarios/memory_search/catalog.yaml` (backend admission/store/session-lifecycle scenarios) is not the applicable catalog for this frontend-only change — no scenario IDs added there.

## Tests
- Unit/behavioral (`MemoryProfilePanel.test.tsx`, 14 cases, `render`/`screen`/`userEvent`, asserting actual visibility and `aria-expanded` rather than DOM-text presence): initial collapsed state, title-trigger open/close via click, keyboard activation (Enter + Space), evidence independently open/close without affecting the entry, sibling-entry independence, explicit-info and implicit-trait sections, deterministic per-section fallback numbering (including a long-Unicode title with no truncation and wrap classes asserted), empty/absent evidence renders no toggle, basis vs evidence distinctness, hostile/inert text for both summary and entry-level values, summary/legacy `item.text`/origin-label rendering preserved.
- `npx vitest run src/components/settings/memory` — 9 files / 84 tests pass (whole directory, confirming no regressions in sibling memory panels).
- Changed-file ESLint (`npx eslint`) clean; `node scripts/lint-baseline.mjs` — no drift.
- `npm run build` (`tsc -b && vite build`) succeeds.
- Residual: lightweight browser verification (synthetic long Chinese content, desktop/mobile widths) was attempted via the sanctioned integrated-browser tool, but no connected desktop app was available in this environment, and no Playwright browser binaries are provisioned on this host — installing a new browser binary was treated as out of scope for a hermetic, no-new-host-install verification pass. This is a residual: the behavioral test suite exercises the actual DOM/ARIA state (open/closed visibility, wrap classes) but is not a substitute for a rendered-pixel check. Flagging for a manual/visual pass before merge if that's required for this PR.

## Scope
Frontend-only; touches exactly the granted file set: `MemoryProfilePanel.tsx`, `MemoryProfilePanel.test.tsx`, `en.json`/`zh.json` (one new key each), and the plan doc.