### PR TITLE
docs(desktop): freeze G4/G5/G6 contracts and defer native multi-window

### DIFF
--- a/docs/plans/desktop-deep-links.md
+++ b/docs/plans/desktop-deep-links.md
@@ -29,15 +29,25 @@ window for a Show Page is G8 and is not this contract.
 Scheme: `avibe` (no `+` / no vendor prefix). Registered for the
 packaged app identifier `bot.avibe.desktop`.
 
-v1 paths, each a single host-less URL of the form `avibe://<kind>/<id>`
-or `avibe://<kind>`:
+v1 URLs use the `avibe://` form users type and OS scheme handlers
+deliver. A WHATWG parser therefore treats `<kind>` as the **authority
+(host)**, not as a path segment. That is the frozen grammar: kind **is**
+the allow-listed authority. Do not also accept a second, host-less
+spelling (`avibe:session/...`); one form only.
 
-| Link                              | Workbench navigation                         |
+| Link (kind = authority)           | Workbench navigation                         |
 | --------------------------------- | -------------------------------------------- |
 | `avibe://session/<session_id>`    | `/chat/<session_id>`                         |
 | `avibe://show/<session_id>`       | `/apps/show/<session_id>`                    |
 | `avibe://settings`                | `/admin/settings/service`                    |
 | `avibe://vaults/request/<request_id>` | `/vaults?request_id=<request_id>`        |
+
+Parse as a URL. Accept only when `scheme == avibe` and `host` is one of
+`session`, `show`, `settings`, `vaults`. Path/id rules:
+
+- `session` / `show`: path is exactly one segment, the id.
+- `settings`: path empty.
+- `vaults`: path is exactly `request/<request_id>`.
 
 `<session_id>` and `<request_id>` are the product's existing identifiers
 (Workbench session ids, vault request ids). They are accepted only when
@@ -47,16 +57,20 @@ the complete path segments `.` or `..`. Ordinary dots inside an id
 
 Rejected complete `.` / `..` because WHATWG URL path normalization
 would turn `/chat/.` into `/chat/` and `/chat/..` into `/`, so the
-in-window navigation could not land on the mapped session route. Percent-
-encoded `%2E` / `%2E%2E` are not those segments and stay subject only
-to the character/length rule (they do not normalize as dot-segments).
+in-window navigation could not land on the mapped session route. Percent-encoded `%2E` / `%2E%2E` **do** normalize as dot-segments under
+WHATWG (`/chat/%2E` → `/chat/`, `/chat/%2E%2E` → `/`). They are still
+rejected, but by the character-class rule (`%` is not in
+`[A-Za-z0-9._-]`), not by a special encoded-dot exception. Do not
+document them as surviving the parser.
 
 Rejected (no navigation, no quoted echo into the WebView):
 
 - any scheme other than `avibe`;
-- unknown kind / extra path segments / unexpected query or fragment;
-- an id that fails the character/length rule;
-- anything that looks like a host (`avibe://session@…`, `//` authority).
+- host/authority not in `{session, show, settings, vaults}`
+  (this is what "reject unknown authority" means — userinfo,
+  non-allow-listed hosts, `avibe://session@…`);
+- extra path segments, query, or fragment other than the table;
+- an id that fails the character/length rule or is complete `.` / `..`.
 
 The mapping table is the contract. A new kind is a contract revision,
 not a silent addition in the parser.
@@ -65,16 +79,22 @@ not a silent addition in the parser.
 
 Two launch shapes, one Workbench mechanism.
 
-1. **Hot path** (app already running). `tauri-plugin-single-instance`
-   already hands a second launch to the live process and focuses the
-   main window (`desktop/src-tauri/src/lib.rs`). v1 extends that
-   callback to read argv, parse one `avibe://` URL, and — after the
-   window is showing the Workbench origin — ask the WebView to
-   navigate **in-window** to `{origin}{path}{query}` from the table
-   above. Same origin as the currently adopted Runtime; never a
-   different host.
+1. **Hot path** (app already running). Every OS delivery of an
+   `avibe://` URL is parsed by the **same** function and applied to
+   the live window. On Windows a second launch typically arrives as
+   single-instance argv (already wired to focus the main window in
+   `desktop/src-tauri/src/lib.rs`). On macOS, Launch Services delivers
+   custom-scheme activations as a native open-URL event
+   (`RunEvent::Opened` / the deep-link plugin's current-URL /
+   `on_open_url` **Rust** callback) — **not** as a second-process
+   argv. Feed that native event into the same parser/stash as argv.
+   Never handle it in WebView JavaScript, never add an IPC command.
+   After the window is showing the Workbench origin, navigate
+   **in-window** to `{origin}{path}{query}` from the table. Same
+   origin as the currently adopted Runtime; never `devUrl` / port 1420.
 2. **Cold path** (app was not running). OS starts the packaged app
-   with the URL in argv. The shell stashes the parsed target, runs
+   with the URL in argv **or** (macOS) as the first open-URL event.
+   The shell stashes the parsed target, runs
    the existing bootstrap/adopt flow unchanged, and on the first
    successful Workbench navigation includes the target path so the
    SPA lands on it instead of the default session list.

