### PR TITLE
feat(desktop): add startup receipts and service-owner stop gate

### DIFF
--- a/docs/plans/desktop-start-receipt.md
+++ b/docs/plans/desktop-start-receipt.md
@@ -1,0 +1,90 @@
+# Desktop startup receipt and service-owner stop gate
+
+## Outcome and boundaries
+
+The desktop shell needs to distinguish a Runtime it started from one it adopted.
+Python produces launch provenance at the actual spawn/reuse branch; the shell
+retains stop authority only for a `started` receipt. A pre-launch process snapshot
+is not provenance: another launcher can start the service before `start_service`
+reads the pidfile. Service and UI startup both capture their actual process
+identity and reuse decision without changing their existing integer return value.
+
+This change does not modify desktop Rust code, deployment, routing, data location,
+or the existing unscoped shutdown behavior.
+
+## Frozen schema-v1 startup line
+
+Every successful `vibe start`, including `vibe start --no-open-browser`, writes
+exactly one additional stdout line with this exact prefix and compact JSON:
+
+```text
+@avibe-start-receipt:{"schema_version":1,"outcome":"started","service_pid":1234,"ui_pid":5678,"service_create_unix_ms":1789010100123.5,"ui_create_unix_ms":1789010100456.5}
+```
+
+- `schema_version`: integer `1`.
+- `outcome`: provenance from the spawn-vs-return-existing branch inside
+  `start_service`, never a caller's pre-launch snapshot. `started` means its
+  spawn branch, including a scoped launch resolving its authoritative PID;
+  `reused` means its return-existing branch. UI reuse does not change it.
+- `service_pid`, `ui_pid`: positive integer process IDs.
+- `service_create_unix_ms`, `ui_create_unix_ms`: finite positive epoch
+  milliseconds from `psutil.Process(pid).create_time() * 1000`, captured during
+  startup, not wall-clock sampling or the human-readable status file. Fractional
+  milliseconds are allowed. If a scoped launcher resolves to another service
+  PID, its identity is updated to the authoritative service process.
+
+Consumers match the prefix at the beginning of a line and parse only its JSON
+suffix; other stdout remains human-readable. Failed startup must not emit a
+success receipt. Unreadable process identity must not be fabricated.
+The desktop consumer treats a `reused` receipt as adoption regardless of which
+process invoked start.
+
+## Frozen scoped-stop interface
+
+```text
+vibe stop --receipt '<the receipt JSON, without the stdout prefix>'
+```
+
+Before any shutdown side effect, the service pidfile must contain the receipt's
+`service_pid`, and that live process's psutil create-time must match
+`service_create_unix_ms` with an inclusive absolute tolerance of **2 ms**.
+Malformed/unsupported receipts, missing identity, replacement PIDs, and recycled
+PIDs fail closed: **exit 3**, one JSON object on stderr with a `reason` string,
+no fallback to unscoped stop, no status/pidfile edits, and no shutdown calls.
+
+Reason codes are `invalid_receipt`, `service_pid_mismatch`,
+`service_identity_unavailable`, and `service_create_time_mismatch`.
+
+A match runs today's full graceful stop, including the service sweep, UI,
+OpenCode server, and tunnel. Its normal success/stop-failure exit codes remain
+`0`/`2`. Without `--receipt`, output, exit codes, and behavior are unchanged.
+Python validates identity, not ownership policy: `outcome=reused` is valid input;
+the desktop consumer must not offer or invoke stop for adopted runtimes.
+
+## Security rationale and known limits
+
+A PID alone can refer to an unrelated process after recycling; checking the
+recorded PID and the live kernel-backed create-time prevents a stale desktop
+receipt from authorizing shutdown of a replacement Runtime at gate time.
+
+This is a **service-owner gate**, not a per-process capability or an
+authentication token. It preserves today's full-stop semantics after the gate
+passes. It does not prevent same-install concurrent replacement after the gate,
+nor independently authorize each UI, OpenCode, or tunnel process. A future
+per-process guarantee requires a new contract version. Receipts contain no
+secrets, and a same-user caller can still invoke the existing unscoped stop.
+
+## Validation contract
+
+- Startup output preserves human prose and emits one exact-prefix receipt with
+  launch-captured identities, regardless of browser-opening configuration.
+- Provenance reflects the startup function's branch even when the caller's
+  earlier view of the service differs; service and UI reuse are observed at
+  their owning layer.
+- Every rejected scoped stop leaves shutdown collaborators and state untouched.
+- Matching identities preserve full-stop behavior, including exit `2` failures;
+  omitting the receipt preserves the legacy path.
+- Parser and dispatch tests exercise the documented command shape.
+- Fake-process tests remain hermetic. Real desktop-to-Python acceptance is
+  deferred to the orchestrator's integration pass; never restart the local
+  agent-hosting Runtime for verification.

--- a/tests/test_cli_setup_status.py
+++ b/tests/test_cli_setup_status.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import json
+from functools import partial
 from types import SimpleNamespace
 from unittest.mock import patch
 
 from vibe import cli
+from vibe.runtime import ProcessStartInfo
 
 
 def _config_with_setup_state(*, ready: bool) -> SimpleNamespace:
@@ -14,6 +17,26 @@ def _config_with_setup_state(*, ready: bool) -> SimpleNamespace:
     )
 
 
+def _start_process(pid: int, *args, start_info: ProcessStartInfo, **kwargs) -> int:
+    start_info.pid = pid
+    start_info.create_unix_ms = 1789010100000.5 + pid
+    start_info.reused = False
+    return pid
+
+
+def _assert_start_receipt(output: str) -> None:
+    receipts = [line for line in output.splitlines() if line.startswith("@avibe-start-receipt:")]
+    assert len(receipts) == 1
+    assert json.loads(receipts[0].split(":", 1)[1]) == {
+        "schema_version": 1,
+        "outcome": "started",
+        "service_pid": 101,
+        "ui_pid": 202,
+        "service_create_unix_ms": 1789010100101.5,
+        "ui_create_unix_ms": 1789010100202.5,
+    }
+
+
 def test_cmd_vibe_marks_setup_when_no_enabled_platform_has_credentials(capsys) -> None:
     config = _config_with_setup_state(ready=False)
 
@@ -22,8 +45,8 @@ def test_cmd_vibe_marks_setup_when_no_enabled_platform_has_credentials(capsys) -
         patch("vibe.cli._ensure_config", return_value=config),
         patch("vibe.cli.runtime.stop_service") as stop_service,
         patch("vibe.cli.runtime.stop_ui") as stop_ui,
-        patch("vibe.cli.runtime.start_service", return_value=101),
-        patch("vibe.cli.runtime.start_ui", return_value=202),
+        patch("vibe.cli.runtime.start_service", side_effect=partial(_start_process, 101)),
+        patch("vibe.cli.runtime.start_ui", side_effect=partial(_start_process, 202)),
         patch("vibe.cli.runtime.service_pid_recorded", return_value=True),
         patch("vibe.cli.runtime.write_status"),
         patch("vibe.cli._write_status") as write_status,
