### PR TITLE
fix(desktop): drop identity matches flagged by current clippy

### DIFF
--- a/desktop/runtime-host/src/private_runtime.rs
+++ b/desktop/runtime-host/src/private_runtime.rs
@@ -273,19 +273,11 @@ fn validate_manifest(manifest: &RuntimeBundleManifest) -> Result<(), PrivateRunt
 }
 
 fn current_os() -> &'static str {
-    match std::env::consts::OS {
-        "macos" => "macos",
-        "windows" => "windows",
-        other => other,
-    }
+    std::env::consts::OS
 }
 
 fn current_arch() -> &'static str {
-    match std::env::consts::ARCH {
-        "aarch64" => "aarch64",
-        "x86_64" => "x86_64",
-        other => other,
-    }
+    std::env::consts::ARCH
 }
 
 fn safe_segment(value: &str) -> bool {


### PR DESCRIPTION
## Changed capability

None — build-gate repair. `desktop-shell` CI (Lint Rust, `-D warnings`)
fails on the desktop **baseline** with current clippy: two identity match
expressions in `desktop/runtime-host/src/private_runtime.rs`
(`current_os`, `current_arch`) trip the redundant-match lint. Every PR
touching `desktop/**` is red until this lands.

Fix: replace both with the `std::env::consts` they mirrored (behavior
identical — each arm returned its own scrutinee).

## Evidence layers

- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean on the patched tree (the failing lint is gone)
- `cargo test -p avibe-runtime-host`: 64 + 21 + 1 tests green
- `cargo fmt --all -- --check`: clean
- CI on this PR re-runs the full desktop-shell gate on macOS + Windows — that is the authoritative proof the baseline is unblocked

## Dependencies / ordering

- Merge this **before** re-reviewing #1971 (its desktop-shell run went red on this same baseline lint, not on its own diff; #1971 will rebase onto this fix)
- No functional change; no contract impact