--- a/docs/plans/desktop-deep-links.md
+++ b/docs/plans/desktop-deep-links.md
@@ -1,0 +1,170 @@
+# Desktop deep links (`avibe://`)
+
+## Status
+
+Frozen implementation contract for gap G5. Companion to
+`desktop-product-gaps.md` (G5), `desktop-notifications-sse.md` (G4 click
+upgrades to a locate, not a redesign), and
+`tauri-desktop-vertical-slice.md` (thin shell, Workbench stays the
+product UI).
+
+Owner: Avibe core
+Date: 2026-09-10
+Baseline: `desktop` branch after #1975 (single-instance plugin already
+focuses the running window and ignores argv).
+
+## Product outcome
+
+A click on `avibe://session/<id>` (from IM, mail, or a future G4
+notification) brings Avibe to the front and shows that session. If the
+app was not running, it starts, finishes bootstrap, then shows the
+session. Unknown or malformed links are dropped, never echoed back
+into a WebView.
+
+v1 is **locate-in-the-existing-window**. Opening a second native
+window for a Show Page is G8 and is not this contract.
+
+## Frozen grammar
+
+Scheme: `avibe` (no `+` / no vendor prefix). Registered for the
+packaged app identifier `bot.avibe.desktop`.
+
+v1 paths, each a single host-less URL of the form `avibe://<kind>/<id>`
+or `avibe://<kind>`:
+
+| Link                              | Workbench navigation                         |
+| --------------------------------- | -------------------------------------------- |
+| `avibe://session/<session_id>`    | `/chat/<session_id>`                         |
+| `avibe://show/<session_id>`       | `/apps/show/<session_id>`                    |
+| `avibe://settings`                | `/admin/settings/service`                    |
+| `avibe://vaults/request/<request_id>` | `/vaults?request_id=<request_id>`        |
+
+`<session_id>` and `<request_id>` are the product's existing identifiers
+(Workbench session ids, vault request ids). They are accepted only when
+they match `^[A-Za-z0-9._-]+$` and are at most 128 bytes. Anything else
+is malformed.
+
+Rejected (no navigation, no quoted echo into the WebView):
+
+- any scheme other than `avibe`;
+- unknown kind / extra path segments / unexpected query or fragment;
+- an id that fails the character/length rule;
+- anything that looks like a host (`avibe://session@…`, `//` authority).
+
+The mapping table is the contract. A new kind is a contract revision,
+not a silent addition in the parser.
+
+## Delivery: the shell never talks IPC to the Workbench
+
+Two launch shapes, one Workbench mechanism.
+
+1. **Hot path** (app already running). `tauri-plugin-single-instance`
+   already hands a second launch to the live process and focuses the
+   main window (`desktop/src-tauri/src/lib.rs`). v1 extends that
+   callback to read argv, parse one `avibe://` URL, and — after the
+   window is showing the Workbench origin — ask the WebView to
+   navigate **in-window** to `{origin}{path}{query}` from the table
+   above. Same origin as the currently adopted Runtime; never a
+   different host.
+2. **Cold path** (app was not running). OS starts the packaged app
+   with the URL in argv. The shell stashes the parsed target, runs
+   the existing bootstrap/adopt flow unchanged, and on the first
+   successful Workbench navigation includes the target path so the
+   SPA lands on it instead of the default session list.
+
+Both paths resolve to "the Workbench SPA navigates to a same-origin
+URL it already implements". There is **no new Tauri command, no new
+capability, no `remote` grant**. A Workbench page still cannot invoke
+bootstrap IPC; the shell pushing a same-origin path into its own
+WebView is not an IPC grant.
+
+If the Runtime is not yet ready (bootstrap screen still up), the
+stashed target waits. Bootstrap failure discards it and stays on the
+bootstrap screen — a deep link must not override a failed Runtime
+with a half-navigated Workbench.
+
+## Why not an IPC command
+
+An IPC `open_target` callable from the WebView would have to be
+granted to the navigated Workbench to be useful on the hot path,
+which is exactly the capability boundary `shell_boundaries.rs`
+forbids. Same-origin in-window navigation keeps the privilege in
+the shell: only the process that owns the window decides to move it.
+
+## Producer side (Python, separate from the shell PR if needed)
+
+Today `vault_request_url` / IM formatters emit public `https://`
+Workbench URLs via `workbench_url` (`core/avibe_cloud.py`). That
+remains the right link for browsers and for users without the
+desktop app.
+
+v1 desktop does **not** require those producers to switch. The
+shell's job is to honour `avibe://` when the OS delivers one.
+Producers may start emitting `avibe://` **in addition to** https
+(for example in a native-notification payload once G4 lands) under
+their own PR; that is a link-grammar consumer, not a scheme-parser
+change. Until they do, G5 is still testable: open
+`avibe://session/<known-id>` from Terminal / a test page.
+
+Do not replace https links in IM with `avibe://` in v1: IM clients
+are not the desktop OS and cannot route the scheme.
+
+## Plugin and packaging
+
+- `tauri-plugin-deep-link` registers the scheme at build/install
+  time for the packaged app. Development `tauri dev` may not receive
+  OS-level `avibe://` clicks (scheme registration is an installed-app
+  concern); argv injection and the single-instance callback remain
+  the testable path.
+- macOS: the scheme lands in `Info.plist` via the plugin. That file
+  is generated; do not hand-edit it in source.
+- Windows: the scheme lands in the NSIS file association. Unsigned
+  acceptance builds still register it for that install; signing (G1)
+  does not change the grammar.
+
+## Tests (invariants)
+
+- Parser: every row in the mapping table produces the exact
+  Workbench path; every rejected shape (wrong scheme, extra
+  segment, bad id, authority) produces `None` and never includes the
+  raw input in a UI string.
+- Hot path: a second-instance argv containing a valid link focuses
+  the main window and requests in-window navigation to the mapped
+  path on the **currently adopted origin**, not on `devUrl` / port
+  1420.
+- Cold path: a stashed valid target is applied on the first
+  successful Workbench navigation and then cleared; a failed
+  bootstrap leaves the stash dropped and the window on bootstrap.
+- Boundary: no new command appears in `src-tauri/build.rs`;
+  `shell_boundaries.rs` still forbids `remote` grants. Deep-link
+  handling lives in the single-instance callback / argv path, which
+  is not WebView-callable.
+- Capability: a Workbench origin (remote after navigation) still
+  cannot invoke bootstrap commands after a deep link is consumed.
+
+Drive parser tests without Tauri (pure function in `runtime-host` or
+an equivalent Tauri-free module). Drive the stash/apply state
+machine with the existing fake-Runtime bootstrap tests.
+
+## Explicit non-goals (v1)
+
+- Native multi-window as the link's destination (G8).
+  `avibe://show/<id>` in v1 locates inside the main window.
+- Replacing https Workbench URLs in IM / mail.
+- Authenticating the link (ids are capabilities-by-guess of a
+  local-only app; loopback Workbench already assumes the user on
+  the machine).
+- Query parameters other than `request_id` on `/vaults`.
+- Custom URL scheme beyond `avibe`.
+
+## Sequencing
+
+- Independent of G1 signing. Scheme registration works on unsigned
+  acceptance builds.
+- G4 may adopt these URLs as notification click targets in a
+  follow-up; G4 v1 remains "focus the window".
+- G6 (window state) is independent; a restored frame still receives
+  the in-window navigation.
+- G8, when it exists, may reinterpret `avibe://show/<id>` as "tear
+  out that Show Page"; the grammar stays, the destination policy
+  is a G8 revision of this table's third column.

--- a/docs/plans/desktop-deep-links.md
+++ b/docs/plans/desktop-deep-links.md
@@ -155,20 +155,26 @@ are not the desktop OS and cannot route the scheme.
 
 - Parser: every row in the mapping table produces the exact
   Workbench path; every rejected shape (wrong scheme, extra
-  segment, bad id, complete `.` / `..` path id, authority) produces
-  `None` and never includes the raw input in a UI string. An id that
-  merely contains a dot still maps.
-- Hot path: a second-instance argv containing a valid link focuses
-  the main window and requests in-window navigation to the mapped
-  path on the **currently adopted origin**, not on `devUrl` / port
-  1420.
-- Cold path: a stashed valid target is applied on the first
-  successful Workbench navigation and then cleared; a failed
-  bootstrap leaves the stash dropped and the window on bootstrap.
+  segment, bad id, complete `.` / `..` path id, authority, explicit
+  port) produces `None` and never includes the raw input in a UI
+  string. An id that merely contains a dot still maps.
+- Hot path: a valid link focuses the main window and requests
+  in-window navigation to the mapped path on the **currently adopted
+  origin**, not on `devUrl` / port 1420 — whether the link arrived as
+  second-instance argv **or** as a macOS native open-URL / GURL
+  Apple Event (raw string into the same parser/stash). An
+  implementation that only wires argv does not satisfy this.
+- Cold path: a stashed valid target (from argv **or** the first
+  macOS open-URL event) is applied on the first successful Workbench
+  navigation and then cleared; a failed bootstrap leaves the stash
+  dropped and the window on bootstrap.
 - Boundary: no new command appears in `src-tauri/build.rs`;
   `shell_boundaries.rs` still forbids `remote` grants. Deep-link
-  handling lives in the single-instance callback / argv path, which
-  is not WebView-callable.
+  handling lives in argv, the single-instance callback, and the
+  macOS native open-URL adapter — none of which are
+  WebView-callable. The adapter must feed the shared parser/stash;
+  it must not reintroduce a `Url::as_str()` path after Tao has
+  normalized the URL.
 - Capability: a Workbench origin (remote after navigation) still
   cannot invoke bootstrap commands after a deep link is consumed.
 

--- a/docs/plans/desktop-deep-links.md
+++ b/docs/plans/desktop-deep-links.md
@@ -41,8 +41,15 @@ or `avibe://<kind>`:
 
 `<session_id>` and `<request_id>` are the product's existing identifiers
 (Workbench session ids, vault request ids). They are accepted only when
-they match `^[A-Za-z0-9._-]+$` and are at most 128 bytes. Anything else
-is malformed.
+they match `^[A-Za-z0-9._-]+$`, are at most 128 bytes, and are **not**
+the complete path segments `.` or `..`. Ordinary dots inside an id
+(`ses.abc`) remain valid.
+
+Rejected complete `.` / `..` because WHATWG URL path normalization
+would turn `/chat/.` into `/chat/` and `/chat/..` into `/`, so the
+in-window navigation could not land on the mapped session route. Percent-
+encoded `%2E` / `%2E%2E` are not those segments and stay subject only
+to the character/length rule (they do not normalize as dot-segments).
 
 Rejected (no navigation, no quoted echo into the WebView):
 