@@ -36,9 +59,10 @@ def test_cmd_vibe_marks_setup_when_no_enabled_platform_has_credentials(capsys) -
     output = capsys.readouterr().out
     assert "Run: vibe remote" in output
     assert "SSH port forwarding" not in output
+    _assert_start_receipt(output)
 
 
-def test_cmd_vibe_marks_starting_when_non_slack_platform_is_configured() -> None:
+def test_cmd_vibe_marks_starting_when_non_slack_platform_is_configured(capsys) -> None:
     config = _config_with_setup_state(ready=True)
 
     with (
@@ -46,8 +70,8 @@ def test_cmd_vibe_marks_starting_when_non_slack_platform_is_configured() -> None
         patch("vibe.cli._ensure_config", return_value=config),
         patch("vibe.cli.runtime.stop_service") as stop_service,
         patch("vibe.cli.runtime.stop_ui") as stop_ui,
-        patch("vibe.cli.runtime.start_service", return_value=101),
-        patch("vibe.cli.runtime.start_ui", return_value=202),
+        patch("vibe.cli.runtime.start_service", side_effect=partial(_start_process, 101)),
+        patch("vibe.cli.runtime.start_ui", side_effect=partial(_start_process, 202)),
         patch("vibe.cli.runtime.service_pid_recorded", return_value=True),
         patch("vibe.cli.runtime.write_status"),
         patch("vibe.cli._write_status") as write_status,
@@ -57,3 +81,4 @@ def test_cmd_vibe_marks_starting_when_non_slack_platform_is_configured() -> None
     stop_service.assert_not_called()
     stop_ui.assert_not_called()
     write_status.assert_called_once_with("starting")
+    _assert_start_receipt(capsys.readouterr().out)

--- a/tests/test_vibe_cli.py
+++ b/tests/test_vibe_cli.py
@@ -495,6 +495,152 @@ def test_cmd_restart_schedules_supervisor_by_default(monkeypatch):
     assert calls == [{"delay_seconds": 0.0, "vibe_path": "/usr/local/bin/vibe", "trigger": "cli"}]
 
 
+def _startup_receipt_payload():
+    return {
+        "schema_version": 1, "outcome": "started",
+        "service_pid": 1234, "ui_pid": 5678,
+        "service_create_unix_ms": 1789010100.1235 * 1000,
+        "ui_create_unix_ms": 1789010100.4565 * 1000,
+    }
+
+
+@pytest.fixture
+def receipt_shutdown(monkeypatch):
+    pid_path = paths.get_runtime_pid_path()
+    pid_path.parent.mkdir(parents=True, exist_ok=True)
+    pid_path.write_text("1234\n", encoding="utf-8")
+    calls = []
+    monkeypatch.setattr(runtime, "pid_alive", lambda pid: True)
+    monkeypatch.setattr(runtime, "process_create_time", lambda pid: 1789010100.1235)
+    monkeypatch.setattr(cli, "_pid_file_points_to_live_process", lambda path: True)
+    monkeypatch.setattr(runtime, "stop_service", lambda: calls.append("service") or True)
+    monkeypatch.setattr(runtime, "stop_ui", lambda: calls.append("ui") or True)
+    monkeypatch.setattr(cli, "_stop_opencode_server", lambda: calls.append("opencode") or True)
+    monkeypatch.setattr(cli, "_write_status", lambda *args: calls.append(args))
+    return SimpleNamespace(pid_path=pid_path, calls=calls)
+
+
+@pytest.mark.parametrize("delta_ms", [-2, -1.999, 0, 1.999, 2])
+@pytest.mark.parametrize("outcome", ["started", "reused"])
+def test_cmd_stop_receipt_matches_with_inclusive_tolerance(capsys, receipt_shutdown, delta_ms, outcome):
+    receipt = _startup_receipt_payload()
+    receipt["service_create_unix_ms"] += delta_ms
+    receipt["outcome"] = outcome
+
+    assert cli.cmd_stop(receipt=json.dumps(receipt)) == 0
+
+    assert receipt_shutdown.calls == ["service", "ui", "opencode", ("stopped",)]
+    output = capsys.readouterr()
+    assert output.out == "OpenCode server stopped\n"
+    assert output.err == ""
+
+
+@pytest.mark.parametrize(
+    ("state", "reason"),
+    [
+        ("replaced", "service_pid_mismatch"),
+        ("missing", "service_pid_mismatch"),
+        ("unreadable_pid", "service_pid_mismatch"),
+        ("recycled", "service_create_time_mismatch"),
+        ("older_time", "service_create_time_mismatch"),
+        ("dead", "service_identity_unavailable"),
+        ("unreadable_time", "service_identity_unavailable"),
+        ("invalid_live_time", "service_create_time_mismatch"),
+    ],
+)
+def test_cmd_stop_receipt_refuses_without_any_shutdown_side_effect(
+    monkeypatch, capsys, receipt_shutdown, state, reason,
+):
+    receipt = _startup_receipt_payload()
+    if state == "replaced":
+        receipt_shutdown.pid_path.write_text("9012\n", encoding="utf-8")
+    elif state == "missing":
+        receipt_shutdown.pid_path.unlink()
+    elif state == "unreadable_pid":
+        receipt_shutdown.pid_path.write_bytes(b"\xff")
+    elif state in ("recycled", "older_time"):
+        receipt["service_create_unix_ms"] += 2.001 if state == "recycled" else -2.001
+    elif state == "dead":
+        monkeypatch.setattr(runtime, "pid_alive", lambda pid: False)
+    else:
+        monkeypatch.setattr(runtime, "process_create_time", lambda pid: None if state == "unreadable_time" else float("nan"))
+    before = receipt_shutdown.pid_path.read_bytes() if receipt_shutdown.pid_path.exists() else None
+
+    assert cli.cmd_stop(receipt=json.dumps(receipt)) == 3
+
+    output = capsys.readouterr()
+    assert output.out == ""
+    assert json.loads(output.err) == {"reason": reason}
+    assert receipt_shutdown.calls == []
+    assert (receipt_shutdown.pid_path.read_bytes() if receipt_shutdown.pid_path.exists() else None) == before
+
+
+@pytest.mark.parametrize("field", list(_startup_receipt_payload()))
+def test_cmd_stop_rejects_incomplete_receipt(capsys, receipt_shutdown, field):
+    receipt = _startup_receipt_payload()
+    del receipt[field]
+
+    assert cli.cmd_stop(receipt=json.dumps(receipt)) == 3
+
+    assert json.loads(capsys.readouterr().err) == {"reason": "invalid_receipt"}
+    assert receipt_shutdown.calls == []
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("schema_version", True), ("schema_version", 1.0), ("schema_version", 2),
+        ("outcome", "unknown"), ("outcome", ["started"]),
+        ("service_pid", True), ("service_pid", -1234), ("service_pid", 1234.0),
+        ("ui_pid", 0), ("ui_pid", "5678"),
+        ("service_create_unix_ms", None), ("service_create_unix_ms", "1789010100123.5"),
+        ("service_create_unix_ms", float("nan")), ("service_create_unix_ms", float("inf")),
+        ("ui_create_unix_ms", -1), ("ui_create_unix_ms", True),
+        ("ui_create_unix_ms", float("-inf")), ("ui_create_unix_ms", 10 ** 400),
+    ],
+)
+def test_cmd_stop_rejects_invalid_receipt_values(capsys, receipt_shutdown, field, value):
+    receipt = _startup_receipt_payload()
+    receipt[field] = value
+
+    assert cli.cmd_stop(receipt=json.dumps(receipt)) == 3
+
+    assert json.loads(capsys.readouterr().err) == {"reason": "invalid_receipt"}
+    assert receipt_shutdown.calls == []
+
+
+@pytest.mark.parametrize("receipt", ["", "{", "null", "[]", '"receipt"', "[" * 2000 + "]" * 2000])
+def test_cmd_stop_rejects_malformed_receipt(capsys, receipt_shutdown, receipt):
+    assert cli.cmd_stop(receipt=receipt) == 3
+
+    assert json.loads(capsys.readouterr().err) == {"reason": "invalid_receipt"}
+    assert receipt_shutdown.calls == []
+
+
+def test_cmd_stop_without_receipt_keeps_legacy_full_stop(monkeypatch, capsys, receipt_shutdown):
+    def unexpected_identity_read(pid):
+        raise AssertionError("Unscoped stop must not inspect receipt identity")
+
+    monkeypatch.setattr(runtime, "process_create_time", unexpected_identity_read)
+    receipt_shutdown.pid_path.unlink()
+
+    assert cli.cmd_stop() == 0
+
+    assert receipt_shutdown.calls == ["service", "ui", "opencode", ("stopped",)]
+    output = capsys.readouterr()
+    assert output.out == "OpenCode server stopped\n"
+    assert output.err == ""
+
+
+def test_cmd_stop_matched_receipt_preserves_stop_failure_exit_code(monkeypatch, capsys, receipt_shutdown):
+    monkeypatch.setattr(runtime, "stop_service", lambda: receipt_shutdown.calls.append("service") or False)
+
+    assert cli.cmd_stop(receipt=json.dumps(_startup_receipt_payload())) == 2
+
+    assert receipt_shutdown.calls == ["service", "ui", "opencode", ("error", "service stop failed")]
+    assert capsys.readouterr().err == "ERROR: Avibe service did not stop; preserving pidfile and aborting.\n"
+
+
 def test_cmd_stop_ignores_absent_services(monkeypatch):
     status = []
 
@@ -654,6 +800,183 @@ def _no_live_runtime_processes(monkeypatch):
     monkeypatch.setattr(cli, "_live_ui_server_pid", lambda: None)
 
 
+def _fake_start_result(pid, kwargs, *, reused=False):
+    start_info = kwargs.get("start_info")
+    if start_info is not None:
+        start_info.pid = pid
+        start_info.create_unix_ms = 1789010100000.5 + pid
+        start_info.reused = reused
+    return pid
+
+
+@pytest.fixture
+def receipt_runtime(monkeypatch):
+    service_path = paths.get_runtime_pid_path()
+    ui_path = paths.get_runtime_ui_pid_path()
+    service_path.parent.mkdir(parents=True, exist_ok=True)
+    process_times = {1234: 1789010100.1235, 5678: 1789010100.4565, 9012: 1789010100.7895}
+    spawned = []
+    captured = []
+    opened = []
+
+    def fake_process(pid):
+        captured.append(pid)
+        return SimpleNamespace(create_time=lambda: process_times[pid])
+
+    def spawn_service(*args, **kwargs):
+        spawned.append("service")
+        return SimpleNamespace(pid=1234, poll=lambda: None)
+
+    def spawn_ui(args, pid_path, *logs, **kwargs):
+        spawned.append("ui")
+        pid_path.write_text("5678", encoding="utf-8")
+        return 5678
+
+    monkeypatch.setattr(cli, "_guard_cli_default_state_migration", lambda: None)
+    monkeypatch.setattr(cli, "_handover_superseded_desktop_runtime", lambda: None)
+    monkeypatch.setattr(cli, "_ensure_config", lambda: SimpleNamespace(
+        has_configured_platform_credentials=lambda: True,
+        ui=SimpleNamespace(setup_host="127.0.0.1", setup_port=5123, open_browser=True),
+    ))
+    monkeypatch.setattr(cli, "_write_status", lambda *args: None)
+    monkeypatch.setattr(cli, "_in_ssh_session", lambda: False)
+    monkeypatch.setattr(cli, "_open_browser", lambda url: opened.append(url) or True)
+    monkeypatch.setattr(runtime, "write_status", lambda *args: None)
+    monkeypatch.setattr(runtime, "effective_ui_bind_host", lambda config: "127.0.0.1")
+    monkeypatch.setattr(runtime, "_SERVICE_START_PROCESSES", {})
+    monkeypatch.setattr(runtime, "pid_alive", lambda pid: pid in process_times)
+    monkeypatch.setattr(runtime.psutil, "Process", fake_process)
+    monkeypatch.setattr(runtime, "_pid_mismatches_service", lambda pid: False)
+    monkeypatch.setattr(runtime, "_pid_matches_ui_server", lambda pid: True)
+    monkeypatch.setattr(runtime, "_ui_server_compatible", lambda host, port: True)
+    monkeypatch.setattr(runtime, "service_pid_recorded", lambda pid: True)
+    monkeypatch.setattr(runtime, "service_instance_lock_available", lambda: (True, None))
+    monkeypatch.setattr(runtime, "extra_service_process_pids", lambda **kwargs: [])
+    monkeypatch.setattr(runtime, "maybe_systemd_scope_prefix", lambda: [])
+    monkeypatch.setattr(runtime, "wait_for_service_pid", lambda pid, timeout: True)
+    monkeypatch.setattr(runtime, "wait_for_ui_server", lambda host, port: True)
+    monkeypatch.setattr(runtime, "spawn_service_background_process", spawn_service)
+    monkeypatch.setattr(runtime, "spawn_background", spawn_ui)
+    return SimpleNamespace(
+        service_path=service_path, ui_path=ui_path, process_times=process_times,
+        spawned=spawned, captured=captured, opened=opened,
+    )
+
+
+@pytest.mark.parametrize("reused", [False, True])
+@pytest.mark.parametrize("open_browser", [None, False])
+def test_cmd_start_receipt_uses_launch_provenance_and_psutil_identity(
+    monkeypatch, capsys, receipt_runtime, reused, open_browser,
+):
+    if reused:
+        receipt_runtime.service_path.write_text("1234", encoding="utf-8")
+        receipt_runtime.ui_path.write_text("5678", encoding="utf-8")
+    monkeypatch.setattr(runtime, "resolve_service_owner_pid", lambda **kwargs: None if reused else 1234)
+
+    assert cli.cmd_start(open_browser=open_browser) == 0
+
+    output = capsys.readouterr().out
+    receipts = [line for line in output.splitlines() if line.startswith("@avibe-start-receipt:")]
+    assert len(receipts) == 1
+    assert json.loads(receipts[0].split(":", 1)[1]) == {
+        "schema_version": 1, "outcome": "reused" if reused else "started",
+        "service_pid": 1234, "ui_pid": 5678,
+        "service_create_unix_ms": receipt_runtime.process_times[1234] * 1000,
+        "ui_create_unix_ms": receipt_runtime.process_times[5678] * 1000,
+    }
+    assert receipt_runtime.spawned == ([] if reused else ["service", "ui"])
+    assert receipt_runtime.captured == [1234, 5678]
+    assert bool(receipt_runtime.opened) == (open_browser is None)
+    assert "Web UI:\n  http://127.0.0.1:5123\n" in output
+    assert "Run: vibe remote" in output
+
+
+@pytest.mark.parametrize("reused", [False, True])
+def test_start_ui_captures_its_own_provenance_before_readiness(monkeypatch, receipt_runtime, reused):
+    if reused:
+        receipt_runtime.ui_path.write_text("5678", encoding="utf-8")
+    before = receipt_runtime.process_times[5678] * 1000
+    monkeypatch.setattr(runtime, "wait_for_ui_server", lambda host, port: receipt_runtime.process_times.update({5678: 9999}) or True)
+    info = runtime.ProcessStartInfo()
+
+    assert runtime.start_ui("127.0.0.1", 5123, start_info=info) == 5678
+
+    assert info.reused is reused
+    assert info.create_unix_ms == before
+    assert receipt_runtime.spawned == ([] if reused else ["ui"])
+
+
+@pytest.mark.parametrize("branch", ["recorded", "starting", "ready_owner", "mismatched_command", "lock_owner"])
+def test_start_service_receipt_marks_every_existing_return_as_reused(monkeypatch, receipt_runtime, branch):
+    receipt_runtime.service_path.write_text("1234", encoding="utf-8")
+    alive_checks = iter([False, True]) if branch == "lock_owner" else None
+    if alive_checks is not None:
+        monkeypatch.setattr(runtime, "pid_alive", lambda pid: next(alive_checks))
+    monkeypatch.setattr(runtime, "service_pid_recorded", lambda pid: branch == "recorded")
+    monkeypatch.setattr(runtime, "_pid_reservation_is_fresh", lambda *args: True)
+    monkeypatch.setattr(runtime, "wait_for_service_ready", lambda pid, timeout: 9012)
+    monkeypatch.setattr(runtime, "_pid_mismatches_service", lambda pid: branch == "mismatched_command")
+    monkeypatch.setattr(runtime, "service_instance_lock_available", lambda: (False, 1234))
+    info = runtime.ProcessStartInfo()
+    expected_pid = 9012 if branch == "ready_owner" else 1234
+
+    assert runtime.start_service(wait_for_ready=branch != "starting", start_info=info) == expected_pid
+
+    assert info.reused is True
+    assert info.pid == expected_pid
+    assert info.create_unix_ms == receipt_runtime.process_times[expected_pid] * 1000
+    assert receipt_runtime.spawned == []
+
+
+def test_start_service_receipt_adopts_scoped_owner(monkeypatch, receipt_runtime):
+    monkeypatch.setattr(runtime, "maybe_systemd_scope_prefix", lambda: ["systemd-run", "--scope"])
+    monkeypatch.setattr(runtime, "_start_scoped_service_result", lambda *args, **kwargs: 9012)
+    info = runtime.ProcessStartInfo()
+
+    assert runtime.start_service(start_info=info) == 9012
+
+    assert info.reused is False
+    assert info.create_unix_ms == receipt_runtime.process_times[9012] * 1000
+    assert receipt_runtime.captured == [1234, 9012]
+    assert receipt_runtime.spawned == ["service"]
+
+
+def test_start_service_receipt_keeps_identity_captured_before_readiness(monkeypatch, receipt_runtime):
+    before = receipt_runtime.process_times[1234] * 1000
+    monkeypatch.setattr(runtime, "wait_for_service_pid", lambda pid, timeout: receipt_runtime.process_times.update({1234: 9999}) or True)
+    info = runtime.ProcessStartInfo()
+
+    assert runtime.start_service(start_info=info) == 1234
+
+    assert info.reused is False
+    assert info.create_unix_ms == before
+    assert receipt_runtime.captured == [1234]
+
+
+def test_cmd_start_receipt_tracks_late_authoritative_service_pid(monkeypatch, capsys, receipt_runtime):
+    monkeypatch.setattr(runtime, "service_pid_recorded", lambda pid: False)
+    monkeypatch.setattr(runtime, "wait_for_service_pid", lambda pid, timeout: False)
+    monkeypatch.setattr(runtime, "wait_for_service_ready", lambda pid, timeout: 9012)
+
+    assert cli.cmd_start(open_browser=False) == 0
+
+    receipt_line = next(line for line in capsys.readouterr().out.splitlines() if line.startswith("@avibe-start-receipt:"))
+    receipt = json.loads(receipt_line.split(":", 1)[1])
+    assert receipt["service_pid"] == 9012
+    assert receipt["service_create_unix_ms"] == receipt_runtime.process_times[9012] * 1000
+    assert receipt["outcome"] == "started"
+    assert receipt_runtime.captured == [1234, 5678, 9012]
+
+
+def test_cmd_start_does_not_emit_a_receipt_with_unreadable_identity(monkeypatch, capsys, receipt_runtime):
+    monkeypatch.setattr(runtime, "process_create_time", lambda pid: None)
+
+    with pytest.raises(ValueError, match="service_create_unix_ms"):
+        cli.cmd_start(open_browser=False)
+
+    assert "@avibe-start-receipt:" not in capsys.readouterr().out
+
+
 def test_cmd_start_ensures_services_without_stopping(monkeypatch):
     calls = []
     config = SimpleNamespace(
@@ -670,12 +993,12 @@ def test_cmd_start_ensures_services_without_stopping(monkeypatch):
         lambda: calls.append(("handover",)),
     )
     monkeypatch.setattr(cli, "_write_status", lambda *args, **kwargs: calls.append(("status", args)))