@@ -126,8 +133,9 @@ are not the desktop OS and cannot route the scheme.
 
 - Parser: every row in the mapping table produces the exact
   Workbench path; every rejected shape (wrong scheme, extra
-  segment, bad id, authority) produces `None` and never includes the
-  raw input in a UI string.
+  segment, bad id, complete `.` / `..` path id, authority) produces
+  `None` and never includes the raw input in a UI string. An id that
+  merely contains a dot still maps.
 - Hot path: a second-instance argv containing a valid link focuses
   the main window and requests in-window navigation to the mapped
   path on the **currently adopted origin**, not on `devUrl` / port

--- a/docs/plans/desktop-deep-links.md
+++ b/docs/plans/desktop-deep-links.md
@@ -42,8 +42,10 @@ spelling (`avibe:session/...`); one form only.
 | `avibe://settings`                | `/admin/settings/service`                    |
 | `avibe://vaults/request/<request_id>` | `/vaults?request_id=<request_id>`        |
 
-Parse as a URL. Accept only when `scheme == avibe` and `host` is one of
-`session`, `show`, `settings`, `vaults`. Path/id rules:
+Parse as a URL. Accept only when `scheme == avibe`, `host` is one of
+`session`, `show`, `settings`, `vaults`, **and `port` is absent**
+(`avibe://session:443/<id>` is malformed even though `host_str()`
+would look allow-listed). Userinfo is rejected. Path/id rules:
 
 - `session` / `show`: path is exactly one segment, the id.
 - `settings`: path empty.

--- a/docs/plans/desktop-notifications-sse.md
+++ b/docs/plans/desktop-notifications-sse.md
@@ -117,9 +117,10 @@ A terminal `runs.updated` notifies only if **either**:
    shell first observed it, if it joined mid-flight) is ≥ 30 seconds;
    or
 2. the run was started in a way the product already treats as
-   background (Harness scheduled/watched runs: `run_type` in
-   `{task, watch}` — the existing `run_updated_payload` already
-   carries `run_type`). Interactive Workbench turns
+   background. Stored `run_type` values (from `core/scheduled_tasks.py` /
+   `core/watches.py`) are `scheduled` and `watch` — not the user-facing
+   definition kind `task`. Notify when `run_type` is in `{scheduled, watch}`.
+   Interactive Workbench turns
    (`run_type` absent or `agent_run` / session-bound chat) that
    finish in under 30 seconds never notify.
 