-    monkeypatch.setattr(cli.runtime, "start_service", lambda **kwargs: calls.append(("start_service", kwargs)) or 1234)
+    monkeypatch.setattr(cli.runtime, "start_service", lambda **kwargs: calls.append(("start_service", kwargs)) or _fake_start_result(1234, kwargs))
     monkeypatch.setattr(cli.runtime, "effective_ui_bind_host", lambda cfg: "127.0.0.1")
     monkeypatch.setattr(
         cli.runtime,
         "start_ui",
-        lambda host, port, **kwargs: calls.append(("start_ui", host, port, kwargs)) or 5678,
+        lambda host, port, **kwargs: calls.append(("start_ui", host, port, kwargs)) or _fake_start_result(5678, kwargs),
     )
     monkeypatch.setattr(cli.runtime, "service_pid_recorded", lambda pid: True)
     monkeypatch.setattr(cli.runtime, "write_status", lambda *args: calls.append(("runtime_status", args)))
@@ -758,12 +1081,13 @@ def test_cmd_start_can_suppress_configured_browser_open(monkeypatch):
     )
     opened = []
 
+    _no_live_runtime_processes(monkeypatch)
     monkeypatch.setattr(cli.paths, "ensure_data_dirs", lambda: None)
     monkeypatch.setattr(cli, "_ensure_config", lambda: config)
     monkeypatch.setattr(cli, "_write_status", lambda *args, **kwargs: None)
-    monkeypatch.setattr(cli.runtime, "start_service", lambda **kwargs: 1234)
+    monkeypatch.setattr(cli.runtime, "start_service", lambda **kwargs: _fake_start_result(1234, kwargs))
     monkeypatch.setattr(cli.runtime, "effective_ui_bind_host", lambda cfg: "127.0.0.1")
-    monkeypatch.setattr(cli.runtime, "start_ui", lambda host, port, **kwargs: 5678)
+    monkeypatch.setattr(cli.runtime, "start_ui", lambda host, port, **kwargs: _fake_start_result(5678, kwargs))
     monkeypatch.setattr(cli.runtime, "service_pid_recorded", lambda pid: True)
     monkeypatch.setattr(cli.runtime, "write_status", lambda *args: None)
     monkeypatch.setattr(cli, "_open_browser", lambda url: opened.append(url) or True)
@@ -784,12 +1108,12 @@ def test_cmd_start_keeps_ui_up_while_service_lock_is_slow(monkeypatch):
     monkeypatch.setattr(cli.paths, "ensure_data_dirs", lambda: None)
     monkeypatch.setattr(cli, "_ensure_config", lambda: config)
     monkeypatch.setattr(cli, "_write_status", lambda *args, **kwargs: calls.append(("status", args)))
-    monkeypatch.setattr(cli.runtime, "start_service", lambda **kwargs: calls.append(("start_service", kwargs)) or 1234)
+    monkeypatch.setattr(cli.runtime, "start_service", lambda **kwargs: calls.append(("start_service", kwargs)) or _fake_start_result(1234, kwargs))
     monkeypatch.setattr(cli.runtime, "effective_ui_bind_host", lambda cfg: "127.0.0.1")
     monkeypatch.setattr(
         cli.runtime,
         "start_ui",
-        lambda host, port, **kwargs: calls.append(("start_ui", host, port, kwargs)) or 5678,
+        lambda host, port, **kwargs: calls.append(("start_ui", host, port, kwargs)) or _fake_start_result(5678, kwargs),
     )
     monkeypatch.setattr(cli.runtime, "service_pid_recorded", lambda pid: False)
     monkeypatch.setattr(cli.runtime, "wait_for_service_ready", lambda pid, timeout: None)
@@ -817,9 +1141,9 @@ def test_cmd_start_fails_only_when_slow_service_exits(monkeypatch):
     monkeypatch.setattr(cli.paths, "ensure_data_dirs", lambda: None)
     monkeypatch.setattr(cli, "_ensure_config", lambda: config)
     monkeypatch.setattr(cli, "_write_status", lambda *args, **kwargs: None)
-    monkeypatch.setattr(cli.runtime, "start_service", lambda **kwargs: 1234)
+    monkeypatch.setattr(cli.runtime, "start_service", lambda **kwargs: _fake_start_result(1234, kwargs))
     monkeypatch.setattr(cli.runtime, "effective_ui_bind_host", lambda cfg: "127.0.0.1")
-    monkeypatch.setattr(cli.runtime, "start_ui", lambda host, port, **kwargs: 5678)
+    monkeypatch.setattr(cli.runtime, "start_ui", lambda host, port, **kwargs: _fake_start_result(5678, kwargs))
     monkeypatch.setattr(cli.runtime, "service_pid_recorded", lambda pid: False)
     monkeypatch.setattr(cli.runtime, "wait_for_service_ready", lambda pid, timeout: None)
     monkeypatch.setattr(cli.runtime, "pid_alive", lambda pid: False)