--- a/docs/plans/desktop-notifications-sse.md
+++ b/docs/plans/desktop-notifications-sse.md
@@ -1,0 +1,255 @@
+# Desktop notifications over Workbench SSE
+
+## Status
+
+Frozen implementation contract for gap G4. Companion to
+`desktop-product-gaps.md` (G4) and `desktop-start-receipt.md` (ownership of
+the Runtime is already settled; this contract does not reopen it).
+
+Owner: Avibe core
+Date: 2026-09-10
+Baseline: `desktop` branch after #1975 / #1977 (tray + start-receipt).
+
+## Product outcome
+
+When the Avibe window is unfocused or closed (tray still alive), the user
+gets a native OS notification for the two classes of event that actually
+need them to look:
+
+1. A Vault request that is waiting on them (`approval.requested`).
+2. A background agent run that has reached a terminal state
+   (`run.terminal`), only if the run was clearly backgrounded or ran
+   longer than ~30 seconds.
+
+Default on. The tray has a checkable "Notifications" item that persists
+the preference. System Focus / Do Not Disturb is left to the OS; Avibe
+does not reimplement it.
+
+Clicking a notification focuses the Avibe window. Deep-link navigation
+into a specific session (`avibe://session/<id>`) is G5 and is **not**
+in this slice — the click is "come back to Avibe", not "open this row".
+
+## Why SSE, not polling
+
+The shell already probes `GET /ready` every two seconds after navigation;
+that loop is the liveness signal ("is the Runtime still there?").
+Attention ("something needs you") is a different job. Polling it off
+`/ready` would:
+
+- bound notification latency to the probe period (bad for blocking
+  Vault approvals);
+- tax a tray-resident Agent OS with permanent empty-cycle HTTP;
+- fork the product's event model: Workbench already consumes SSE,
+  desktop notifications would pull.
+
+v1 therefore **reuses the existing event source** (`GET /api/events`)
+and leaves `/ready` as liveness-only.
+
+## Frozen transport
+
+### Endpoint
+
+`GET {origin}/api/events` on the adopted Runtime origin (the same
+loopback origin the shell already validated and navigated to).
+
+No new HTTP route. The Workbench EventSource client at
+`ui/src/context/ApiContext.tsx` already opens this path with no extra
+auth on loopback; the shell does the same. Adding a cookie or token
+requirement to `/api/events` is a breaking change for both clients and
+is out of scope.
+
+SSE framing already in production (`vibe/ui_server.py::workbench_events`):
+
+- handshake: `: stream connected` comment, then `event: connected`;
+- 15-second keep-alive comment (`: ping`) so proxies do not idle-kill;
+- each application event: `event: <type>` + `data: <json>` where the
+  JSON is `{"type": <type>, "data": <payload>}` (see `sse_broker.py`).
+
+The shell parses this framing; it does not invent a second protocol.
+
+### Connection ownership
+
+The **shell** owns the SSE connection, not the WebView.
+
+- Opened once the Runtime is adopted/started and `/ready` has succeeded.
+- Survives window close (the tray is the user's handle on a living
+  Runtime; notifications must still arrive).
+- Torn down when the shell gives up on the Runtime: three consecutive
+  `/ready` failures (existing bootstrap recovery), explicit Stop of an
+  owned Runtime, Uninstall, or Quit-and-stop. Adopted Runtimes that
+  outlive the shell keep running; the SSE dies with the shell, which
+  is the same visibility the user already accepted by quitting.
+- Reconnect with bounded backoff on stream drop, independently of the
+  `/ready` probe. A reconnect does not replay history (the broker has
+  no replay); the shell must tolerate missed events. Vault pending
+  state is recoverable on click by opening the Workbench.
+
+`/ready` probing and the SSE are two loops with one shared origin.
+Neither substitutes for the other: a live SSE with a failing `/ready`
+still triggers bootstrap recovery; a live `/ready` with a down SSE
+retries the stream and does not take the window back to bootstrap.
+
+### Filtering, not a second bus
+
+The broker is a global fan-out. The shell **subscribes to the existing
+stream and filters**. It does not ask Python for a dedicated attention
+channel in v1. Adding `GET /api/desktop/attention` would be a contract
+v2 if the filter ever becomes a product-logic burden the shell should
+not carry.
+
+v1 filter (exact event type strings, already published):
+
+| SSE `event`        | Payload fields used                         | Notification class    | When it fires                          |
+| ------------------ | ------------------------------------------- | --------------------- | -------------------------------------- |
+| `vaults.updated`   | `request_id`, `request_status`              | `approval.requested`  | `request_status == "pending"` and `request_id` present |
+| `runs.updated`     | `run_id`, `status`, `session_id`, `run_type`| `run.terminal`        | `status` in `{succeeded, failed, canceled}` AND the run is "background" (see below) |
+
+Every other event (`message.new`, `session.activity`, `queue.updated`,
+`inbox.unread.changed`, `show.event`, keep-alives, unknown types) is
+ignored by the notification path. The filter is an allow-list: a new
+event type never becomes a notification by accident.
+
+### "Background" for `run.terminal`
+
+A terminal `runs.updated` notifies only if **either**:
+
+1. the run's wall time since it first went `running` (or since the
+   shell first observed it, if it joined mid-flight) is ≥ 30 seconds;
+   or
+2. the run was started in a way the product already treats as
+   background (Harness scheduled/watched runs: `run_type` in
+   `{task, watch}` — the existing `run_updated_payload` already
+   carries `run_type`). Interactive Workbench turns
+   (`run_type` absent or `agent_run` / session-bound chat) that
+   finish in under 30 seconds never notify.
+
+The 30-second threshold is measured by the shell from SSE
+observations, not by Python. Python does not grow a
+"please notify" flag in v1.
+
+### Dedup
+
+- `approval.requested`: key = `request_id`. The same pending request
+  is never notified twice per shell lifetime. Status transitions away
+  from `pending` drop the key so a later re-open can notify again.
+- `run.terminal`: key = `run_id`. Terminal is once.
+
+A notification is suppressed (not queued) when:
+
+- the Avibe window is focused and visible; or
+- the tray "Notifications" item is unchecked.
+
+System DND / Focus is the OS's problem.
+
+## Frozen presentation
+
+### Copy lives in the shell, keyed by class + locale
+
+Existing SSE payloads are refetch hints (`run_id` / `request_id`), not
+finished user copy. The shell therefore owns notification title/body,
+using the same locale catalog pattern as the tray (`sys-locale` →
+`desktopBootstrap` keys in `ui/src/i18n/{en,zh}.json`, verified by
+`npm run test:i18n`).
+
+v1 keys (names frozen; wording is i18n content, not contract):
+
+- `desktopBootstrap.notifications.approvalRequested.title`
+- `desktopBootstrap.notifications.approvalRequested.body`
+- `desktopBootstrap.notifications.runSucceeded.title`
+- `desktopBootstrap.notifications.runSucceeded.body`
+- `desktopBootstrap.notifications.runFailed.title`
+- `desktopBootstrap.notifications.runFailed.body`
+- `desktopBootstrap.notifications.runCanceled.title`
+- `desktopBootstrap.notifications.runCanceled.body`
+- `desktopBootstrap.notifications.toggle` (tray menu label)
+
+Bodies may include the `session_id` / `run_id` as a short suffix when
+present; they must not interpolate unsanitized Runtime strings into
+the OS notification (the payload is untrusted process output on its
+way to a privileged surface, same rule as refused origins).
+
+### Plugin and permission
+
+`tauri-plugin-notification` on the shell. Permission prompts are the
+OS's (macOS notification permission on first fire). The plugin is
+invoked from Rust, never from the WebView.
+
+**No new IPC command, no capability widening.** Notifications are
+shell-privileged the same way the tray is: the Workbench page cannot
+trigger them. `shell_boundaries.rs` gains an assertion that the
+notification path does not grant any `remote` capability.
+
+### Click
+
+Click = `show` + `unminimize` + `set_focus` on the main window.
+No Workbench navigation in v1 (that is G5). If the window was hidden
+to tray, this is the same path as the tray "Open Avibe" item.
+
+## Frozen architecture split
+
+```
+Python Runtime                         Shell (Rust)
+──────────────                         ────────────
+SSEBroker ──GET /api/events──►         attention filter
+  vaults.updated                       (allow-list)
+  runs.updated                         + 30s / run_type rule
+  (everything else ignored)            + dedup
+                                       + focus/pref gate
+                                       └── tauri-plugin-notification
+/ready probe (existing, 2s)  liveness only, never attention
+```
+
+Python changes in v1: **none**, unless a test needs a fixture event.
+The two event types already flow to `/api/events` today
+(`publish_run_updated` / `_publish_vaults_updated`).
+
+Rust changes live in `desktop/runtime-host` (filter, dedup, reconnect
+— Tauri-free, testable) and a thin `src-tauri` adapter that fires the
+plugin and reads window-focus / tray-pref state.
+
+## Tests (invariants, not enumerations)
+
+- Filter allow-list: given a stream that mixes ignored types with one
+  `vaults.updated {request_status: pending, request_id}` and one
+  terminal `runs.updated`, only those two classes produce a
+  notification intent. A newly invented event type in the same
+  fixture must not.
+- Dedup: two identical `request_id` pendings → one intent; a
+  non-pending transition then a new pending with the same id → a
+  second intent.
+- Background rule: a `runs.updated` that reaches `succeeded` in under
+  30s with no `run_type` of `{task, watch}` produces no intent; the
+  same run after 30s, or with `run_type=task`, does.
+- Focus gate: window focused + visible → no intent even on a matching
+  event.
+- Reconnect: stream drop then restore does not panic, does not
+  replay, does not take bootstrap recovery by itself.
+- Boundary: `shell_boundaries` still forbids remote capabilities;
+  notification code is not reachable from a navigated Workbench page.
+- i18n: the new keys exist in both catalogs with matching
+  placeholders (`npm run test:i18n`).
+
+Drive the filter with a fake SSE collaborator under tokio's virtual
+clock (same pattern as `runtime-host/tests/bootstrap.rs`) so the 30s
+threshold is exercised in microseconds.
+
+## Explicit non-goals (v1)
+
+- A new HTTP route or a Python "please notify" flag.
+- Deep-link click targets (G5).
+- Notifying on every chat message, every `session.activity`, or
+  foreground turns that finish quickly.
+- Replaying missed events after reconnect.
+- Changing `/api/events` auth.
+- Windows-vs-macOS copy differences beyond the shared catalog.
+
+## Sequencing
+
+Depends on the tray (#1975, merged): the Notifications toggle lives
+on the same menu as "Start at Login", and window-hidden-to-tray is
+the state in which notifications matter.
+
+Does not depend on G1 signing or G2 auto-update.
+
+Does not block G5; G5 should reuse the same notification click
+once deep links exist (swap `show window` for `show + navigate`).

--- a/docs/plans/desktop-notifications-sse.md
+++ b/docs/plans/desktop-notifications-sse.md
@@ -113,8 +113,15 @@ event type never becomes a notification by accident.
 
 A terminal `runs.updated` notifies only if **either**:
 
-1. the run's wall time since it first went `running` (or since the
-   shell first observed it, if it joined mid-flight) is ≥ 30 seconds;
+1. the run's wall time since it **started** is ≥ 30 seconds. The
+   clock is the run's durable `started_at`, not "when this shell first
+   saw a `running` event" — the broker has no replay, so attaching
+   mid-flight or reconnecting can miss that transition. Terminal
+   `runs.updated` events therefore include `started_at` (ISO-8601). If
+   a terminal event omits it, the shell refetches `GET /api/harness/runs/<run_id>`
+   once and reads `started_at` there before applying the threshold.
+   A missing timestamp after refetch fails closed (no notify) rather
+   than treating "first seen at terminal" as zero duration.
    or
 2. the run was started in a way the product already treats as
    background. Stored `run_type` values (from `core/scheduled_tasks.py` /
@@ -200,9 +207,11 @@ SSEBroker ──GET /api/events──►         attention filter
 /ready probe (existing, 2s)  liveness only, never attention
 ```
 
-Python changes in v1: **none**, unless a test needs a fixture event.
-The two event types already flow to `/api/events` today
-(`publish_run_updated` / `_publish_vaults_updated`).
+Python changes in v1: include `started_at` on terminal `runs.updated`
+payloads (`run_updated_payload` / `publish_run_updated`). The two
+event types already flow to `/api/events`; this is an additive field
+on an existing payload, not a new route. Interactive Workbench refetch
+consumers ignore unknown fields.
 
 Rust changes live in `desktop/runtime-host` (filter, dedup, reconnect
 — Tauri-free, testable) and a thin `src-tauri` adapter that fires the
@@ -221,6 +230,10 @@ plugin and reads window-focus / tray-pref state.
 - Background rule: a `runs.updated` that reaches `succeeded` in under
   30s with no `run_type` of `{scheduled, watch}` produces no intent;
   the same run after 30s, or with `run_type=scheduled`, does.
+  Mid-flight attach: a terminal event for an interactive run whose
+  `started_at` is ≥ 30s in the past produces an intent even if the
+  shell never saw `running`; a terminal event with no `started_at` and
+  a refetch that also lacks it produces none.
 - Focus gate: window focused + visible → no intent even on a matching
   event.
 - Reconnect: stream drop then restore does not panic, does not

--- a/docs/plans/desktop-notifications-sse.md
+++ b/docs/plans/desktop-notifications-sse.md
@@ -143,7 +143,12 @@ Python does not grow a "please notify" flag or a `visibility` field in v1.
 - `approval.requested`: key = `request_id`. The same pending request
   is never notified twice per shell lifetime. Status transitions away
   from `pending` drop the key so a later re-open can notify again.
-- `run.terminal`: key = `run_id`. Terminal is once.
+- `run.terminal`: key = `run_id`. Terminal is once per key while the
+  key is retained. Retention is **bounded** (LRU or TTL, frozen
+  default: 512 entries or 24 hours, whichever hits first). The bound
+  only needs to cover repeated terminal publications of the same run
+  (SSE bursts / reconnect duplicates), not process lifetime. A
+  tray-resident shell must not grow this set without bound.
 
 A notification is suppressed (not queued) when:
 

--- a/docs/plans/desktop-notifications-sse.md
+++ b/docs/plans/desktop-notifications-sse.md
@@ -120,29 +120,34 @@ rule only. v1 does not add `visibility` to the SSE payload.
 
 A terminal `runs.updated` notifies if **either**:
 
-1. the run's wall time since it **started** is ≥ 30 seconds. The
-   clock is the run's durable `started_at`, not "when this shell first
-   saw a `running` event" — the broker has no replay, so attaching
-   mid-flight or reconnecting can miss that transition. Terminal
-   `runs.updated` events therefore include `started_at` (ISO-8601). If
-   a terminal event omits it, the shell refetches `GET /api/harness/runs/<run_id>`
-   once and reads `started_at` there before applying the threshold.
-   A missing timestamp after refetch fails closed (no notify) rather
-   than treating "first seen at terminal" as zero duration.
+1. **Duration ≥ 30s**, measured as
+   `completed_at − started_at` (both durable, ISO-8601 on the
+   terminal event). `completed_at` is the event's `completed_at` if
+   present, otherwise the terminal `updated_at`. Never "receipt time
+   minus started_at" — a two-second run delivered a minute later
+   (sleep, stall, reconnect) must not cross the threshold. If the
+   terminal event omits `started_at` or the completion timestamp, the
+   shell refetches `GET /api/harness/runs/<run_id>` once. Still
+   missing either stamp → fail closed (no notify).
    or
-2. the run was started in a way the product already treats as
-   background. Stored `run_type` values (from `core/scheduled_tasks.py` /
-   `core/watches.py`) are `scheduled` and `watch` — not the user-facing
-   definition kind `task`. Notify when `run_type` is in `{scheduled, watch}` even under 30s.
+2. **`run_type` ∈ `{scheduled, watch}`** even under 30s (stored
+   values from `core/scheduled_tasks.py` / `core/watches.py`; `task`
+   is a definition kind, not a run_type).
 
-The duration clock is durable `started_at`, not SSE observation time.
-Python does not grow a "please notify" flag or a `visibility` field in v1.
+Python adds `started_at` and `completed_at` (or always-populated
+terminal `updated_at`) on terminal `runs.updated`. No "please
+notify" flag, no `visibility` field in v1.
 
 ### Dedup
 
-- `approval.requested`: key = `request_id`. The same pending request
-  is never notified twice per shell lifetime. Status transitions away
-  from `pending` drop the key so a later re-open can notify again.
+- `approval.requested`: key = `request_id`. Same pending request is
+  never notified twice **while the key is retained**. Non-pending
+  transitions drop the key when observed. Because the broker has no
+  replay, a reconnect can miss that transition — so this set is
+  **bounded the same way as run keys** (LRU or TTL; default 512 or
+  24h). Do not rely on seeing a later status to bound memory. A
+  dropped key may notify again if the same request is still pending;
+  that is acceptable (at-least-once), not a leak.
 - `run.terminal`: key = `run_id`. Terminal is once per key while the
   key is retained. Retention is **bounded** (LRU or TTL, frozen
   default: 512 entries or 24 hours, whichever hits first). The bound
@@ -215,11 +220,11 @@ SSEBroker ──GET /api/events──►         attention filter
 /ready probe (existing, 2s)  liveness only, never attention
 ```
 
-Python changes in v1: include `started_at` on terminal `runs.updated`
-payloads (`run_updated_payload` / `publish_run_updated`). The two
-event types already flow to `/api/events`; this is an additive field
-on an existing payload, not a new route. Interactive Workbench refetch
-consumers ignore unknown fields.
+Python changes in v1: include `started_at` and `completed_at` (or
+guarantee terminal `updated_at`) on terminal `runs.updated` payloads
+(`run_updated_payload` / `publish_run_updated`). Additive fields on
+the existing payload, not a new route. Workbench refetch consumers
+ignore unknown fields.
 
 Rust changes live in `desktop/runtime-host` (filter, dedup, reconnect
 — Tauri-free, testable) and a thin `src-tauri` adapter that fires the
@@ -235,13 +240,15 @@ plugin and reads window-focus / tray-pref state.
 - Dedup: two identical `request_id` pendings → one intent; a
   non-pending transition then a new pending with the same id → a
   second intent.
-- Background rule (property): a short `agent_run` / missing `run_type`
-  with `started_at` < 30s → no intent; the same row with `started_at`
-  ≥ 30s → intent; `run_type=scheduled` (or `watch`) → intent even
-  when < 30s. Mid-flight attach uses `started_at`, not first-seen.
-  Terminal event without `started_at` and a refetch that also lacks
-  it → no intent. Adding a new run_type to the fixture must not
-  notify unless it is `scheduled`/`watch` or the duration rule hits.
+- Duration property: `completed_at − started_at` (or terminal
+  `updated_at − started_at`) ≥ 30s → intent for a non-scheduled run;
+  a 2s run whose event arrives 60s later does **not**. Missing either
+  stamp after one refetch → no intent. `run_type=scheduled`/`watch`
+  → intent even under 30s. A new run_type in the fixture must not
+  notify unless it is those two or the duration property hits.
+- Dedup bound: both approval and run key sets stay within 512
+  entries / 24h; inserting past the bound drops the oldest, and a
+  later duplicate of a dropped key may notify again.
 - Focus gate: window focused + visible → no intent even on a matching
   event.
 - Reconnect: stream drop then restore does not panic, does not

--- a/docs/plans/desktop-notifications-sse.md
+++ b/docs/plans/desktop-notifications-sse.md
@@ -111,7 +111,14 @@ event type never becomes a notification by accident.
 
 ### "Background" for `run.terminal`
 
-A terminal `runs.updated` notifies only if **either**:
+A terminal `runs.updated` notifies iff **at least one** of the two
+properties below holds. This is not an allow-list of product verbs
+and is not extended in v1 (a new always-background kind is a contract
+revision). `run_type=agent_run` — including default async
+`vibe agent run` — is not a special case: it follows the duration
+rule only. v1 does not add `visibility` to the SSE payload.
+
+A terminal `runs.updated` notifies if **either**:
 
 1. the run's wall time since it **started** is ≥ 30 seconds. The
    clock is the run's durable `started_at`, not "when this shell first
@@ -126,14 +133,10 @@ A terminal `runs.updated` notifies only if **either**:
 2. the run was started in a way the product already treats as
    background. Stored `run_type` values (from `core/scheduled_tasks.py` /
    `core/watches.py`) are `scheduled` and `watch` — not the user-facing
-   definition kind `task`. Notify when `run_type` is in `{scheduled, watch}`.
-   Interactive Workbench turns
-   (`run_type` absent or `agent_run` / session-bound chat) that
-   finish in under 30 seconds never notify.
+   definition kind `task`. Notify when `run_type` is in `{scheduled, watch}` even under 30s.
 
-The 30-second threshold is measured by the shell from SSE
-observations, not by Python. Python does not grow a
-"please notify" flag in v1.
+The duration clock is durable `started_at`, not SSE observation time.
+Python does not grow a "please notify" flag or a `visibility` field in v1.
 
 ### Dedup
 
@@ -227,13 +230,13 @@ plugin and reads window-focus / tray-pref state.
 - Dedup: two identical `request_id` pendings → one intent; a
   non-pending transition then a new pending with the same id → a
   second intent.
-- Background rule: a `runs.updated` that reaches `succeeded` in under
-  30s with no `run_type` of `{scheduled, watch}` produces no intent;
-  the same run after 30s, or with `run_type=scheduled`, does.
-  Mid-flight attach: a terminal event for an interactive run whose
-  `started_at` is ≥ 30s in the past produces an intent even if the
-  shell never saw `running`; a terminal event with no `started_at` and
-  a refetch that also lacks it produces none.
+- Background rule (property): a short `agent_run` / missing `run_type`
+  with `started_at` < 30s → no intent; the same row with `started_at`
+  ≥ 30s → intent; `run_type=scheduled` (or `watch`) → intent even
+  when < 30s. Mid-flight attach uses `started_at`, not first-seen.
+  Terminal event without `started_at` and a refetch that also lacks
+  it → no intent. Adding a new run_type to the fixture must not
+  notify unless it is `scheduled`/`watch` or the duration rule hits.
 - Focus gate: window focused + visible → no intent even on a matching
   event.
 - Reconnect: stream drop then restore does not panic, does not

--- a/docs/plans/desktop-notifications-sse.md
+++ b/docs/plans/desktop-notifications-sse.md
@@ -219,8 +219,8 @@ plugin and reads window-focus / tray-pref state.
   non-pending transition then a new pending with the same id → a
   second intent.
 - Background rule: a `runs.updated` that reaches `succeeded` in under
-  30s with no `run_type` of `{task, watch}` produces no intent; the
-  same run after 30s, or with `run_type=task`, does.
+  30s with no `run_type` of `{scheduled, watch}` produces no intent;
+  the same run after 30s, or with `run_type=scheduled`, does.
 - Focus gate: window focused + visible → no intent even on a matching
   event.
 - Reconnect: stream drop then restore does not panic, does not

--- a/docs/plans/desktop-product-gaps.md
+++ b/docs/plans/desktop-product-gaps.md
@@ -1,0 +1,206 @@
+# Desktop Product Gaps
+
+## Status
+
+- Owner: Avibe core
+- Date: 2026-09-10
+- Baseline: `desktop` branch @ `b2ed55f11` (post master-sync 2026-08-11)
+- Scope: what the desktop product still lacks to read as a first-class desktop
+  application, not a windowed browser. The shell engineering base (loopback
+  adoption, capability boundary, private Runtime, lazy backends) is sound and
+  is **not** re-litigated here.
+- Companion docs: `tauri-desktop-vertical-slice.md` (original slice),
+  `desktop-backend-lazy-install.md` (frozen backend-install contract),
+  `desktop-notifications-sse.md` (G4), `desktop-deep-links.md` (G5),
+  `desktop-window-state.md` (G6)
+
+## Baseline: what already exists
+
+A Tauri v2 thin shell (window + bootstrap screen) that adopts or starts one
+local Avibe Runtime, hands the window to the Workbench, and verifies integrity
+of the installed private Runtime on every launch. Self-contained packages
+embed CPython, the Avibe wheel, locked Python dependencies, Node, and npm.
+CI produces unsigned acceptance artifacts for macOS arm/x64 and Windows x64.
+
+What the baseline deliberately does **not** have: any distribution signing,
+auto-update, tray, notifications, deep links, multi-window, or persisted
+window state. That is the gap list below.
+
+## P0 — distribution and trust (the release gate)
+
+### G1. Code signing and notarization
+
+- Problem: unsigned artifacts are stopped by Gatekeeper (macOS) and flagged by
+  SmartScreen (Windows). There is currently no way to ship to a real user.
+- Work: introduce a `desktop-package-sign.yml`-style manual workflow or extend
+  `desktop-package.yml`: macOS Developer ID signing + notarytool notarization +
+  stapling; Windows EV/OV certificate signing of the NSIS installer. Secrets
+  via GitHub Environments; artifacts published as Draft releases only.
+- Acceptance: a DMG and an NSIS installer, both signed, open on a clean
+  machine with no security warning and no right-click override.
+- Estimate: M. The Rust/Tauri side is configuration; the cost is certificate
+  procurement and Apple/Windows account plumbing.
+- Risk: certificate processes (Apple Developer ID, EV certs) have lead time;
+  start procurement first.
+
+### G2. Auto-update
+
+- Problem: today an update means "download and replace the app". No security
+  fix can reach an installed base.
+- Work: integrate `tauri-plugin-updater` against a JSON endpoint (GitHub
+  Releases draft flow or a dedicated channel). Decide the signing story for
+  update artifacts (updater signature key, independent of G1 codesigning).
+  Respect the version identity already stamped by `desktop-package.yml` input.
+  The private Runtime install path is already content-addressed and versioned,
+  so app replacement composes with it by design.
+- Acceptance: an installed app detects a newer published artifact, downloads,
+  verifies, and applies it; user state (`~/.avibe`) and private Runtime slots
+  survive; rollback path is the previous app bundle reinstalling its payload.
+- Estimate: M. Endpoint + key management + first signed release is the bulk.
+- Depends: G1 (signed artifacts worth updating to).
+
+### G3. Tray / Runtime lifecycle visibility
+
+- Problem: the Runtime outlives the window by design, but the user has no
+  visible handle on that. A closed window with a running process reads as a
+  bug or a privacy concern; Activity Monitor is the only exit.
+- Work: menu-bar tray (macOS) / notification-area icon (Windows) showing
+  Runtime state (adopted/private, version, port), a "quit Runtime" action with
+  confirmation, and an explicit quit semantics decision: quit-app vs
+  quit-runtime, surfaced both in the tray and the first application menu.
+  Align with the existing Uninstall flow, which already stops a private
+  Runtime it owns.
+- Acceptance: with the window closed, the tray shows live Runtime state; the
+  user can stop the Runtime from the tray without opening a terminal; quitting
+  the app never silently kills an adopted Runtime.
+- Estimate: M. New tray plugin + state bridge; the Runtime already exposes
+  `/ready` and status commands to poll.
+- Note: this is the visible half of a decision the architecture already made;
+  it converts a silent behavior into a product statement.
+
+## P1 — system integration (the native feel)
+
+### G4. Desktop notifications
+
+- Problem: task completion, approval requests, and errors are the core
+  feedback loop of an agent OS and are invisible when the window is not
+  focused (which is most of the time for long-running work).
+- Work: frozen in `desktop-notifications-sse.md`. The shell owns an SSE
+  connection to the existing `GET /api/events` (not a new route, not polling
+  `/ready`); filters an allow-list (`vaults.updated` pending →
+  `approval.requested`; terminal `runs.updated` that ran ≥30s or has
+  `run_type` in `{task, watch}` → `run.terminal`); fires
+  `tauri-plugin-notification`. Connection survives window-close-to-tray.
+  Default on, tray toggle, OS DND untouched. Click focuses the window (deep
+  links are G5).
+- Acceptance: with the window unfocused or hidden to tray, a pending Vault
+  request and a long/background run completion each produce one native
+  notification; duplicates of the same `request_id`/`run_id` do not; a
+  focused visible window produces none; toggling the tray item off produces
+  none. No new IPC / no remote capability.
+- Estimate: M. Event source exists; the work is the shell-owned stream,
+  filter/dedup, reconnect, and the plugin/permission prompt.
+- Depends: tray (#1975, merged). Does not depend on G1/G2.
+
+### G5. Deep links (`avibe://`)
+
+- Problem: no path back into a specific session, Show Page, or approval from
+  outside the app (IM messages, emails, notifications). The Workbench is only
+  reachable as a single entry URL.
+- Work: frozen in `desktop-deep-links.md`. Scheme `avibe`, four kinds
+  (`session`, `show`, `settings`, `vaults/request`) mapping onto existing
+  Workbench routes. Hot path extends the existing single-instance callback;
+  cold path stashes the target until bootstrap navigates. Delivery is
+  same-origin in-window navigation — no new IPC, no capability widening.
+  Malformed links are dropped and never quoted into the WebView. IM/https
+  producers are not switched in v1.
+- Acceptance: `avibe://session/<id>` focuses the running app and opens that
+  chat; a cold start finishes bootstrap then lands on it; unknown or
+  malformed URLs do nothing visible in the Workbench. Click-on-notification
+  locating is a G4 follow-up, not this slice.
+- Estimate: M. Parser + stash/apply + scheme registration; security review
+  of untrusted argv.
+- Independent of G1/G6. G8 may later reinterpret `show` as a torn-out
+  window; the grammar stays.
+
+### G6. Window state persistence
+
+- Problem: the window always opens 1200×800 centered. Every desktop user
+  notices within a week.
+- Work: frozen in `desktop-window-state.md`. `tauri-plugin-window-state`
+  on the native frame (`x/y/width/height/maximized` per window label).
+  Full-screen/Spaces are not restored. Off-screen frames clamp so the
+  title bar is visible and size ≥ 880×600. Bootstrap and Runtime
+  navigation must not reset the restored frame.
+- Acceptance: move and resize, quit, relaunch → same frame; unplug the
+  display the window was on → window still visible, not smaller than
+  minimum. Hide-to-tray then Open restores the last shown frame.
+- Estimate: S.
+- No dependencies. Do this before G8 so new windows inherit the store.
+
+### G7. Launch at login (optional, off by default)
+
+- **Shipped** in #1975 (tray checkable "Start at Login", default off).
+  Remaining work is real-OS verification on a signed build, not a new
+  feature.
+
+## P2 — polish and reach
+
+### G8. Multi-window — deferred
+
+- **Decision (2026-09-10):** do not implement native multi-window. Keep the
+  current single-WebView shell wrapping the Workbench SPA. Session switching,
+  Show Pages, and Settings stay in-SPA.
+- Why: every frozen v1 contract (tray, start-receipt, G4 SSE, G5 deep
+  links, G6 window state) already holds at N=1. Native multi-window is not
+  "browser tabs"; it requires a singleton-Runtime + multi-WebView
+  lifecycle (only the main window bootstraps; extra windows are remote
+  from frame one and must never gain bootstrap IPC; closing them must not
+  stop the Runtime). That lifecycle is unverifiable without a second
+  window, so it ships in the same slice as the first extra window — not
+  ahead of it.
+- Trigger to reopen: a demonstrated need to pin a Show Page on another
+  display. First slice then is "settings window + torn-out Show Page",
+  not per-session windows. Until that trigger, Workbench split-pane (web
+  + desktop) is the cheaper way to sit two sessions side by side.
+- Estimate when reopened: M–L, lifecycle invariants + two window kinds.
+
+### G9. macOS Universal Binary
+
+- One DMG for both architectures instead of two (lipo the app binaries;
+  runtime payloads are per-arch and can stay separate resources or be
+  universal-merged).
+- Estimate: S–M, mostly packaging automation. Low priority while dual-DMG
+  works.
+
+### G10. Accessibility and shortcuts
+
+- Keyboard access to the full Workbench under WKWebView/WebView2, global
+  hotkey to summon the window, standard cut/copy/paste menu wiring on macOS.
+- Estimate: M, spread thin. Audit first, fix by surface.
+
+### G11. Diagnostics surface
+
+- `vibe doctor` and logs exist; the desktop has no "open logs / run
+  diagnostics" affordance in-app. Pairs naturally with the tray menu (G3).
+- Estimate: S once G3 lands.
+
+## Explicit non-goals for this phase
+
+- Mobile (per the original slice doc).
+- Auto-updating agent backends from the app (frozen contract in
+  `desktop-backend-lazy-install.md` keeps backends independent).
+- Rewriting Workbench behavior for desktop: everything above is shell-layer
+  and composes with the replaceable-shell constraint.
+
+## Suggested sequencing
+
+1. G1 signing (start certificate procurement immediately — longest lead time)
+2. G3 tray + lifecycle (product meaning of the architecture, no dependencies)
+3. G2 auto-update (needs G1; ship together with the first signed release)
+4. G6 + G4 + G7 (small system-integration wins, parallelizable)
+5. G5 deep links, then P2 items by demand
+
+The deliberate observation from the review: every gap is shell-layer. The
+thin-shell bet held — the missing work is breadth on one boundary, not
+rework under it.

--- a/docs/plans/desktop-product-gaps.md
+++ b/docs/plans/desktop-product-gaps.md
@@ -89,7 +89,7 @@ window state. That is the gap list below.
   connection to the existing `GET /api/events` (not a new route, not polling
   `/ready`); filters an allow-list (`vaults.updated` pending →
   `approval.requested`; terminal `runs.updated` that ran ≥30s or has
-  `run_type` in `{task, watch}` → `run.terminal`); fires
+  `run_type` in `{scheduled, watch}` → `run.terminal`); fires
   `tauri-plugin-notification`. Connection survives window-close-to-tray.
   Default on, tray toggle, OS DND untouched. Click focuses the window (deep
   links are G5).

--- a/docs/plans/desktop-product-gaps.md
+++ b/docs/plans/desktop-product-gaps.md
@@ -4,7 +4,9 @@
 
 - Owner: Avibe core
 - Date: 2026-09-10
-- Baseline: `desktop` branch @ `b2ed55f11` (post master-sync 2026-08-11)
+- Baseline: `desktop` branch after #1975 / #1977 / #1971 / #1972
+  (tray + start-receipt + notarization preflight; local docs head
+  tracks origin/desktop @ `937d23e35` plus this planning slice)
 - Scope: what the desktop product still lacks to read as a first-class desktop
   application, not a windowed browser. The shell engineering base (loopback
   adoption, capability boundary, private Runtime, lazy backends) is sound and
@@ -22,9 +24,10 @@ of the installed private Runtime on every launch. Self-contained packages
 embed CPython, the Avibe wheel, locked Python dependencies, Node, and npm.
 CI produces unsigned acceptance artifacts for macOS arm/x64 and Windows x64.
 
-What the baseline deliberately does **not** have: any distribution signing,
-auto-update, tray, notifications, deep links, multi-window, or persisted
-window state. That is the gap list below.
+What the baseline deliberately does **not** have: production distribution
+signing (G1 remaining layers), auto-update, notifications, deep links,
+native multi-window, or persisted window state. Tray / Runtime lifecycle
+visibility and launch-at-login **shipped** in #1975.
 
 ## P0 — distribution and trust (the release gate)
 
@@ -61,22 +64,10 @@ window state. That is the gap list below.
 
 ### G3. Tray / Runtime lifecycle visibility
 
-- Problem: the Runtime outlives the window by design, but the user has no
-  visible handle on that. A closed window with a running process reads as a
-  bug or a privacy concern; Activity Monitor is the only exit.
-- Work: menu-bar tray (macOS) / notification-area icon (Windows) showing
-  Runtime state (adopted/private, version, port), a "quit Runtime" action with
-  confirmation, and an explicit quit semantics decision: quit-app vs
-  quit-runtime, surfaced both in the tray and the first application menu.
-  Align with the existing Uninstall flow, which already stops a private
-  Runtime it owns.
-- Acceptance: with the window closed, the tray shows live Runtime state; the
-  user can stop the Runtime from the tray without opening a terminal; quitting
-  the app never silently kills an adopted Runtime.
-- Estimate: M. New tray plugin + state bridge; the Runtime already exposes
-  `/ready` and status commands to poll.
-- Note: this is the visible half of a decision the architecture already made;
-  it converts a silent behavior into a product statement.
+- **Shipped** in #1975 (`install_native_tray`: live Runtime state, Open /
+  Stop / Quit with receipt-gated stop, Start at Login default off).
+  Remaining work is real-OS verification on a signed build, not a new
+  feature. G4's Notifications toggle lands on this same menu.
 
 ## P1 — system integration (the native feel)
 