@@ -849,7 +1173,7 @@ def test_cmd_start_restarts_a_surviving_ui_so_it_shares_the_new_service_secret(m
     monkeypatch.setattr(cli, "_write_status", lambda *args, **kwargs: None)
     monkeypatch.setattr(cli.runtime, "resolve_service_owner_pid", lambda **kwargs: None)
     monkeypatch.setattr(cli, "_live_ui_server_pid", lambda: 5678)
-    monkeypatch.setattr(cli.runtime, "start_service", lambda **kwargs: calls.append(("start_service", kwargs)) or 1234)
+    monkeypatch.setattr(cli.runtime, "start_service", lambda **kwargs: calls.append(("start_service", kwargs)) or _fake_start_result(1234, kwargs))
     monkeypatch.setattr(
         cli.runtime,
         "stop_ui",
@@ -859,7 +1183,7 @@ def test_cmd_start_restarts_a_surviving_ui_so_it_shares_the_new_service_secret(m
     monkeypatch.setattr(
         cli.runtime,
         "start_ui",
-        lambda host, port, **kwargs: calls.append(("start_ui", kwargs)) or 9012,
+        lambda host, port, **kwargs: calls.append(("start_ui", kwargs)) or _fake_start_result(9012, kwargs),
     )
     monkeypatch.setattr(cli.runtime, "service_pid_recorded", lambda pid: True)
     monkeypatch.setattr(cli.runtime, "write_status", lambda *args: None)
@@ -895,7 +1219,7 @@ def test_cmd_start_never_signs_with_a_secret_a_reused_service_cannot_verify(
     monkeypatch.setattr(cli, "_write_status", lambda *args, **kwargs: None)
     monkeypatch.setattr(cli.runtime, "resolve_service_owner_pid", lambda **kwargs: 1234)
     monkeypatch.setattr(cli, "_live_ui_server_pid", lambda: None)
-    monkeypatch.setattr(cli.runtime, "start_service", lambda **kwargs: calls.append(("start_service", kwargs)) or 1234)
+    monkeypatch.setattr(cli.runtime, "start_service", lambda **kwargs: calls.append(("start_service", kwargs)) or _fake_start_result(1234, kwargs, reused=True))
     monkeypatch.setattr(
         cli.runtime,
         "stop_ui",
@@ -905,7 +1229,7 @@ def test_cmd_start_never_signs_with_a_secret_a_reused_service_cannot_verify(
     monkeypatch.setattr(
         cli.runtime,
         "start_ui",
-        lambda host, port, **kwargs: calls.append(("start_ui", kwargs)) or 9012,
+        lambda host, port, **kwargs: calls.append(("start_ui", kwargs)) or _fake_start_result(9012, kwargs),
     )
     monkeypatch.setattr(cli.runtime, "service_pid_recorded", lambda pid: True)
     monkeypatch.setattr(cli.runtime, "write_status", lambda *args: None)
@@ -928,7 +1252,7 @@ def test_cmd_start_keeps_a_reused_pair_untouched(monkeypatch, capsys):
     monkeypatch.setattr(cli, "_write_status", lambda *args, **kwargs: None)
     monkeypatch.setattr(cli.runtime, "resolve_service_owner_pid", lambda **kwargs: 1234)
     monkeypatch.setattr(cli, "_live_ui_server_pid", lambda: 5678)
-    monkeypatch.setattr(cli.runtime, "start_service", lambda **kwargs: calls.append(("start_service", kwargs)) or 1234)
+    monkeypatch.setattr(cli.runtime, "start_service", lambda **kwargs: calls.append(("start_service", kwargs)) or _fake_start_result(1234, kwargs, reused=True))
     monkeypatch.setattr(
         cli.runtime,
         "stop_ui",
@@ -938,7 +1262,7 @@ def test_cmd_start_keeps_a_reused_pair_untouched(monkeypatch, capsys):
     monkeypatch.setattr(
         cli.runtime,
         "start_ui",
-        lambda host, port, **kwargs: calls.append(("start_ui", kwargs)) or 5678,
+        lambda host, port, **kwargs: calls.append(("start_ui", kwargs)) or _fake_start_result(5678, kwargs, reused=True),
     )
     monkeypatch.setattr(cli.runtime, "service_pid_recorded", lambda pid: True)
     monkeypatch.setattr(cli.runtime, "write_status", lambda *args: None)
@@ -2053,6 +2377,24 @@ def test_start_parser_accepts_no_open_browser():
 
     assert args.command == "start"
     assert args.open_browser is False
+
+
+@pytest.mark.parametrize("receipt", [None, json.dumps(_startup_receipt_payload())])
+def test_stop_parser_and_main_preserve_optional_receipt(monkeypatch, receipt):
+    arguments = ["stop"] if receipt is None else ["stop", "--receipt", receipt]
+    parsed = cli.build_parser().parse_args(arguments)
+    assert parsed.command == "stop"
+    assert parsed.receipt == receipt
+    calls = []
+    monkeypatch.setattr(cli.sys, "argv", ["vibe", *arguments])
+    monkeypatch.setattr(cli, "cache_running_vibe_path", lambda: None)
+    monkeypatch.setattr(cli, "cmd_stop", lambda **kwargs: calls.append(kwargs) or 3)
+
+    with pytest.raises(SystemExit) as exited:
+        cli.main()
+
+    assert exited.value.code == 3
+    assert calls == ([{}] if receipt is None else [{"receipt": receipt}])
 
 
 def test_remote_parser_accepts_pairing_command():

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -11820,13 +11820,15 @@ def cmd_start(*, open_browser: bool | None = None):
     # what left Memory profile/search/clear answering memory_access_denied after
     # a partial restart, so track which side actually started here.
     memory_ui_secret = generate_ui_read_secret()
-    live_service_pid = runtime.resolve_service_owner_pid(include_starting=True)
     live_ui_pid = _live_ui_server_pid()
+    service_start = runtime.ProcessStartInfo()
+    ui_start = runtime.ProcessStartInfo()
     service_pid = runtime.start_service(
         wait_for_ready=False,
         memory_ui_secret=memory_ui_secret,
+        start_info=service_start,
     )
-    service_reused = live_service_pid is not None and service_pid == live_service_pid
+    service_reused = service_start.reused
     if service_reused:
         # The reused service still verifies proofs with the secret it was started
         # with. Signing with a different one would only produce requests it
@@ -11845,6 +11847,7 @@ def cmd_start(*, open_browser: bool | None = None):
         bind_host,
         config.ui.setup_port,
         memory_ui_secret=ui_memory_secret,
+        start_info=ui_start,
     )
     if service_reused and ui_pid != live_ui_pid:
         logger.warning(
@@ -11870,6 +11873,7 @@ def cmd_start(*, open_browser: bool | None = None):
         )
         if resolved_pid is not None:
             service_pid = resolved_pid
+            service_start.capture(service_pid, reused=service_reused)
             service_ready = True
     if service_ready:
         runtime.write_status("running", "pid={}".format(service_pid), service_pid, ui_pid)
@@ -11879,6 +11883,18 @@ def cmd_start(*, open_browser: bool | None = None):
         runtime.write_status("error", "service process exited before startup completed", service_pid, ui_pid)
         raise RuntimeError(f"Vibe service process pid={service_pid} exited before acquiring the service lock")
 
+    from vibe.desktop_runtime import start_receipt_line
+
+    receipt_line = start_receipt_line(
+        {
+            "schema_version": 1,
+            "outcome": "reused" if service_reused else "started",
+            "service_pid": service_pid,
+            "ui_pid": ui_pid,
+            "service_create_unix_ms": service_start.create_unix_ms,
+            "ui_create_unix_ms": ui_start.create_unix_ms,
+        }
+    )
     ui_url = "http://{}:{}".format(config.ui.setup_host, config.ui.setup_port)
 
     # Always print Web UI access instructions.
@@ -11898,6 +11914,7 @@ def cmd_start(*, open_browser: bool | None = None):
             print(f"(Tip) Could not auto-open a browser. Open this URL manually: {ui_url}")
             print("")
 
+    print(receipt_line, flush=True)
     return 0
 
 
@@ -11968,7 +11985,35 @@ def _runtime_process_was_running() -> bool:
     return runtime.service_process_running() or runtime.ui_pid_file_points_to_running_ui()
 
 
-def cmd_stop():
+def _stop_receipt_refusal(receipt_json: str) -> str | None:
+    from vibe.desktop_runtime import START_RECEIPT_TIME_TOLERANCE_MS, validate_start_receipt
+
+    try:
+        receipt = validate_start_receipt(json.loads(receipt_json))
+    except (ValueError, RecursionError):
+        return "invalid_receipt"
+    try:
+        recorded_pid = int(paths.get_runtime_pid_path().read_text(encoding="utf-8").strip())
+    except (OSError, ValueError):
+        return "service_pid_mismatch"
+    if recorded_pid != receipt["service_pid"]:
+        return "service_pid_mismatch"
+    if not runtime.pid_alive(recorded_pid):
+        return "service_identity_unavailable"
+    created = runtime.process_create_time(recorded_pid)
+    if created is None:
+        return "service_identity_unavailable"
+    if not abs(created * 1000 - receipt["service_create_unix_ms"]) <= START_RECEIPT_TIME_TOLERANCE_MS:
+        return "service_create_time_mismatch"
+    return None
+
+
+def cmd_stop(*, receipt: str | None = None):
+    if receipt is not None:
+        reason = _stop_receipt_refusal(receipt)
+        if reason is not None:
+            print(json.dumps({"reason": reason}, separators=(",", ":")), file=sys.stderr)
+            return 3
     service_was_running = _pid_file_points_to_live_process(paths.get_runtime_pid_path())
     ui_was_running = _pid_file_points_to_live_process(paths.get_runtime_ui_pid_path())
 
@@ -13897,7 +13942,11 @@ def build_parser():
     parser = VibeArgumentParser(prog="vibe")
     subparsers = parser.add_subparsers(dest="command")
 
-    subparsers.add_parser("stop", help="Stop all services")
+    stop_parser = subparsers.add_parser("stop", help="Stop all services")
+    stop_parser.add_argument(
+        "--receipt",
+        help="Stop only if the service identity matches this startup receipt JSON.",
+    )
     start_parser = subparsers.add_parser("start", help="Start services if needed without stopping running processes")
     start_parser.add_argument(
         "--no-open-browser",
@@ -15521,7 +15570,7 @@ def main():
     args = parser.parse_args()
 
     if args.command == "stop":
-        sys.exit(cmd_stop())
+        sys.exit(cmd_stop(receipt=args.receipt) if args.receipt is not None else cmd_stop())
     if args.command == "start":
         sys.exit(cmd_start(open_browser=args.open_browser))
     if args.command == "desktop" and args.desktop_command == "endpoint":

--- a/vibe/desktop_runtime.py
+++ b/vibe/desktop_runtime.py
@@ -9,11 +9,13 @@ configuration or broaden its navigation policy.
 from __future__ import annotations
 
 import ipaddress
+import json
+import math
 import os
 import socket
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Literal, TypedDict
+from typing import Literal, TypedDict, cast
 
 DESKTOP_ENDPOINT_SCHEMA_VERSION: Literal[1] = 1
 DESKTOP_RUNTIME_ID_ENV = "AVIBE_DESKTOP_RUNTIME_ID"
@@ -21,6 +23,46 @@ DESKTOP_RUNTIME_ROOT_ENV = "AVIBE_DESKTOP_RUNTIME_ROOT"
 DESKTOP_NODE_BIN_ENV = "VIBE_SHOW_RUNTIME_NODE_BIN"
 DESKTOP_NPM_CLI_ENV = "AVIBE_DESKTOP_NPM_CLI"
 DESKTOP_BACKENDS_ROOT_ENV = "AVIBE_DESKTOP_BACKENDS_ROOT"
+START_RECEIPT_PREFIX = "@avibe-start-receipt:"
+START_RECEIPT_TIME_TOLERANCE_MS = 2.0
+
+
+class StartReceipt(TypedDict):
+    schema_version: Literal[1]
+    outcome: Literal["started", "reused"]
+    service_pid: int
+    ui_pid: int
+    service_create_unix_ms: float
+    ui_create_unix_ms: float
+
+
+def validate_start_receipt(payload: object) -> StartReceipt:
+    if not isinstance(payload, dict):
+        raise ValueError("Startup receipt must be an object")
+    if type(payload.get("schema_version")) is not int or payload["schema_version"] != 1:
+        raise ValueError("Unsupported startup receipt schema")
+    if payload.get("outcome") not in ("started", "reused"):
+        raise ValueError("Invalid startup receipt outcome")
+    for field in ("service_pid", "ui_pid"):
+        value = payload.get(field)
+        if type(value) is not int or value <= 0:
+            raise ValueError(f"Invalid startup receipt {field}")
+    for field in ("service_create_unix_ms", "ui_create_unix_ms"):
+        value = payload.get(field)
+        if type(value) not in (int, float) or value <= 0:
+            raise ValueError(f"Invalid startup receipt {field}")
+        try:
+            finite = math.isfinite(value)
+        except OverflowError:
+            finite = False
+        if not finite:
+            raise ValueError(f"Invalid startup receipt {field}")
+    return cast(StartReceipt, payload)
+
+
+def start_receipt_line(payload: object) -> str:
+    receipt = validate_start_receipt(payload)
+    return START_RECEIPT_PREFIX + json.dumps(receipt, separators=(",", ":"), allow_nan=False)
 
 
 class DesktopEndpointPayload(TypedDict):

--- a/vibe/runtime.py
+++ b/vibe/runtime.py
@@ -15,6 +15,7 @@ import time
 import urllib.error
 import urllib.request
 import uuid
+from dataclasses import dataclass
 from pathlib import Path
 
 import psutil
@@ -38,6 +39,21 @@ SHUTDOWN_INTENT_TTL_SECONDS = 30
 SHUTDOWN_INTENT_ENV = "VIBE_REQUIRE_SHUTDOWN_INTENT"
 SERVICE_LOCK_READY_TIMEOUT_SECONDS = 5.0
 SERVICE_SLOW_START_TIMEOUT_SECONDS = 120.0
+
+
+@dataclass
+class ProcessStartInfo:
+    pid: int | None = None
+    create_unix_ms: float | None = None
+    reused: bool = False
+
+    def capture(self, pid: int, *, reused: bool) -> int:
+        if self.pid != pid:
+            created = process_create_time(pid)
+            self.pid = pid
+            self.create_unix_ms = created * 1000 if created is not None else None
+        self.reused = reused
+        return pid
 
 
 def get_package_root() -> Path:
@@ -1501,9 +1517,13 @@ def start_service(
     wait_for_ready: bool = True,
     initial_ready_timeout: float = SERVICE_LOCK_READY_TIMEOUT_SECONDS,
     memory_ui_secret: str | None = None,
+    start_info: ProcessStartInfo | None = None,
 ):
     from storage.migrations import guard_source_checkout_default_state_bootstrap
     from core.memory.ui_access import process_ui_read_secret
+
+    def result(pid: int, *, reused: bool) -> int:
+        return start_info.capture(pid, reused=reused) if start_info is not None else pid
 
     memory_ui_secret = memory_ui_secret or process_ui_read_secret()
     guard_source_checkout_default_state_bootstrap()
@@ -1518,16 +1538,16 @@ def start_service(
             if existing_pid and pid_alive(existing_pid):
                 if not _pid_mismatches_service(existing_pid):
                     if service_pid_recorded(existing_pid):
-                        return existing_pid
+                        return result(existing_pid, reused=True)
                     if _pid_reservation_is_fresh(pid_path, existing_pid):
                         if not wait_for_ready:
-                            return existing_pid
+                            return result(existing_pid, reused=True)
                         ready_pid = wait_for_service_ready(
                             existing_pid,
                             timeout=SERVICE_SLOW_START_TIMEOUT_SECONDS,
                         )
                         if ready_pid is not None:
-                            return ready_pid
+                            return result(ready_pid, reused=True)
                         _raise_service_start_not_ready(existing_pid, timeout=SERVICE_SLOW_START_TIMEOUT_SECONDS)
                     logger.warning(
                         "Ignoring stale service pid file pid=%s because it never acquired the service lock",
@@ -1542,7 +1562,7 @@ def start_service(
                                 "match this CLI install",
                                 existing_pid,
                             )
-                            return lock_holder_pid
+                            return result(lock_holder_pid, reused=True)
                         raise ServiceAlreadyRunningError(lock_path=get_service_lock_path(), holder_pid=lock_holder_pid)
                     raise ServiceAlreadyRunningError(lock_path=get_service_lock_path(), holder_pid=lock_holder_pid)
                 logger.warning(
@@ -1554,7 +1574,7 @@ def start_service(
         lock_available, lock_holder_pid = service_instance_lock_available()
         if not lock_available:
             if lock_holder_pid and lock_holder_pid == existing_pid and pid_alive(lock_holder_pid):
-                return lock_holder_pid
+                return result(lock_holder_pid, reused=True)
             raise ServiceAlreadyRunningError(lock_path=get_service_lock_path(), holder_pid=lock_holder_pid)
 
         extra_pids = extra_service_process_pids()
@@ -1582,16 +1602,18 @@ def start_service(
             **spawn_kwargs,
         )
         pid = process.pid
+        result(pid, reused=False)
         _SERVICE_START_PROCESSES[pid] = process
         _record_service_pid_reservation(pid)
         if scope_prefix:
             # Scoped launches resolve their pid via the authoritative lock holder
             # (poll-and-adopt), never by trusting the spawn pid alone.
-            return _start_scoped_service_result(
+            resolved_pid = _start_scoped_service_result(
                 pid,
                 initial_ready_timeout=initial_ready_timeout,
                 wait_for_ready=wait_for_ready,
             )
+            return result(resolved_pid, reused=False)
         if initial_ready_timeout > 0 and wait_for_service_pid(pid, timeout=initial_ready_timeout):
             return pid
         exit_code = _service_start_exit_code(pid)
@@ -1808,6 +1830,7 @@ def start_ui(
     *,
     wait_for_ready: bool = True,
     memory_ui_secret: str | None = None,
+    start_info: ProcessStartInfo | None = None,
 ):
     from core.memory.ui_access import process_ui_read_secret
     from vibe.desktop_runtime import normalize_desktop_port
@@ -1822,6 +1845,8 @@ def start_ui(
             existing_pid = 0
         if existing_pid and pid_alive(existing_pid):
             if _pid_matches_ui_server(existing_pid) and _ui_server_compatible(host, port):
+                if start_info is not None:
+                    start_info.capture(existing_pid, reused=True)
                 return existing_pid
             if _pid_matches_ui_server(existing_pid):
                 logger.warning(
@@ -1850,6 +1875,8 @@ def start_ui(
         "ui_stderr.log",
         **spawn_kwargs,
     )
+    if start_info is not None:
+        start_info.capture(pid, reused=False)
     if wait_for_ready and not wait_for_ui_server(host, port):
         logger.warning(
             "Started UI pid=%s but required health checks did not pass for %s",


### PR DESCRIPTION
## Capability and frozen contract

Shapes frozen; implementation and focused validation complete.

- `vibe start` and `vibe start --no-open-browser` emit one exact-prefix schema-v1 startup receipt, preserving the human-readable output.
- Process identity and reuse are captured inside `start_service` / `start_ui`. Service provenance, not a caller-side pre-launch snapshot, selects `outcome`; scoped launches update identity to the authoritative service PID.
- `vibe stop --receipt <json>` checks the recorded service PID and live psutil create-time (inclusive ±2 ms) before any shutdown side effect. Mismatch or malformed input returns exit 3 and reason JSON; a match follows the existing full graceful stop, including its exit-2 failure path. Unscoped stop is unchanged.
- Frozen producer/consumer specification: `docs/plans/desktop-start-receipt.md`.

## Dependencies and integration

- Base: `desktop`, including merged #1972 (`0fe5ce480`). No unmerged implementation dependency or stacked branch.
- This is the producer contract consumed by the independent Rust tray lifecycle lane #1975. The consumer must cite this PR as its integration dependency.
- No changes to `desktop/**`, workflows, deployment, or the consumer-owned lifecycle plan.

## Evidence layers

- Unit / producer contract: 368 tests pass across CLI, runtime service locks, scoped bootstrap, desktop Runtime helpers, restart supervisor, and state migration guards, and legacy setup-status callers.
- Coverage includes actual startup functions with fake process creation, every service reuse-return path, stale caller snapshots, service/UI launch-captured psutil timestamps, scoped and late authoritative-PID adoption, both browser modes, strict malformed-receipt rejection, inclusive tolerance, PID replacement/recycling, no-side-effect refusal, legacy full-stop behavior, and parser-to-dispatch propagation.
- Static checks: Ruff passes for all changed Python files; `git diff --check` passes.
- Scenario catalog: no dedicated startup-receipt scenario ID exists; coverage extends the existing `tests/test_vibe_cli.py` suite.
- Residual manual / integration: the orchestrator's desktop acceptance pass must exercise real shell startup, adoption, and receipt-conditioned stop across Rust/Python. The local agent-hosting service was not restarted; no production or regression product state was modified.

## Known-by-design ledger

- **Service-owner gate, not per-process capability:** after the service identity matches, today's service sweep, UI, OpenCode, and tunnel shutdown remain intentionally unchanged. This v1 gate does not prevent same-install concurrent replacement after gate time, nor independently authorize each UI or helper process. A stronger guarantee would require a new contract version.
- **Ownership policy belongs to the consumer:** `outcome` describes the service's actual spawn/reuse branch only; UI reuse does not change it. Python accepts `outcome=reused` as identity input. The desktop consumer treats a `reused` receipt as adoption regardless of which process invoked start, never offers stop for an adopted runtime, and must never retry a refused scoped stop as unscoped stop.
- **No secret or same-user isolation claim:** the receipt contains process identity, not a capability token; existing same-user unscoped stop remains available.

- **English-only CLI flag help (explicit scope ruling):** the task brief explicitly requires English-only strings in this CLI path, with no new i18n keys. `VibeArgumentParser` extends parsing and error reporting, not `format_help`; the existing parser help strings, including adjacent start/stop options, are English and do not load the configured locale. An isolated render with a Chinese configuration confirmed English start/stop help and zero configuration-language reads. Localizing only `--receipt` would create a lone inconsistent translated flag. A future localization effort must address the CLI help surface consistently as a separate cross-cutting change; it is outside this receipt contract. The orchestrator reaffirmed this non-change after review comment 3975755196.

Do not merge automatically; exact-head Codex review, zero unresolved threads, and all expected CI checks remain delivery gates.