@@ -183,7 +174,7 @@ window state. That is the gap list below.
 
 - `vibe doctor` and logs exist; the desktop has no "open logs / run
   diagnostics" affordance in-app. Pairs naturally with the tray menu (G3).
-- Estimate: S once G3 lands.
+- Estimate: S (tray menu already exists).
 
 ## Explicit non-goals for this phase
 
@@ -195,11 +186,11 @@ window state. That is the gap list below.
 
 ## Suggested sequencing
 
-1. G1 signing (start certificate procurement immediately — longest lead time)
-2. G3 tray + lifecycle (product meaning of the architecture, no dependencies)
-3. G2 auto-update (needs G1; ship together with the first signed release)
-4. G6 + G4 + G7 (small system-integration wins, parallelizable)
-5. G5 deep links, then P2 items by demand
+1. G1 remaining signing layers + certificate procurement (longest lead)
+2. G2 auto-update (needs G1; ship with the first signed release)
+3. G6 window state + G5 deep links (in flight; no G1 dependency)
+4. G4 notifications (depends on shipped tray)
+5. P2 items by demand; G8 stays deferred until a Show Page needs another display
 
 The deliberate observation from the review: every gap is shell-layer. The
 thin-shell bet held — the missing work is breadth on one boundary, not

--- a/docs/plans/desktop-window-state.md
+++ b/docs/plans/desktop-window-state.md
@@ -52,8 +52,10 @@ launch, frozen:
    does not).
 3. On successful `/ready`, navigate the WebView to the Runtime
    origin (content changes; frame does not).
-4. User moves/resizes: plugin debounces writes to the app config
-   directory.
+4. User moves/resizes: the shell debounces calls to the plugin's
+   existing `save_window_state` (the plugin writes on demand / on
+   close, it does not debounce to disk by itself). Do not introduce a
+   second store. Debounce is a shell-side timer around that API.
 
 Closing to tray and re-showing ("Open Avibe") must restore the
 **last shown frame**, not re-center. Quit and relaunch reads the

--- a/docs/plans/desktop-window-state.md
+++ b/docs/plans/desktop-window-state.md
@@ -1,0 +1,109 @@
+# Desktop window state persistence
+
+## Status
+
+Frozen implementation contract for gap G6. Companion to
+`desktop-product-gaps.md` (G6) and `tauri-desktop-vertical-slice.md`.
+
+Owner: Avibe core
+Date: 2026-09-10
+Baseline: `desktop` branch after #1975. The main window is still a
+single Tauri window labeled `main` (`tauri.conf.json`: 1200×800,
+min 880×600, centered).
+
+## Product outcome
+
+The Avibe window reopens at the size and position the user last left
+it, including after a Runtime adopt/start cycle. Maximized is
+restored as maximized. Full-screen / Spaces assignment is **not**
+restored (macOS Spaces restore is a common way to lose the window).
+
+If the saved frame would land off the current display configuration
+(external display unplugged), the window is clamped onto a visible
+display and kept at or above `minWidth` × `minHeight`. A missing or
+corrupt save falls back to the current 1200×800 centered default.
+
+## Frozen mechanism
+
+`tauri-plugin-window-state` (Tauri v2), keyed by window label.
+
+What is persisted, per label:
+
+- `x`, `y`, `width`, `height`
+- `maximized` (bool)
+
+What is not persisted:
+
+- full-screen / simple-fullscreen;
+- workspace / Spaces / virtual-desktop membership;
+- monitor identity (clamp-to-visible is the recovery, not a saved
+  display id);
+- Workbench scroll / SPA route (that is product UI state, not the
+  shell frame).
+
+The plugin hooks the **native window frame**, not the WebView
+document. Bootstrap content swapping and the later navigation to the
+Runtime origin do not reset the frame. Order of operations at
+launch, frozen:
+
+1. Create the `main` window (hidden or shown — plugin-dependent,
+   but the restored frame is applied **before** the user sees it).
+2. Existing bootstrap state machine runs (content changes; frame
+   does not).
+3. On successful `/ready`, navigate the WebView to the Runtime
+   origin (content changes; frame does not).
+4. User moves/resizes: plugin debounces writes to the app config
+   directory.
+
+Closing to tray and re-showing ("Open Avibe") must restore the
+**last shown frame**, not re-center. Quit and relaunch reads the
+same store.
+
+## Multi-window (G8) without a contract change
+
+The plugin already namespaces by label. G8 adding `settings` or
+`show-<id>` windows gets a frame per label for free, provided each
+new window has a stable label. This contract does not require G8;
+G8 must not invent a second persistence path.
+
+v1 of this contract only guarantees the `main` label. Additional
+labels become guaranteed when those windows exist.
+
+## Tests (invariants)
+
+- Saved frame round-trip: a `main` window at a non-default size and
+  position is restored on the next launch of the same app data
+  directory.
+- Off-screen clamp: a saved origin that lies entirely outside the
+  current display bounds is moved so at least the title bar is
+  visible; size stays ≥ minWidth × minHeight.
+- Corrupt / missing store → 1200×800 centered, no panic, no
+  bootstrap failure.
+- Bootstrap then navigate does not overwrite a restored frame with
+  the config.json defaults.
+- `shell_boundaries.rs` still forbids remote capabilities; the
+  plugin is not WebView-callable as a command the Workbench can
+  invoke to move the window (if the plugin exposes commands, they
+  stay off the Workbench capability).
+
+Prefer a focused integration test over mocking the plugin: launch
+the shell against a fake Runtime in a throwaway config dir, set
+frame, quit, relaunch, assert. If that is too heavy for CI, a unit
+test of the clamp function plus a source assertion that
+`tauri-plugin-window-state` is registered for `main` is the
+minimum; the clamp tests must not enumerate display sizes — they
+state the "title bar visible, size ≥ min" property.
+
+## Explicit non-goals (v1)
+
+- Remembering the Workbench route or scroll.
+- Remembering full-screen.
+- Per-display docking layouts.
+- Syncing frame state across machines.
+
+## Sequencing
+
+No dependency on G1, G4, G5, or G8. Cheapest desktop-feel win;
+safe to ship before deep links. If G8 is scheduled, doing G6 first
+means the new windows inherit persistence instead of growing a
+second store.


### PR DESCRIPTION
## Changed capability

Desktop product planning for the next shell slices, all targeting `desktop`:

- Gap inventory (`docs/plans/desktop-product-gaps.md`) for what the thin Tauri shell still lacks versus a first-class desktop app.
- Frozen v1 contracts:
  - G4 notifications: `docs/plans/desktop-notifications-sse.md` — reuse existing `GET /api/events`, shell-owned SSE, allow-list filter, no new route / no Python change / no IPC.
  - G5 deep links: `docs/plans/desktop-deep-links.md` — `avibe://` maps onto existing Workbench routes; hot path extends the single-instance callback; same-origin in-window navigation; no new IPC.
  - G6 window state: `docs/plans/desktop-window-state.md` — `tauri-plugin-window-state` on the native frame; bootstrap/navigation must not reset it; off-screen clamp.
- **G8 native multi-window is deferred.** Keep the current single-WebView shell. Reopen only if a Show Page needs another display; first slice then is settings window + torn-out Show Page, not per-session windows. Session side-by-side stays a Workbench (web-shared) concern.

## Evidence

Documentation only. Contracts were written against the current `desktop` code (SSE broker, Workbench routes in `ui/src/App.tsx`, single-instance callback, `vault_request_url`).

## Dependencies

None. Implementation of G5+G6 will follow on a separate PR that cites these files as the contract.

## Known-by-design

- G8 is explicitly out of this milestone; do not treat "multi-window not specified" as an omission in the G5/G6 contracts.
- IM/https producers are not switched to `avibe://` in G5 v1 (IM clients cannot route the scheme).
