### PR TITLE
feat(desktop): restore window frame and honour avibe:// deep links

### DIFF
--- a/desktop/Cargo.lock
+++ b/desktop/Cargo.lock
@@ -244,9 +244,11 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-autostart",
+ "tauri-plugin-deep-link",
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
  "tauri-plugin-single-instance",
+ "tauri-plugin-window-state",
  "tokio",
  "url",
 ]
@@ -538,6 +540,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -619,6 +641,12 @@ name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -850,6 +878,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -1483,6 +1520,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -2369,6 +2412,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "ordered-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2854,6 +2907,16 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -3592,6 +3655,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-deep-link"
+version = "2.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d489b8ecceae1cd09f6e1f7606f2095ac721cc8d54cf2f0e6bb377cc52cff6"
+dependencies = [
+ "dunce",
+ "plist",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.19",
+ "tracing",
+ "url",
+ "windows-registry",
+ "windows-result 0.3.4",
+]
+
+[[package]]
 name = "tauri-plugin-dialog"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3669,6 +3753,21 @@ dependencies = [
  "tracing",
  "windows-sys 0.60.2",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-window-state"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704"
+dependencies = [
+ "bitflags 2.13.1",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3861,6 +3960,15 @@ checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -4653,6 +4761,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]

--- a/desktop/Cargo.lock
+++ b/desktop/Cargo.lock
@@ -238,6 +238,8 @@ name = "avibe-desktop"
 version = "0.1.0"
 dependencies = [
  "avibe-runtime-host",
+ "objc2",
+ "objc2-foundation",
  "serde",
  "serde_json",
  "sys-locale",

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -159,6 +159,35 @@ Run everything from `desktop/`.
 embeds the frontend at compile time. Run `npm run build` first in a fresh
 checkout — `npm run tauri dev` and `npm run tauri build` handle this themselves.
 
+## Native links and window frame
+
+Packaged installations register `avibe://` for native, single-window navigation:
+
+| Link | Existing Workbench destination |
+| --- | --- |
+| `avibe://session/<id>` | `/chat/<id>` |
+| `avibe://show/<id>` | `/apps/show/<id>` |
+| `avibe://settings` | `/admin/settings/service` |
+| `avibe://vaults/request/<id>` | `/vaults?request_id=<id>` |
+
+IDs use literal ASCII letters, digits, `.`, `_`, and `-`, up to 128 bytes;
+complete `.` and `..` are not IDs. Other schemes, URL syntax, and extra segments
+are silently dropped. A link received during startup waits for readiness; a
+failed bootstrap discards it. Links never select a different Runtime origin or
+grant the Workbench native commands. IM/browser links remain HTTPS.
+
+The main window remembers its native position, size, and maximized state in the
+window-state plugin's app configuration store. Restore happens before showing
+the window; bootstrap and Runtime navigation only change its content. Open from
+the tray preserves the last shown frame, with off-screen recovery against the
+current display work areas. Fullscreen, Spaces, visibility, and routes are not
+restored. An absent or corrupt store uses the centered 1200×800 default.
+
+For manual acceptance, use a packaged test install with isolated app config and
+a fake loopback Runtime: set a non-default frame, quit/relaunch, hide/Open, and
+deliver a link both before and after readiness. Check the destination and frame,
+not just process startup. Development `tauri dev` does not register the scheme.
+
 ## Environment overrides
 
 All optional; the defaults are what ships.

--- a/desktop/runtime-host/src/deep_link.rs
+++ b/desktop/runtime-host/src/deep_link.rs
@@ -1,6 +1,8 @@
+use std::sync::Arc;
+
 use url::Url;
 
-use crate::{BootstrapPhase, BootstrapStatus, LoopbackOrigin};
+use crate::{BootstrapNoticeCode, BootstrapPhase, BootstrapStatus, LoopbackOrigin};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DeepLinkTarget {
@@ -68,9 +70,20 @@ fn valid_identifier(identifier: &str) -> bool {
             .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
 }
 
+pub struct DeepLinkNavigation {
+    destination: Url,
+    delivery: Option<Arc<DeepLinkTarget>>,
+}
+
+impl DeepLinkNavigation {
+    pub fn url(&self) -> &Url {
+        &self.destination
+    }
+}
+
 #[derive(Default)]
 pub struct DeepLinks {
-    pending: Option<DeepLinkTarget>,
+    pending: Option<Arc<DeepLinkTarget>>,
     failed: bool,
 }
 
@@ -83,35 +96,62 @@ impl DeepLinks {
             .into_iter()
             .find_map(|argument| parse_deep_link(argument.as_ref()))
         {
-            self.pending = Some(target);
+            self.pending = Some(Arc::new(target));
         }
     }
 
     pub fn observe_bootstrap(&mut self, status: &BootstrapStatus) {
-        self.failed = status.phase == BootstrapPhase::Failed;
+        self.failed = status.phase == BootstrapPhase::Failed
+            && status.notice.code != BootstrapNoticeCode::WorkbenchNavigationFailed;
         if self.failed {
             self.pending = None;
         }
     }
 
-    pub fn bootstrap_navigation(&mut self, status: &BootstrapStatus) -> Option<Url> {
+    pub fn bootstrap_navigation(&mut self, status: &BootstrapStatus) -> Option<DeepLinkNavigation> {
         self.observe_bootstrap(status);
         if status.phase != BootstrapPhase::Ready {
             return None;
         }
         let origin = LoopbackOrigin::parse(&status.origin).ok()?;
-        Some(self.take_navigation(&origin).unwrap_or_else(|| origin.navigation_url()))
+        Some(self.prepare_navigation(&origin))
     }
 
-    pub fn workbench_navigation(&mut self, origin: &LoopbackOrigin, current_url: &Url) -> Option<Url> {
+    pub fn workbench_navigation(&self, origin: &LoopbackOrigin, current_url: &Url) -> Option<DeepLinkNavigation> {
         if !origin.matches_url_origin(current_url) {
             return None;
         }
-        self.take_navigation(origin)
+        self.pending.as_ref()?;
+        Some(self.prepare_navigation(origin))
     }
 
-    fn take_navigation(&mut self, origin: &LoopbackOrigin) -> Option<Url> {
-        self.pending.take().map(|target| target.navigation_url(origin))
+    pub fn commit_navigation(
+        &mut self,
+        navigation: &DeepLinkNavigation,
+        navigation_succeeded: bool,
+        issuing_generation: u64,
+        current_generation: u64,
+    ) -> bool {
+        if !navigation_succeeded || issuing_generation != current_generation {
+            return false;
+        }
+        match (&self.pending, &navigation.delivery) {
+            (Some(pending), Some(delivery)) if Arc::ptr_eq(pending, delivery) => {
+                self.pending = None;
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn prepare_navigation(&self, origin: &LoopbackOrigin) -> DeepLinkNavigation {
+        DeepLinkNavigation {
+            destination: self
+                .pending
+                .as_ref()
+                .map_or_else(|| origin.navigation_url(), |target| target.navigation_url(origin)),
+            delivery: self.pending.clone(),
+        }
     }
 }
 
@@ -201,13 +241,9 @@ mod tests {
                 .workbench_navigation(&origin, &Url::parse(current).unwrap())
                 .is_none());
         }
-        assert_eq!(
-            links
-                .workbench_navigation(&origin, &origin.navigation_url())
-                .unwrap()
-                .as_str(),
-            "http://127.0.0.1:39567/chat/hot"
-        );
+        let navigation = links.workbench_navigation(&origin, &origin.navigation_url()).unwrap();
+        assert_eq!(navigation.url().as_str(), "http://127.0.0.1:39567/chat/hot");
+        assert!(links.commit_navigation(&navigation, true, 1, 1));
         assert!(links.workbench_navigation(&origin, &origin.navigation_url()).is_none());
     }
 
@@ -221,8 +257,58 @@ mod tests {
             links
                 .workbench_navigation(&origin, &origin.navigation_url())
                 .unwrap()
+                .url()
                 .path(),
             "/chat/first"
         );
+    }
+
+    #[test]
+    fn only_success_in_the_issuing_window_consumes_a_prepared_delivery() {
+        let origin = LoopbackOrigin::parse("http://127.0.0.1:39567").unwrap();
+        let issuing_generation = 2;
+        for navigation_succeeded in [false, true] {
+            for current_generation in 1..=3 {
+                let mut links = DeepLinks::default();
+                links.receive(["avibe://session/pending"]);
+                let navigation = links.workbench_navigation(&origin, &origin.navigation_url()).unwrap();
+                assert!(links.workbench_navigation(&origin, &origin.navigation_url()).is_some());
+                let should_commit = navigation_succeeded && issuing_generation == current_generation;
+                assert_eq!(
+                    links.commit_navigation(
+                        &navigation,
+                        navigation_succeeded,
+                        issuing_generation,
+                        current_generation
+                    ),
+                    should_commit
+                );
+                assert_eq!(
+                    links.workbench_navigation(&origin, &origin.navigation_url()).is_none(),
+                    should_commit
+                );
+                assert!(!links.commit_navigation(&navigation, false, issuing_generation, current_generation));
+            }
+        }
+    }
+
+    #[test]
+    fn an_older_commit_never_clears_a_newer_delivery_even_for_the_same_url() {
+        let origin = LoopbackOrigin::parse("http://127.0.0.1:39567").unwrap();
+        let ready = BootstrapStatus::ready(&origin, 1, BootstrapNoticeCode::Ready);
+        for first in [None, Some("avibe://session/first")] {
+            for next in ["avibe://session/first", "avibe://show/newer"] {
+                let mut links = DeepLinks::default();
+                links.receive(first);
+                let older = links.bootstrap_navigation(&ready).unwrap();
+                links.receive([next]);
+                assert!(!links.commit_navigation(&older, true, 1, 1));
+                let newer = links.workbench_navigation(&origin, &origin.navigation_url()).unwrap();
+                assert_eq!(newer.url(), &parse_deep_link(next).unwrap().navigation_url(&origin));
+                assert!(links.commit_navigation(&newer, true, 1, 1));
+                assert!(!links.commit_navigation(&newer, true, 1, 1));
+                assert!(links.workbench_navigation(&origin, &origin.navigation_url()).is_none());
+            }
+        }
     }
 }

--- a/desktop/runtime-host/src/deep_link.rs
+++ b/desktop/runtime-host/src/deep_link.rs
@@ -1,0 +1,228 @@
+use url::Url;
+
+use crate::{BootstrapPhase, BootstrapStatus, LoopbackOrigin};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DeepLinkTarget {
+    path: String,
+}
+
+impl DeepLinkTarget {
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+
+    pub fn navigation_url(&self, origin: &LoopbackOrigin) -> Url {
+        origin
+            .navigation_url()
+            .join(&self.path)
+            .expect("a parsed deep link is a same-origin path")
+    }
+}
+
+pub fn parse_deep_link(raw: &str) -> Option<DeepLinkTarget> {
+    let parsed = Url::parse(raw).ok()?;
+    if parsed.scheme() != "avibe"
+        || !raw.starts_with("avibe://")
+        || parsed.as_str() != raw
+        || !parsed.username().is_empty()
+        || parsed.password().is_some()
+        || parsed.port().is_some()
+        || parsed.query().is_some()
+        || parsed.fragment().is_some()
+    {
+        return None;
+    }
+    let path = match (parsed.host_str()?, parsed.path()) {
+        ("session", path) | ("show", path) => {
+            let identifier = path.strip_prefix('/')?;
+            if !valid_identifier(identifier) {
+                return None;
+            }
+            let prefix = if parsed.host_str() == Some("session") {
+                "/chat"
+            } else {
+                "/apps/show"
+            };
+            format!("{prefix}/{identifier}")
+        }
+        ("settings", "") => "/admin/settings/service".to_owned(),
+        ("vaults", path) => {
+            let identifier = path.strip_prefix("/request/")?;
+            if !valid_identifier(identifier) {
+                return None;
+            }
+            format!("/vaults?request_id={identifier}")
+        }
+        _ => return None,
+    };
+    Some(DeepLinkTarget { path })
+}
+
+fn valid_identifier(identifier: &str) -> bool {
+    !identifier.is_empty()
+        && identifier.len() <= 128
+        && !matches!(identifier, "." | "..")
+        && identifier
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
+}
+
+#[derive(Default)]
+pub struct DeepLinks {
+    pending: Option<DeepLinkTarget>,
+    failed: bool,
+}
+
+impl DeepLinks {
+    pub fn receive(&mut self, arguments: impl IntoIterator<Item = impl AsRef<str>>) {
+        if self.failed {
+            return;
+        }
+        if let Some(target) = arguments
+            .into_iter()
+            .find_map(|argument| parse_deep_link(argument.as_ref()))
+        {
+            self.pending = Some(target);
+        }
+    }
+
+    pub fn observe_bootstrap(&mut self, status: &BootstrapStatus) {
+        self.failed = status.phase == BootstrapPhase::Failed;
+        if self.failed {
+            self.pending = None;
+        }
+    }
+
+    pub fn bootstrap_navigation(&mut self, status: &BootstrapStatus) -> Option<Url> {
+        self.observe_bootstrap(status);
+        if status.phase != BootstrapPhase::Ready {
+            return None;
+        }
+        let origin = LoopbackOrigin::parse(&status.origin).ok()?;
+        Some(self.take_navigation(&origin).unwrap_or_else(|| origin.navigation_url()))
+    }
+
+    pub fn workbench_navigation(&mut self, origin: &LoopbackOrigin, current_url: &Url) -> Option<Url> {
+        if !origin.matches_url_origin(current_url) {
+            return None;
+        }
+        self.take_navigation(origin)
+    }
+
+    fn take_navigation(&mut self, origin: &LoopbackOrigin) -> Option<Url> {
+        self.pending.take().map(|target| target.navigation_url(origin))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MAPPINGS: &[(&str, &str)] = &[
+        ("avibe://session/ses.A_b-9", "/chat/ses.A_b-9"),
+        ("avibe://show/ses.A_b-9", "/apps/show/ses.A_b-9"),
+        ("avibe://settings", "/admin/settings/service"),
+        ("avibe://vaults/request/req.A_b-9", "/vaults?request_id=req.A_b-9"),
+    ];
+
+    #[test]
+    fn every_contract_mapping_preserves_its_path_and_the_adopted_origin() {
+        for origin in ["http://127.0.0.1:35123", "http://[::1]:49152"] {
+            let origin = LoopbackOrigin::parse(origin).unwrap();
+            for (input, path) in MAPPINGS {
+                let target = parse_deep_link(input).unwrap();
+                assert_eq!(target.path(), *path);
+                let destination = target.navigation_url(&origin);
+                assert_eq!(destination.as_str(), format!("{}{path}", origin.as_str()));
+                assert!(origin.matches_url_origin(&destination));
+                assert!(!crate::is_shell_ui_url(&destination));
+            }
+        }
+    }
+
+    #[test]
+    fn identifiers_are_bounded_literal_path_segments_not_url_syntax() {
+        for prefix in ["avibe://session/", "avibe://show/", "avibe://vaults/request/"] {
+            for length in 1..=128 {
+                let identifier = "a".repeat(length);
+                assert!(parse_deep_link(&format!("{prefix}{identifier}")).is_some());
+            }
+            assert!(parse_deep_link(&format!("{prefix}{}", "a".repeat(129))).is_none());
+            for byte in 0..=127_u8 {
+                let identifier = format!("a{}b", char::from(byte));
+                let allowed = byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-');
+                assert_eq!(parse_deep_link(&format!("{prefix}{identifier}")).is_some(), allowed);
+            }
+            for identifier in ["", ".", "..", "%2E", "%2E%2E", "你好", "a/b", "a\\b", "a?x", "a#x"] {
+                assert!(parse_deep_link(&format!("{prefix}{identifier}")).is_none());
+            }
+        }
+    }
+
+    #[test]
+    fn only_the_literal_frozen_grammar_can_produce_a_navigation() {
+        for (input, _) in MAPPINGS {
+            for malformed in [
+                input.replacen("avibe:", "https:", 1),
+                input.replacen("avibe://", "avibe://host@", 1),
+                input.replacen("avibe://", "avibe:///", 1),
+                input.replacen("avibe://", "avibe://unknown/", 1),
+                input.replacen("avibe://", "avibe:", 1),
+                format!("{input}/"),
+                format!("{input}/extra"),
+                format!("{input}?unexpected"),
+                format!("{input}#fragment"),
+                format!(" {input}"),
+                format!("{input}\n"),
+            ] {
+                assert!(parse_deep_link(&malformed).is_none(), "{malformed:?}");
+            }
+        }
+        for malformed in [
+            "avibe://session:80/id",
+            "avibe://session@show/id",
+            "avibe://@session/id",
+            "avibe://session/id/../normalized",
+            "avibe://session/id/%2E%2E/normalized",
+            "avibe://session/id/./normalized",
+        ] {
+            assert!(parse_deep_link(malformed).is_none(), "{malformed:?}");
+        }
+    }
+
+    #[test]
+    fn hot_delivery_waits_for_the_adopted_workbench_and_applies_once() {
+        let origin = LoopbackOrigin::parse("http://127.0.0.1:39567").unwrap();
+        let mut links = DeepLinks::default();
+        links.receive(["avibe", "--flag", "avibe://session/hot"]);
+        for current in ["tauri://localhost/", "http://localhost:1420/", "http://127.0.0.1:5123/"] {
+            assert!(links
+                .workbench_navigation(&origin, &Url::parse(current).unwrap())
+                .is_none());
+        }
+        assert_eq!(
+            links
+                .workbench_navigation(&origin, &origin.navigation_url())
+                .unwrap()
+                .as_str(),
+            "http://127.0.0.1:39567/chat/hot"
+        );
+        assert!(links.workbench_navigation(&origin, &origin.navigation_url()).is_none());
+    }
+
+    #[test]
+    fn a_delivery_selects_one_valid_link_and_invalid_input_cannot_erase_it() {
+        let origin = LoopbackOrigin::parse("http://127.0.0.1:39567").unwrap();
+        let mut links = DeepLinks::default();
+        links.receive(["avibe", "avibe://session/first", "avibe://session/second"]);
+        links.receive(["avibe://session/../settings"]);
+        assert_eq!(
+            links
+                .workbench_navigation(&origin, &origin.navigation_url())
+                .unwrap()
+                .path(),
+            "/chat/first"
+        );
+    }
+}

--- a/desktop/runtime-host/src/lib.rs
+++ b/desktop/runtime-host/src/lib.rs
@@ -21,11 +21,13 @@
 #![forbid(unsafe_code)]
 
 pub mod bootstrap;
+pub mod deep_link;
 pub mod health;
 pub mod launcher;
 pub mod origin;
 pub mod private_runtime;
 pub mod status;
+pub mod window_frame;
 
 use std::sync::Arc;
 

--- a/desktop/runtime-host/src/window_frame.rs
+++ b/desktop/runtime-host/src/window_frame.rs
@@ -1,0 +1,122 @@
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct WindowFrame {
+    pub x: i32,
+    pub y: i32,
+    pub width: u32,
+    pub height: u32,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct MonitorArea {
+    pub frame: WindowFrame,
+    pub scale_factor: f64,
+}
+
+pub fn clamp_window_frame(frame: WindowFrame, monitors: &[MonitorArea], minimum: (f64, f64)) -> WindowFrame {
+    let Some(monitor) = monitors
+        .iter()
+        .filter(|monitor| monitor.frame.width > 0 && monitor.frame.height > 0)
+        .max_by_key(|monitor| overlap_area(frame, monitor.frame))
+    else {
+        return frame;
+    };
+    let bounds = monitor.frame;
+    let width = frame.width.max((minimum.0 * monitor.scale_factor).ceil() as u32);
+    let height = frame.height.max((minimum.1 * monitor.scale_factor).ceil() as u32);
+    let title_bar = ((32.0 * monitor.scale_factor).ceil() as u32).min(bounds.height);
+    let clamp_position = |position: i32, start: i32, extent: u32, visible: u32| {
+        let start = i64::from(start);
+        let end = start + i64::from(extent.saturating_sub(visible));
+        i64::from(position)
+            .clamp(start, end)
+            .clamp(i64::from(i32::MIN), i64::from(i32::MAX)) as i32
+    };
+    WindowFrame {
+        x: clamp_position(frame.x, bounds.x, bounds.width, width),
+        y: clamp_position(frame.y, bounds.y, bounds.height, title_bar),
+        width,
+        height,
+    }
+}
+
+fn overlap_area(frame: WindowFrame, bounds: WindowFrame) -> u64 {
+    let overlap = |start: i32, extent: u32, other_start: i32, other_extent: u32| {
+        let right = (i64::from(start) + i64::from(extent)).min(i64::from(other_start) + i64::from(other_extent));
+        (right - i64::from(start.max(other_start))).max(0) as u64
+    };
+    overlap(frame.x, frame.width, bounds.x, bounds.width) * overlap(frame.y, frame.height, bounds.y, bounds.height)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clamping_makes_the_title_bar_visible_and_preserves_the_scaled_minimum() {
+        let minimum = (880.0, 600.0);
+        for seed in 1..200_u32 {
+            let monitor = MonitorArea {
+                frame: WindowFrame {
+                    x: -(seed as i32) * 37,
+                    y: seed as i32 * 13,
+                    width: 480 + seed * 17,
+                    height: 320 + seed * 11,
+                },
+                scale_factor: 1.0 + f64::from(seed % 5) * 0.5,
+            };
+            for position in [i32::MIN, -10_000, 0, 10_000, i32::MAX] {
+                let saved = WindowFrame {
+                    x: position,
+                    y: position,
+                    width: seed * 21,
+                    height: seed * 15,
+                };
+                let restored = clamp_window_frame(saved, &[monitor], minimum);
+                assert!(restored.width >= (minimum.0 * monitor.scale_factor).ceil() as u32);
+                assert!(restored.height >= (minimum.1 * monitor.scale_factor).ceil() as u32);
+                assert!(restored.width >= saved.width && restored.height >= saved.height);
+                assert!(restored.x >= monitor.frame.x);
+                assert!(i64::from(restored.x) < i64::from(monitor.frame.x) + i64::from(monitor.frame.width));
+                assert!(restored.y >= monitor.frame.y);
+                let title_bar = ((32.0 * monitor.scale_factor).ceil() as u32).min(monitor.frame.height);
+                assert!(
+                    i64::from(restored.y) + i64::from(title_bar)
+                        <= i64::from(monitor.frame.y) + i64::from(monitor.frame.height)
+                );
+                assert_eq!(clamp_window_frame(restored, &[monitor], minimum), restored);
+            }
+        }
+    }
+
+    #[test]
+    fn an_accessible_frame_is_unchanged_across_restore_and_show() {
+        let monitors = [
+            MonitorArea {
+                frame: WindowFrame {
+                    x: -2000,
+                    y: 40,
+                    width: 2000,
+                    height: 1400,
+                },
+                scale_factor: 1.0,
+            },
+            MonitorArea {
+                frame: WindowFrame {
+                    x: 0,
+                    y: 40,
+                    width: 2000,
+                    height: 1400,
+                },
+                scale_factor: 1.0,
+            },
+        ];
+        let frame = WindowFrame {
+            x: -1800,
+            y: 200,
+            width: 1000,
+            height: 700,
+        };
+        assert_eq!(clamp_window_frame(frame, &monitors, (880.0, 600.0)), frame);
+        assert!(clamp_window_frame(frame, &monitors[1..], (880.0, 600.0)).x >= 0);
+    }
+}

--- a/desktop/runtime-host/tests/bootstrap.rs
+++ b/desktop/runtime-host/tests/bootstrap.rs
@@ -13,6 +13,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use async_trait::async_trait;
+use avibe_runtime_host::deep_link::DeepLinks;
 use avibe_runtime_host::{
     BootstrapNoticeCode, BootstrapPhase, BootstrapStatus, HealthProbe, LaunchError, LaunchWatch, LaunchedRuntime,
     LoopbackOrigin, ResolvedRuntimeLauncher, RuntimeHost, RuntimeHostSettings, RuntimeLauncher, RuntimeReadiness,
@@ -279,6 +280,45 @@ fn immediate_timeout_settings() -> RuntimeHostSettings {
 
 fn host(probe: Arc<FakeProbe>, launcher: Arc<FakeLauncher>, settings: RuntimeHostSettings) -> RuntimeHost {
     RuntimeHost::new(probe, launcher, settings)
+}
+
+#[tokio::test(start_paused = true)]
+async fn a_cold_link_is_consumed_only_after_runtime_readiness_and_never_replayed() {
+    let launcher = FakeLauncher::working();
+    let host = host(FakeProbe::healthy_from(3), launcher.clone(), fast_settings());
+    let recorder = Recorder::default();
+    let mut links = DeepLinks::default();
+    links.receive(["avibe", "avibe://show/cold.session"]);
+    let ready = host.bootstrap(&recorder).await;
+    for status in recorder
+        .statuses
+        .lock()
+        .unwrap()
+        .iter()
+        .filter(|status| status.phase != BootstrapPhase::Ready)
+    {
+        assert!(links.bootstrap_navigation(status).is_none());
+    }
+    assert_eq!(ready.phase, BootstrapPhase::Ready);
+    let destination = links.bootstrap_navigation(&ready).unwrap();
+    assert_eq!(destination.as_str(), format!("{}/apps/show/cold.session", ready.origin));
+    assert_eq!(links.bootstrap_navigation(&ready).unwrap().path(), "/");
+    assert_eq!(launcher.calls(), 1);
+}
+
+#[tokio::test(start_paused = true)]
+async fn bootstrap_failure_discards_the_link_without_navigating_or_replaying_on_retry() {
+    let host = host(FakeProbe::never_healthy(), FakeLauncher::working(), fast_settings());
+    let recorder = Recorder::default();
+    let mut links = DeepLinks::default();
+    links.receive(["avibe://session/failed"]);
+    let failed = host.bootstrap(&recorder).await;
+    assert_eq!(failed.phase, BootstrapPhase::Failed);
+    assert!(links.bootstrap_navigation(&failed).is_none());
+    links.receive(["avibe://session/arrived-after-failure"]);
+    let healthy = RuntimeHost::new(FakeProbe::healthy_from(1), FakeLauncher::working(), fast_settings());
+    let ready = healthy.bootstrap(&recorder).await;
+    assert_eq!(links.bootstrap_navigation(&ready).unwrap().path(), "/");
 }
 
 #[tokio::test(start_paused = true)]

--- a/desktop/runtime-host/tests/bootstrap.rs
+++ b/desktop/runtime-host/tests/bootstrap.rs
@@ -283,7 +283,7 @@ fn host(probe: Arc<FakeProbe>, launcher: Arc<FakeLauncher>, settings: RuntimeHos
 }
 
 #[tokio::test(start_paused = true)]
-async fn a_cold_link_is_consumed_only_after_runtime_readiness_and_never_replayed() {
+async fn a_cold_link_is_consumed_only_after_ready_navigation_commits_and_never_replayed() {
     let launcher = FakeLauncher::working();
     let host = host(FakeProbe::healthy_from(3), launcher.clone(), fast_settings());
     let recorder = Recorder::default();
@@ -301,8 +301,13 @@ async fn a_cold_link_is_consumed_only_after_runtime_readiness_and_never_replayed
     }
     assert_eq!(ready.phase, BootstrapPhase::Ready);
     let destination = links.bootstrap_navigation(&ready).unwrap();
-    assert_eq!(destination.as_str(), format!("{}/apps/show/cold.session", ready.origin));
-    assert_eq!(links.bootstrap_navigation(&ready).unwrap().path(), "/");
+    assert_eq!(
+        destination.url().as_str(),
+        format!("{}/apps/show/cold.session", ready.origin)
+    );
+    assert_eq!(links.bootstrap_navigation(&ready).unwrap().url(), destination.url());
+    assert!(links.commit_navigation(&destination, true, 1, 1));
+    assert_eq!(links.bootstrap_navigation(&ready).unwrap().url().path(), "/");
     assert_eq!(launcher.calls(), 1);
 }
 
@@ -318,7 +323,33 @@ async fn bootstrap_failure_discards_the_link_without_navigating_or_replaying_on_
     links.receive(["avibe://session/arrived-after-failure"]);
     let healthy = RuntimeHost::new(FakeProbe::healthy_from(1), FakeLauncher::working(), fast_settings());
     let ready = healthy.bootstrap(&recorder).await;
-    assert_eq!(links.bootstrap_navigation(&ready).unwrap().path(), "/");
+    assert_eq!(links.bootstrap_navigation(&ready).unwrap().url().path(), "/");
+}
+
+#[tokio::test(start_paused = true)]
+async fn a_ready_link_survives_failed_handoffs_until_the_current_window_accepts_it() {
+    let host = host(FakeProbe::healthy_from(1), FakeLauncher::working(), fast_settings());
+    let mut links = DeepLinks::default();
+    links.receive(["avibe://session/retry"]);
+    let ready = host.bootstrap(&Recorder::default()).await;
+    let origin = LoopbackOrigin::parse(&ready.origin).unwrap();
+    let first = links.bootstrap_navigation(&ready).unwrap();
+    assert!(!links.commit_navigation(&first, false, 1, 1));
+    let handoff_failed = BootstrapStatus::failed(
+        &origin,
+        ready.attempt,
+        avibe_runtime_host::BootstrapNotice::new(BootstrapNoticeCode::WorkbenchNavigationFailed),
+        true,
+    );
+    assert!(links.bootstrap_navigation(&handoff_failed).is_none());
+    let retried = host.bootstrap(&Recorder::default()).await;
+    let replacement = links.bootstrap_navigation(&retried).unwrap();
+    assert_eq!(replacement.url(), first.url());
+    assert!(!links.commit_navigation(&replacement, true, 1, 2));
+    let current = links.bootstrap_navigation(&retried).unwrap();
+    assert_eq!(current.url(), first.url());
+    assert!(links.commit_navigation(&current, true, 2, 2));
+    assert_eq!(links.bootstrap_navigation(&retried).unwrap().url().path(), "/");
 }
 
 #[tokio::test(start_paused = true)]

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -33,3 +33,10 @@ tauri-plugin-single-instance = "2"
 tauri-plugin-window-state = "2"
 tokio.workspace = true
 url.workspace = true
+
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6.4"
+objc2-foundation = { version = "0.3.2", default-features = false, features = [
+  "NSAppleEventDescriptor",
+  "NSAppleEventManager",
+] }

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -26,8 +26,10 @@ serde_json.workspace = true
 sys-locale.workspace = true
 tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-autostart = "2"
+tauri-plugin-deep-link = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-single-instance = "2"
+tauri-plugin-window-state = "2"
 tokio.workspace = true
 url.workspace = true

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -25,7 +25,7 @@ mod macos_deep_link;
 
 #[cfg(feature = "bundled-runtime")]
 use avibe_runtime_host::bundled_runtime_host;
-use avibe_runtime_host::deep_link::DeepLinks;
+use avibe_runtime_host::deep_link::{DeepLinkNavigation, DeepLinks};
 #[cfg(not(feature = "bundled-runtime"))]
 use avibe_runtime_host::default_runtime_host;
 use avibe_runtime_host::{
@@ -791,13 +791,6 @@ fn open_workbench(app: &AppHandle, ready: &BootstrapStatus, activity: Arc<Atomic
         return;
     };
     let window_generation = app.state::<Shell>().window_generation.clone();
-    let destination = app
-        .state::<Mutex<DeepLinks>>()
-        .lock()
-        .ok()
-        .and_then(|mut links| links.bootstrap_navigation(ready))
-        .unwrap_or_else(|| origin.navigation_url());
-
     loop {
         let observed_generation = window_generation.load(Ordering::SeqCst);
         let Some(window) = app.get_webview_window(MAIN_WINDOW) else {
@@ -810,6 +803,15 @@ fn open_workbench(app: &AppHandle, ready: &BootstrapStatus, activity: Arc<Atomic
         if window_generation.load(Ordering::SeqCst) != observed_generation {
             continue;
         }
+        let Some(navigation) = app
+            .state::<Mutex<DeepLinks>>()
+            .lock()
+            .ok()
+            .and_then(|mut links| links.bootstrap_navigation(ready))
+        else {
+            let _ = activity.compare_exchange(ACTIVITY_BOOTSTRAP, ACTIVITY_IDLE, Ordering::SeqCst, Ordering::SeqCst);
+            return;
+        };
         // A recreated window clears the previous navigation grant. Restore the
         // exact ready origin for each generation immediately before navigating
         // that generation's window.
@@ -817,7 +819,7 @@ fn open_workbench(app: &AppHandle, ready: &BootstrapStatus, activity: Arc<Atomic
             let _ = activity.compare_exchange(ACTIVITY_BOOTSTRAP, ACTIVITY_IDLE, Ordering::SeqCst, Ordering::SeqCst);
             return;
         }
-        if window.navigate(destination.clone()).is_err() {
+        if window.navigate(navigation.url().clone()).is_err() {
             if window_generation.load(Ordering::SeqCst) != observed_generation {
                 continue;
             }
@@ -832,6 +834,7 @@ fn open_workbench(app: &AppHandle, ready: &BootstrapStatus, activity: Arc<Atomic
         }
         match complete_workbench_handoff(&activity, &window_generation, observed_generation) {
             WorkbenchHandoff::Monitor => {
+                commit_deep_link_navigation(app, &navigation, true, observed_generation);
                 apply_pending_deep_link(app);
                 start_runtime_monitor(app.clone(), origin, activity);
                 return;
@@ -1069,6 +1072,7 @@ fn apply_pending_deep_link(app: &AppHandle) {
     if shell.activity.load(Ordering::SeqCst) != ACTIVITY_MONITOR {
         return;
     }
+    let observed_generation = shell.window_generation.load(Ordering::SeqCst);
     let Some(window) = app.get_webview_window(MAIN_WINDOW) else {
         return;
     };
@@ -1078,13 +1082,34 @@ fn apply_pending_deep_link(app: &AppHandle) {
     let Ok(current_url) = window.url() else {
         return;
     };
-    let destination = app
+    let navigation = app
         .state::<Mutex<DeepLinks>>()
         .lock()
         .ok()
-        .and_then(|mut links| links.workbench_navigation(&origin, &current_url));
-    if let Some(destination) = destination {
-        let _ = window.navigate(destination);
+        .and_then(|links| links.workbench_navigation(&origin, &current_url));
+    if let Some(navigation) = navigation {
+        if shell.window_generation.load(Ordering::SeqCst) != observed_generation {
+            return;
+        }
+        let succeeded = window.navigate(navigation.url().clone()).is_ok();
+        commit_deep_link_navigation(app, &navigation, succeeded, observed_generation);
+    }
+}
+
+fn commit_deep_link_navigation(
+    app: &AppHandle,
+    navigation: &DeepLinkNavigation,
+    navigation_succeeded: bool,
+    issuing_generation: u64,
+) {
+    let shell = app.state::<Shell>();
+    if let Ok(mut links) = app.state::<Mutex<DeepLinks>>().lock() {
+        links.commit_navigation(
+            navigation,
+            navigation_succeeded,
+            issuing_generation,
+            shell.window_generation.load(Ordering::SeqCst),
+        );
     }
 }
 
@@ -1482,26 +1507,45 @@ mod tests {
     fn a_navigation_failure_is_retryable_without_losing_the_ready_origin() {
         let origin = LoopbackOrigin::parse("http://127.0.0.1:5123").expect("a loopback origin");
         let ready = BootstrapStatus::ready(&origin, 4, BootstrapNoticeCode::Ready);
+        let mut links = DeepLinks::default();
+        links.receive(["avibe://session/retry"]);
+        let navigation = links.bootstrap_navigation(&ready).unwrap();
 
         let failed = workbench_navigation_failure_status(&ready, &origin);
+        links.observe_bootstrap(&failed);
 
         assert_eq!(failed.phase, BootstrapPhase::Failed);
         assert_eq!(failed.origin, origin.as_str());
         assert_eq!(failed.attempt, ready.attempt);
         assert_eq!(failed.notice.code, BootstrapNoticeCode::WorkbenchNavigationFailed);
         assert!(failed.retryable);
+        assert_eq!(links.bootstrap_navigation(&ready).unwrap().url(), navigation.url());
     }
 
     #[test]
     fn a_recreated_window_keeps_bootstrap_ownership_during_handoff() {
         let activity = AtomicU8::new(ACTIVITY_BOOTSTRAP);
         let generation = AtomicU64::new(2);
+        let origin = LoopbackOrigin::parse("http://127.0.0.1:5123").unwrap();
+        let ready = BootstrapStatus::ready(&origin, 1, BootstrapNoticeCode::Ready);
+        let mut links = DeepLinks::default();
+        links.receive(["avibe://session/recreated"]);
+        let navigation = links.bootstrap_navigation(&ready).unwrap();
 
         assert_eq!(
             complete_workbench_handoff(&activity, &generation, 1),
             WorkbenchHandoff::RetryCurrentWindow
         );
         assert_eq!(activity.load(Ordering::SeqCst), ACTIVITY_BOOTSTRAP);
+        assert!(!links.commit_navigation(&navigation, true, 1, generation.load(Ordering::SeqCst)));
+        let replacement = links.bootstrap_navigation(&ready).unwrap();
+        assert_eq!(replacement.url(), navigation.url());
+        assert_eq!(
+            complete_workbench_handoff(&activity, &generation, 2),
+            WorkbenchHandoff::Monitor
+        );
+        assert!(links.commit_navigation(&replacement, true, 2, generation.load(Ordering::SeqCst)));
+        assert_eq!(links.bootstrap_navigation(&ready).unwrap().url().path(), "/");
     }
 
     #[test]

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -20,6 +20,9 @@ use std::time::Duration;
 
 mod native_frame;
 
+#[cfg(target_os = "macos")]
+mod macos_deep_link;
+
 #[cfg(feature = "bundled-runtime")]
 use avibe_runtime_host::bundled_runtime_host;
 use avibe_runtime_host::deep_link::DeepLinks;
@@ -1200,14 +1203,17 @@ fn request_private_runtime_removal(app: AppHandle) {
 }
 
 pub fn run() {
-    tauri::Builder::default()
+    let builder = tauri::Builder::default()
         .manage(Mutex::new(DeepLinks::default()))
         // Registered first, as the plugin documents: a second launch is handed to
         // the running shell instead of starting a competing Runtime.
         .plugin(tauri_plugin_single_instance::init(|app, argv, _cwd| {
             receive_native_deep_link(app, argv.iter().skip(1));
         }))
-        .plugin(tauri_plugin_deep_link::init())
+        .plugin(tauri_plugin_deep_link::init());
+    #[cfg(target_os = "macos")]
+    let builder = builder.plugin(macos_deep_link::init());
+    builder
         .plugin(
             tauri_plugin_window_state::Builder::new()
                 .with_state_flags(native_frame::state_flags())
@@ -1252,10 +1258,6 @@ pub fn run() {
                     false
                 })
                 .on_event(|app, event| {
-                    #[cfg(target_os = "macos")]
-                    if let RunEvent::Opened { urls } = event {
-                        receive_native_deep_link(app, urls.iter().map(Url::as_str));
-                    }
                     if let RunEvent::WindowEvent {
                         label,
                         event: WindowEvent::CloseRequested { api, .. },

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -18,8 +18,11 @@ use std::sync::atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+mod native_frame;
+
 #[cfg(feature = "bundled-runtime")]
 use avibe_runtime_host::bundled_runtime_host;
+use avibe_runtime_host::deep_link::DeepLinks;
 #[cfg(not(feature = "bundled-runtime"))]
 use avibe_runtime_host::default_runtime_host;
 use avibe_runtime_host::{
@@ -617,6 +620,9 @@ struct WindowSink {
 
 impl StatusSink for WindowSink {
     fn publish(&self, status: BootstrapStatus) {
+        if let Ok(mut links) = self.app.state::<Mutex<DeepLinks>>().lock() {
+            links.observe_bootstrap(&status);
+        }
         if let Ok(mut latest) = self.latest.lock() {
             *latest = Some(status.clone());
         }
@@ -782,6 +788,12 @@ fn open_workbench(app: &AppHandle, ready: &BootstrapStatus, activity: Arc<Atomic
         return;
     };
     let window_generation = app.state::<Shell>().window_generation.clone();
+    let destination = app
+        .state::<Mutex<DeepLinks>>()
+        .lock()
+        .ok()
+        .and_then(|mut links| links.bootstrap_navigation(ready))
+        .unwrap_or_else(|| origin.navigation_url());
 
     loop {
         let observed_generation = window_generation.load(Ordering::SeqCst);
@@ -802,7 +814,7 @@ fn open_workbench(app: &AppHandle, ready: &BootstrapStatus, activity: Arc<Atomic
             let _ = activity.compare_exchange(ACTIVITY_BOOTSTRAP, ACTIVITY_IDLE, Ordering::SeqCst, Ordering::SeqCst);
             return;
         }
-        if window.navigate(origin.navigation_url()).is_err() {
+        if window.navigate(destination.clone()).is_err() {
             if window_generation.load(Ordering::SeqCst) != observed_generation {
                 continue;
             }
@@ -817,6 +829,7 @@ fn open_workbench(app: &AppHandle, ready: &BootstrapStatus, activity: Arc<Atomic
         }
         match complete_workbench_handoff(&activity, &window_generation, observed_generation) {
             WorkbenchHandoff::Monitor => {
+                apply_pending_deep_link(app);
                 start_runtime_monitor(app.clone(), origin, activity);
                 return;
             }
@@ -986,6 +999,7 @@ fn focus_or_restore_main_window(app: &AppHandle) {
         return;
     };
     let _ = window.unminimize();
+    let _ = native_frame::clamp(&window.as_ref().window());
     let _ = window.show();
     let _ = window.set_focus();
     let stopped = app
@@ -1031,6 +1045,43 @@ fn focus_or_restore_main_window(app: &AppHandle) {
             }
             spawn_owned_bootstrap(app.clone());
         }
+    }
+}
+
+fn receive_native_deep_link(app: &AppHandle, arguments: impl IntoIterator<Item = impl AsRef<str>>) {
+    if let Ok(mut links) = app.state::<Mutex<DeepLinks>>().lock() {
+        links.receive(arguments);
+    }
+    if app.try_state::<Shell>().is_none() {
+        return;
+    }
+    focus_or_restore_main_window(app);
+    apply_pending_deep_link(app);
+}
+
+fn apply_pending_deep_link(app: &AppHandle) {
+    let Some(shell) = app.try_state::<Shell>() else {
+        return;
+    };
+    if shell.activity.load(Ordering::SeqCst) != ACTIVITY_MONITOR {
+        return;
+    }
+    let Some(window) = app.get_webview_window(MAIN_WINDOW) else {
+        return;
+    };
+    let Some(origin) = shell.active_origin.lock().ok().and_then(|origin| origin.clone()) else {
+        return;
+    };
+    let Ok(current_url) = window.url() else {
+        return;
+    };
+    let destination = app
+        .state::<Mutex<DeepLinks>>()
+        .lock()
+        .ok()
+        .and_then(|mut links| links.workbench_navigation(&origin, &current_url));
+    if let Some(destination) = destination {
+        let _ = window.navigate(destination);
     }
 }
 
@@ -1150,11 +1201,20 @@ fn request_private_runtime_removal(app: AppHandle) {
 
 pub fn run() {
     tauri::Builder::default()
+        .manage(Mutex::new(DeepLinks::default()))
         // Registered first, as the plugin documents: a second launch is handed to
         // the running shell instead of starting a competing Runtime.
-        .plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
-            focus_or_restore_main_window(app);
+        .plugin(tauri_plugin_single_instance::init(|app, argv, _cwd| {
+            receive_native_deep_link(app, argv.iter().skip(1));
         }))
+        .plugin(tauri_plugin_deep_link::init())
+        .plugin(
+            tauri_plugin_window_state::Builder::new()
+                .with_state_flags(native_frame::state_flags())
+                .with_filter(|label| label == MAIN_WINDOW)
+                .build(),
+        )
+        .plugin(native_frame::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_autostart::Builder::new().build())
         .on_menu_event(|app, event| {
@@ -1172,6 +1232,11 @@ pub fn run() {
         })
         .plugin(
             PluginBuilder::<_, ()>::new("shell-run-events")
+                .on_page_load(|webview, payload| {
+                    if webview.label() == MAIN_WINDOW && payload.event() == tauri::webview::PageLoadEvent::Finished {
+                        apply_pending_deep_link(webview.app_handle());
+                    }
+                })
                 .on_navigation(|webview, url| {
                     let active_origin = webview
                         .try_state::<Shell>()
@@ -1187,6 +1252,10 @@ pub fn run() {
                     false
                 })
                 .on_event(|app, event| {
+                    #[cfg(target_os = "macos")]
+                    if let RunEvent::Opened { urls } = event {
+                        receive_native_deep_link(app, urls.iter().map(Url::as_str));
+                    }
                     if let RunEvent::WindowEvent {
                         label,
                         event: WindowEvent::CloseRequested { api, .. },
@@ -1251,6 +1320,13 @@ pub fn run() {
                 }
             };
             app.manage(Shell::new(host, bootstrap_url));
+            if let Ok(mut links) = app.state::<Mutex<DeepLinks>>().lock() {
+                links.receive(
+                    std::env::args_os()
+                        .skip(1)
+                        .filter_map(|argument| argument.into_string().ok()),
+                );
+            }
             install_native_tray(app.handle())?;
             let _ = spawn_bootstrap(app.handle().clone());
             Ok(())

--- a/desktop/src-tauri/src/macos_deep_link.rs
+++ b/desktop/src-tauri/src/macos_deep_link.rs
@@ -167,7 +167,13 @@ mod tests {
                 .lock()
                 .unwrap()
                 .workbench_navigation(&origin, &origin.navigation_url());
-            assert_eq!(navigation.as_ref().map(|url| url.path()), expected_path);
+            assert_eq!(
+                navigation.as_ref().map(|navigation| navigation.url().path()),
+                expected_path
+            );
+            if let Some(navigation) = navigation {
+                assert!(links.lock().unwrap().commit_navigation(&navigation, true, 1, 1));
+            }
         }
     }
 }

--- a/desktop/src-tauri/src/macos_deep_link.rs
+++ b/desktop/src-tauri/src/macos_deep_link.rs
@@ -1,0 +1,173 @@
+use std::cell::RefCell;
+
+use objc2::rc::Retained;
+use objc2::{define_class, msg_send, sel, AnyThread, DefinedClass};
+use objc2_foundation::{NSAppleEventDescriptor, NSAppleEventManager, NSObject, NSObjectProtocol};
+use tauri::plugin::{Builder, TauriPlugin};
+use tauri::RunEvent;
+
+const GET_URL_EVENT: u32 = u32::from_be_bytes(*b"GURL");
+const DIRECT_OBJECT: u32 = u32::from_be_bytes(*b"----");
+
+struct HandlerState {
+    receive: Box<dyn Fn(String)>,
+}
+
+define_class!(
+    #[unsafe(super = NSObject)]
+    #[name = "AvibeRawDeepLinkHandler"]
+    #[ivars = HandlerState]
+    struct RawDeepLinkHandler;
+
+    unsafe impl NSObjectProtocol for RawDeepLinkHandler {}
+
+    impl RawDeepLinkHandler {
+        #[unsafe(method(handleGetURLEvent:withReplyEvent:))]
+        fn handle_get_url(&self, event: &NSAppleEventDescriptor, _reply: &NSAppleEventDescriptor) {
+            if let Some(raw) = raw_url(event) {
+                (self.ivars().receive)(raw);
+            }
+        }
+    }
+);
+
+impl RawDeepLinkHandler {
+    fn new(receive: impl Fn(String) + 'static) -> Retained<Self> {
+        let allocated = Self::alloc().set_ivars(HandlerState {
+            receive: Box::new(receive),
+        });
+        unsafe { msg_send![super(allocated), init] }
+    }
+}
+
+thread_local! {
+    static HANDLER: RefCell<Option<Retained<RawDeepLinkHandler>>> = const { RefCell::new(None) };
+}
+
+fn raw_url(event: &NSAppleEventDescriptor) -> Option<String> {
+    let descriptor: Option<Retained<NSAppleEventDescriptor>> =
+        unsafe { msg_send![event, paramDescriptorForKeyword: DIRECT_OBJECT] };
+    descriptor?.stringValue().map(|text| text.to_string())
+}
+
+fn install(receive: impl Fn(String) + 'static) {
+    let handler = RawDeepLinkHandler::new(receive);
+    let manager = NSAppleEventManager::sharedAppleEventManager();
+    unsafe {
+        let _: () = msg_send![
+            &*manager,
+            setEventHandler: &*handler,
+            andSelector: sel!(handleGetURLEvent:withReplyEvent:),
+            forEventClass: GET_URL_EVENT,
+            andEventID: GET_URL_EVENT,
+        ];
+    }
+    HANDLER.with(|current| *current.borrow_mut() = Some(handler));
+}
+
+fn remove() {
+    HANDLER.with(|current| {
+        let Some(handler) = current.borrow_mut().take() else {
+            return;
+        };
+        let manager = NSAppleEventManager::sharedAppleEventManager();
+        unsafe {
+            let _: () = msg_send![
+                &*manager,
+                removeEventHandlerForEventClass: GET_URL_EVENT,
+                andEventID: GET_URL_EVENT,
+            ];
+        }
+        drop(handler);
+    });
+}
+
+pub fn init() -> TauriPlugin<tauri::Wry> {
+    Builder::new("macos-deep-link")
+        .setup(|app, _| {
+            let app = app.clone();
+            install(move |raw| crate::receive_native_deep_link(&app, [raw]));
+            Ok(())
+        })
+        .on_event(|_, event| {
+            if matches!(event, RunEvent::Exit) {
+                remove();
+            }
+        })
+        .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use avibe_runtime_host::deep_link::{parse_deep_link, DeepLinks};
+    use avibe_runtime_host::LoopbackOrigin;
+    use objc2::ClassType;
+    use objc2_foundation::NSString;
+
+    use super::*;
+
+    fn native_event(raw: Option<&str>) -> Retained<NSAppleEventDescriptor> {
+        let event: Retained<NSAppleEventDescriptor> = unsafe {
+            msg_send![
+                NSAppleEventDescriptor::class(),
+                appleEventWithEventClass: GET_URL_EVENT,
+                eventID: GET_URL_EVENT,
+                targetDescriptor: None::<&NSAppleEventDescriptor>,
+                returnID: -1_i16,
+                transactionID: 0_i32,
+            ]
+        };
+        if let Some(raw) = raw {
+            let parameter = NSAppleEventDescriptor::descriptorWithString(&NSString::from_str(raw));
+            unsafe {
+                let _: () = msg_send![&*event, setParamDescriptor: &*parameter, forKeyword: DIRECT_OBJECT];
+            }
+        }
+        event
+    }
+
+    #[test]
+    fn native_descriptor_text_keeps_the_literal_grammar_visible_to_the_parser() {
+        let valid = "avibe://session/target";
+        assert!(parse_deep_link(valid).is_some());
+        for raw in [
+            valid,
+            "avibe://session/ignored/../target",
+            "avibe://session/ignored/%2E%2E/target",
+            "avibe://session/target\0ignored",
+            "avibe://session/你好",
+        ] {
+            let event = native_event(Some(raw));
+            let received = raw_url(&event).unwrap();
+            assert_eq!(received, raw);
+            assert_eq!(parse_deep_link(&received).is_some(), raw == valid);
+        }
+        assert!(raw_url(&native_event(None)).is_none());
+    }
+
+    #[test]
+    fn the_native_selector_feeds_literal_input_to_the_shared_stash_without_an_appkit_loop() {
+        let origin = LoopbackOrigin::parse("http://127.0.0.1:39567").unwrap();
+        let links = Arc::new(Mutex::new(DeepLinks::default()));
+        let receiver = links.clone();
+        let handler = RawDeepLinkHandler::new(move |raw| receiver.lock().unwrap().receive([raw]));
+        let reply = NSAppleEventDescriptor::nullDescriptor();
+        for (raw, expected_path) in [
+            ("avibe://session/target", Some("/chat/target")),
+            ("avibe://session/ignored/../target", None),
+            ("avibe://session/ignored/%2E%2E/target", None),
+        ] {
+            let event = native_event(Some(raw));
+            unsafe {
+                let _: () = msg_send![&*handler, handleGetURLEvent: &*event, withReplyEvent: &*reply];
+            }
+            let navigation = links
+                .lock()
+                .unwrap()
+                .workbench_navigation(&origin, &origin.navigation_url());
+            assert_eq!(navigation.as_ref().map(|url| url.path()), expected_path);
+        }
+    }
+}

--- a/desktop/src-tauri/src/native_frame.rs
+++ b/desktop/src-tauri/src/native_frame.rs
@@ -1,0 +1,99 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use avibe_runtime_host::window_frame::{clamp_window_frame, MonitorArea, WindowFrame};
+use tauri::plugin::{Builder, TauriPlugin};
+use tauri::{Manager, PhysicalPosition, PhysicalSize, Runtime, Window, WindowEvent};
+use tauri_plugin_window_state::{AppHandleExt, StateFlags};
+
+use crate::MAIN_WINDOW;
+
+pub fn state_flags() -> StateFlags {
+    StateFlags::POSITION | StateFlags::SIZE | StateFlags::MAXIMIZED
+}
+
+pub fn clamp<R: Runtime>(window: &Window<R>) -> tauri::Result<()> {
+    if window.is_maximized()? || window.is_fullscreen()? || window.is_minimized()? {
+        return Ok(());
+    }
+    let position = window.outer_position()?;
+    let size = window.inner_size()?;
+    let frame = WindowFrame {
+        x: position.x,
+        y: position.y,
+        width: size.width,
+        height: size.height,
+    };
+    let monitors: Vec<_> = window
+        .available_monitors()?
+        .into_iter()
+        .map(|monitor| {
+            let area = monitor.work_area();
+            MonitorArea {
+                frame: WindowFrame {
+                    x: area.position.x,
+                    y: area.position.y,
+                    width: area.size.width,
+                    height: area.size.height,
+                },
+                scale_factor: monitor.scale_factor(),
+            }
+        })
+        .collect();
+    let Some(config) = window
+        .config()
+        .app
+        .windows
+        .iter()
+        .find(|config| config.label == MAIN_WINDOW)
+    else {
+        return Ok(());
+    };
+    let restored = clamp_window_frame(
+        frame,
+        &monitors,
+        (config.min_width.unwrap_or(0.0), config.min_height.unwrap_or(0.0)),
+    );
+    if restored.width != frame.width || restored.height != frame.height {
+        window.set_size(PhysicalSize::new(restored.width, restored.height))?;
+    }
+    if restored.x != frame.x || restored.y != frame.y {
+        window.set_position(PhysicalPosition::new(restored.x, restored.y))?;
+    }
+    Ok(())
+}
+
+pub fn init<R: Runtime>() -> TauriPlugin<R> {
+    Builder::new("native-frame")
+        .on_window_ready(|window| {
+            if window.label() != MAIN_WINDOW {
+                return;
+            }
+            let _ = clamp(&window);
+            let _ = window.show();
+            let generation = Arc::new(AtomicU64::new(0));
+            let app = window.app_handle().clone();
+            window.on_window_event(move |event| {
+                if !matches!(event, WindowEvent::Moved(_) | WindowEvent::Resized(_)) {
+                    return;
+                }
+                let observed = generation.fetch_add(1, Ordering::SeqCst) + 1;
+                let generation = generation.clone();
+                let app = app.clone();
+                tauri::async_runtime::spawn(async move {
+                    tokio::time::sleep(Duration::from_millis(400)).await;
+                    if generation.load(Ordering::SeqCst) != observed {
+                        return;
+                    }
+                    let save_app = app.clone();
+                    let _ = app.run_on_main_thread(move || {
+                        if generation.load(Ordering::SeqCst) == observed {
+                            let _ = save_app.save_window_state(state_flags());
+                        }
+                    });
+                });
+            });
+        })
+        .build()
+}

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -18,6 +18,7 @@
         "height": 800,
         "minWidth": 880,
         "minHeight": 600,
+        "visible": false,
         "center": true,
         "resizable": true
       }
@@ -25,6 +26,13 @@
     "security": {
       "capabilities": ["bootstrap"],
       "csp": "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self' ipc: http://ipc.localhost"
+    }
+  },
+  "plugins": {
+    "deep-link": {
+      "desktop": {
+        "schemes": ["avibe"]
+      }
     }
   },
   "bundle": {

--- a/desktop/src-tauri/tests/shell_boundaries.rs
+++ b/desktop/src-tauri/tests/shell_boundaries.rs
@@ -95,6 +95,79 @@ fn the_shell_enables_no_capability_beyond_bootstrap() {
 }
 
 #[test]
+fn deep_links_have_native_entry_points_without_a_workbench_callable_command() {
+    let source = shipping_source("src/lib.rs");
+    let build = shipping_source("build.rs");
+    for required in [
+        "tauri_plugin_deep_link::init()",
+        "receive_native_deep_link(app, argv.iter().skip(1))",
+        "receive_native_deep_link(app, urls.iter().map(Url::as_str))",
+        "std::env::args_os()",
+        "links.bootstrap_navigation(ready)",
+        "links.workbench_navigation(&origin, &current_url)",
+        "links.observe_bootstrap(&status)",
+        "PageLoadEvent::Finished",
+    ] {
+        assert!(source.contains(required), "native deep-link path is missing {required}");
+    }
+    assert!(!build.contains("deep_link") && !build.contains("window_state"));
+    assert!(!source.contains("on_open_url") && !source.contains(".eval("));
+    let receiver = source
+        .split("fn receive_native_deep_link(")
+        .nth(1)
+        .unwrap()
+        .split("fn apply_pending_deep_link")
+        .next()
+        .unwrap();
+    assert!(receiver.contains("focus_or_restore_main_window(app)"));
+    assert_eq!(
+        config()["plugins"]["deep-link"]["desktop"]["schemes"],
+        serde_json::json!(["avibe"])
+    );
+    assert_eq!(config()["identifier"], "bot.avibe.desktop");
+}
+
+#[test]
+fn window_frames_are_restored_before_show_without_document_or_remote_authority() {
+    let source = shipping_source("src/lib.rs");
+    let native_frame = shipping_source("src/native_frame.rs");
+    let window = &config()["app"]["windows"][0];
+    assert_eq!(window["visible"], false);
+    assert_eq!(window["width"], 1200);
+    assert_eq!(window["height"], 800);
+    assert_eq!(window["minWidth"], 880);
+    assert_eq!(window["minHeight"], 600);
+    assert_eq!(window["center"], true);
+    assert!(
+        source.find("tauri_plugin_window_state::Builder::new()").unwrap()
+            < source.find("native_frame::init()").unwrap()
+    );
+    assert!(source.contains(".with_filter(|label| label == MAIN_WINDOW)"));
+    assert!(source.contains(".with_state_flags(native_frame::state_flags())"));
+    assert!(native_frame.contains("StateFlags::POSITION | StateFlags::SIZE | StateFlags::MAXIMIZED"));
+    assert_eq!(native_frame.matches("StateFlags::").count(), 3);
+    assert!(native_frame.contains(".on_window_ready("));
+    assert!(native_frame.find("clamp(&window)").unwrap() < native_frame.find("window.show()").unwrap());
+    assert!(native_frame.contains("tokio::time::sleep("));
+    assert!(native_frame.contains("save_app.save_window_state(state_flags())"));
+    assert!(!native_frame.contains("#[tauri::command]") && !native_frame.contains("invoke_handler"));
+    assert!(!native_frame.contains("on_page_load") && !native_frame.contains("std::fs"));
+    let handoff = source
+        .split("fn open_workbench(")
+        .nth(1)
+        .unwrap()
+        .split("fn workbench_navigation_failure_status")
+        .next()
+        .unwrap();
+    for mutation in ["set_size", "set_position", ".center(", "restore_state"] {
+        assert!(
+            !handoff.contains(mutation),
+            "content handoff must not alter the restored frame"
+        );
+    }
+}
+
+#[test]
 fn product_bundles_have_an_explicit_private_runtime_gate() {
     let cargo = read_to_string(&crate_dir().join("Cargo.toml"));
     let source = shipping_source("src/lib.rs");
@@ -323,7 +396,7 @@ fn every_navigation_stays_on_the_shell_or_the_proved_runtime_listener() {
 fn native_navigation_failures_return_to_a_retryable_bootstrap_state() {
     let source = shipping_source("src/lib.rs");
     for required in [
-        "window.navigate(origin.navigation_url()).is_err()",
+        "window.navigate(destination.clone()).is_err()",
         "workbench_navigation_failure_status(ready, &origin)",
         "BootstrapNoticeCode::WorkbenchNavigationFailed",
     ] {

--- a/desktop/src-tauri/tests/shell_boundaries.rs
+++ b/desktop/src-tauri/tests/shell_boundaries.rs
@@ -101,7 +101,7 @@ fn deep_links_have_native_entry_points_without_a_workbench_callable_command() {
     for required in [
         "tauri_plugin_deep_link::init()",
         "receive_native_deep_link(app, argv.iter().skip(1))",
-        "receive_native_deep_link(app, urls.iter().map(Url::as_str))",
+        "builder.plugin(macos_deep_link::init())",
         "std::env::args_os()",
         "links.bootstrap_navigation(ready)",
         "links.workbench_navigation(&origin, &current_url)",
@@ -112,6 +112,7 @@ fn deep_links_have_native_entry_points_without_a_workbench_callable_command() {
     }
     assert!(!build.contains("deep_link") && !build.contains("window_state"));
     assert!(!source.contains("on_open_url") && !source.contains(".eval("));
+    assert!(!source.contains("RunEvent::Opened"));
     let receiver = source
         .split("fn receive_native_deep_link(")
         .nth(1)
@@ -125,6 +126,40 @@ fn deep_links_have_native_entry_points_without_a_workbench_callable_command() {
         serde_json::json!(["avibe"])
     );
     assert_eq!(config()["identifier"], "bot.avibe.desktop");
+}
+
+#[test]
+fn macos_receives_original_event_text_before_any_url_parser_can_normalize_it() {
+    let native = shipping_source("src/macos_deep_link.rs");
+    for required in [
+        ".setup(|app, _|",
+        "install(move |raw| crate::receive_native_deep_link(&app, [raw]))",
+        "paramDescriptorForKeyword: DIRECT_OBJECT",
+        "descriptor?.stringValue()",
+        "setEventHandler: &*handler",
+        "forEventClass: GET_URL_EVENT",
+        "andEventID: GET_URL_EVENT",
+        "RunEvent::Exit",
+        "removeEventHandlerForEventClass: GET_URL_EVENT",
+    ] {
+        assert!(native.contains(required), "raw native delivery must retain {required}");
+    }
+    for forbidden in [
+        "Url::",
+        "currentAppleEvent",
+        "invoke_handler",
+        "#[tauri::command]",
+        ".emit(",
+    ] {
+        assert!(!native.contains(forbidden), "raw delivery must not use {forbidden}");
+    }
+    let cargo = read_to_string(&crate_dir().join("Cargo.toml"));
+    let (_, macos_dependencies) = cargo
+        .split_once("[target.'cfg(target_os = \"macos\")'.dependencies]")
+        .unwrap();
+    assert!(macos_dependencies.contains("objc2 = \"0.6.4\""));
+    assert!(macos_dependencies.contains("objc2-foundation = { version = \"0.3.2\""));
+    assert!(!cargo.contains("objc2-core-services"));
 }
 
 #[test]

--- a/desktop/src-tauri/tests/shell_boundaries.rs
+++ b/desktop/src-tauri/tests/shell_boundaries.rs
@@ -163,6 +163,43 @@ fn macos_receives_original_event_text_before_any_url_parser_can_normalize_it() {
 }
 
 #[test]
+fn native_link_consumption_uses_one_success_and_window_generation_commit_boundary() {
+    let source = shipping_source("src/lib.rs");
+    let cold = source
+        .split("fn open_workbench(")
+        .nth(1)
+        .unwrap()
+        .split("fn workbench_navigation_failure_status")
+        .next()
+        .unwrap();
+    assert!(cold.find("let Some(window)").unwrap() < cold.find("links.bootstrap_navigation(ready)").unwrap());
+    assert!(
+        cold.find("window.navigate(navigation.url().clone())").unwrap()
+            < cold.find("commit_deep_link_navigation(").unwrap()
+    );
+    assert!(cold.contains("WorkbenchHandoff::Monitor => {\n                commit_deep_link_navigation"));
+    let hot = source
+        .split("fn apply_pending_deep_link(")
+        .nth(1)
+        .unwrap()
+        .split("fn commit_deep_link_navigation")
+        .next()
+        .unwrap();
+    assert!(hot.contains("let succeeded = window.navigate(navigation.url().clone()).is_ok()"));
+    assert!(hot.contains("commit_deep_link_navigation(app, &navigation, succeeded, observed_generation)"));
+    let commit = source
+        .split("fn commit_deep_link_navigation(")
+        .nth(1)
+        .unwrap()
+        .split("fn application_menu")
+        .next()
+        .unwrap();
+    assert!(commit.contains("links.commit_navigation("));
+    assert!(commit.contains("shell.window_generation.load(Ordering::SeqCst)"));
+    assert!(!commit.contains(".navigate("));
+}
+
+#[test]
 fn window_frames_are_restored_before_show_without_document_or_remote_authority() {
     let source = shipping_source("src/lib.rs");
     let native_frame = shipping_source("src/native_frame.rs");
@@ -431,7 +468,7 @@ fn every_navigation_stays_on_the_shell_or_the_proved_runtime_listener() {
 fn native_navigation_failures_return_to_a_retryable_bootstrap_state() {
     let source = shipping_source("src/lib.rs");
     for required in [
-        "window.navigate(destination.clone()).is_err()",
+        "window.navigate(navigation.url().clone()).is_err()",
         "workbench_navigation_failure_status(ready, &origin)",
         "BootstrapNoticeCode::WorkbenchNavigationFailed",
     ] {

--- a/desktop/src-tauri/tests/shell_boundaries.rs
+++ b/desktop/src-tauri/tests/shell_boundaries.rs
@@ -165,6 +165,13 @@ fn macos_receives_original_event_text_before_any_url_parser_can_normalize_it() {
 #[test]
 fn native_link_consumption_uses_one_success_and_window_generation_commit_boundary() {
     let source = shipping_source("src/lib.rs");
+    for line_ending in ["\n", "\r\n"] {
+        let source = source.lines().collect::<Vec<_>>().join(line_ending);
+        assert_native_link_consumption_boundary(&source);
+    }
+}
+
+fn assert_native_link_consumption_boundary(source: &str) {
     let cold = source
         .split("fn open_workbench(")
         .nth(1)
@@ -177,7 +184,8 @@ fn native_link_consumption_uses_one_success_and_window_generation_commit_boundar
         cold.find("window.navigate(navigation.url().clone())").unwrap()
             < cold.find("commit_deep_link_navigation(").unwrap()
     );
-    assert!(cold.contains("WorkbenchHandoff::Monitor => {\n                commit_deep_link_navigation"));
+    let (_, monitoring) = cold.split_once("WorkbenchHandoff::Monitor => {").unwrap();
+    assert!(monitoring.trim_start().starts_with("commit_deep_link_navigation("));
     let hot = source
         .split("fn apply_pending_deep_link(")
         .nth(1)

--- a/docs/plans/desktop-g5-g6-implementation.md
+++ b/docs/plans/desktop-g5-g6-implementation.md
@@ -9,8 +9,9 @@ amendment. Requires #1979 merged first; its branch is not stacked into this lane
 - Native argv, single-instance delivery, and a macOS raw GURL Apple Event handler share a
   Tauri-free parser and one pending target. The first valid link in one delivery
   wins; a later valid delivery replaces an unconsumed target.
-- Only a ready, adopted Runtime supplies the origin. Bootstrap consumes the
-  pending target once; bootstrap failure drops it. A hot delivery waits until
+- Only a ready, adopted Runtime supplies the origin. Navigation prepares a
+  target and consumes it only on native success in the issuing window generation.
+  True Runtime bootstrap failure drops it. A hot delivery waits until
   the WebView has reached that origin before applying the same route mapping.
 - Raw links never become JavaScript or error copy. Complete dot segments are
   rejected; ordinary identifier dots remain valid. Percent escapes fail the
@@ -64,3 +65,22 @@ the installing thread until Exit removes the registration, and never writes a
 reply descriptor. No delegate replacement, swizzle, or current-event lookup is
 used. Plugin setup runs before Tauri's event loop, while the process-level stash
 already exists, so an early event does not depend on window or Runtime readiness.
+
+## Review correction: navigation commit ownership
+
+Review 5167442411 on head 12f5b5855f identified a distinct second class:
+preparing a cold or hot navigation consumed its target before the native window
+accepted it. The September 10 orchestrator ruling freezes two-phase delivery:
+
+- Missing windows, generation changes, native navigation errors, and
+  `WorkbenchNavigationFailed` retain the target for a ready Runtime.
+- True Runtime bootstrap failure discards the target.
+- Only successful navigation in the issuing window generation may commit.
+- An old attempt cannot clear a newer delivery, even when both URLs are equal.
+
+The existing `DeepLinks` owner retains an immutable delivery identity and returns
+a prepared URL plus that identity. Both native paths share one commit boundary;
+neither holds the stash mutex during native navigation. No new persistent store,
+IPC, capability, dependency, or G6 behavior is introduced. Fake-Runtime tests and
+pure owner tests cover handoff retry, generation changes, failure distinction,
+newer delivery preservation, and one-shot successful consumption.

--- a/docs/plans/desktop-g5-g6-implementation.md
+++ b/docs/plans/desktop-g5-g6-implementation.md
@@ -1,0 +1,45 @@
+# Desktop deep-link and window-frame implementation
+
+## Change contract
+
+Implements the authoritative `desktop-deep-links.md` and
+`desktop-window-state.md` contracts from PR #1979, including the 4bd96455c
+amendment. Requires #1979 merged first; its branch is not stacked into this lane.
+
+- Native argv, single-instance delivery, and macOS `RunEvent::Opened` share a
+  Tauri-free parser and one pending target. The first valid link in one delivery
+  wins; a later valid delivery replaces an unconsumed target.
+- Only a ready, adopted Runtime supplies the origin. Bootstrap consumes the
+  pending target once; bootstrap failure drops it. A hot delivery waits until
+  the WebView has reached that origin before applying the same route mapping.
+- Raw links never become JavaScript or error copy. Complete dot segments are
+  rejected; ordinary identifier dots remain valid. Percent escapes fail the
+  literal identifier character rule. The kind is the allow-listed URL authority;
+  userinfo, ports, host-less spellings, and normalized nonliteral input are rejected.
+- The window-state plugin is the only frame store. It restores native geometry
+  before showing `main`; a native frame hook clamps against monitor work areas
+  with DPI-aware minimum dimensions. Content navigation never reapplies defaults.
+- Native move/resize events debounce the plugin's existing save operation. Only
+  position, size, and maximized state are enabled; visibility and fullscreen are
+  excluded. Hide/Open keeps the same window and frame.
+
+## Boundaries and non-goals
+
+No new application command, capability, remote grant, React route, Python link
+producer, notification, or second native window. The local-first data-location
+and bootstrap-only IPC boundaries remain unchanged. G8 and producer adoption are
+explicitly deferred; malformed links are silently dropped.
+
+## Verification
+
+- Parser properties cover exact mappings, literal identifiers, origin stability,
+  malformed grammar, and one-shot hot delivery without Tauri.
+- Existing fake-Runtime bootstrap tests exercise cold staging, failure discard,
+  and retry without replay. Native source-boundary tests check OS-only entry
+  points, unchanged commands/capabilities, and frame-only plugin lifecycle hooks.
+- Clamp properties check title-bar visibility, DPI-aware minimum dimensions,
+  idempotence, and preservation of accessible frames.
+- Local gates: bootstrap npm install/build/i18n, Rust formatting, all-target
+  all-feature clippy, and all-feature workspace tests. CI repeats on macOS and
+  Windows. Packaged OS scheme registration and native frame round-trip remain
+  manual acceptance checks when an isolated graphical environment is unavailable.

--- a/docs/plans/desktop-g5-g6-implementation.md
+++ b/docs/plans/desktop-g5-g6-implementation.md
@@ -6,7 +6,7 @@ Implements the authoritative `desktop-deep-links.md` and
 `desktop-window-state.md` contracts from PR #1979, including the 4bd96455c
 amendment. Requires #1979 merged first; its branch is not stacked into this lane.
 
-- Native argv, single-instance delivery, and macOS `RunEvent::Opened` share a
+- Native argv, single-instance delivery, and a macOS raw GURL Apple Event handler share a
   Tauri-free parser and one pending target. The first valid link in one delivery
   wins; a later valid delivery replaces an unconsumed target.
 - Only a ready, adopted Runtime supplies the origin. Bootstrap consumes the
@@ -39,7 +39,28 @@ explicitly deferred; malformed links are silently dropped.
   points, unchanged commands/capabilities, and frame-only plugin lifecycle hooks.
 - Clamp properties check title-bar visibility, DPI-aware minimum dimensions,
   idempotence, and preservation of accessible frames.
+- macOS descriptor and Objective-C selector tests retain literal strings through
+  the native adapter into the same stash, including rejected dot segments,
+  percent-encoded dot segments, embedded NUL, and Unicode. No AppKit event loop,
+  installed application, or external Apple Event delivery is required.
 - Local gates: bootstrap npm install/build/i18n, Rust formatting, all-target
   all-feature clippy, and all-feature workspace tests. CI repeats on macOS and
   Windows. Packaged OS scheme registration and native frame round-trip remain
   manual acceptance checks when an isolated graphical environment is unavailable.
+
+## Review correction: native input fidelity
+
+Review 5165620370 on head 722e04e143 identified one input-fidelity class: Tao
+0.35.3 parses NSURL text before Tauri exposes `RunEvent::Opened`, so stringifying
+that event cannot enforce the literal grammar. The orchestrator approved a raw
+GURL handler in plugin setup and removal on Exit, with no normalized fallback.
+The grammar and other OS/G6 behavior are unchanged.
+
+Only macOS directly depends on the already-locked objc2 0.6.4 and Foundation
+0.3.2, adding the descriptor/manager features. The adapter uses Foundation's
+documented selectors with 32-bit FourCC values, not Core Services bindings or a
+new framework. The Objective-C handler owns its Rust callback, is retained on
+the installing thread until Exit removes the registration, and never writes a
+reply descriptor. No delegate replacement, swizzle, or current-event lookup is
+used. Plugin setup runs before Tauri's event loop, while the process-level stash
+already exists, so an early event does not depend on window or Runtime readiness.


### PR DESCRIPTION
## Outcome and contracts

Restore the native `main` window frame across launches and honour the four frozen
`avibe://` link shapes inside the existing Workbench window.

**Dependency satisfied:** #1979 merged into `desktop` on September 10, 2026 at
12:07:52 UTC (squash `456adff26faf770489f433a7b1e550110834b269`). This branch
incorporates that updated base through a normal merge commit, without rebasing,
rewriting existing commits, or stacking the unmerged documentation branch.
The authoritative contracts are now present from `desktop`:

- `docs/plans/desktop-deep-links.md` (G5)
- `docs/plans/desktop-window-state.md` (G6)

Implementation contract and validation boundaries:
`docs/plans/desktop-g5-g6-implementation.md`.

## Changes

- One Tauri-free URL parser and pending-target owner shared by cold argv,
  single-instance argv, and macOS raw GURL Apple Events. Kind is the allow-listed
  URL authority; literal bounded IDs cannot normalize into another route.
- A macOS-only Foundation handler is installed in plugin setup and removed on
  Exit. It reads the original descriptor string before URL normalization, with
  no `RunEvent::Opened` fallback. Explicit macOS dependencies reuse locked objc2
  0.6.4 and objc2-foundation 0.3.2 with descriptor/manager features only; no Core
  Services bindings, delegate replacement, method swizzling, or JS delivery.
- Cold targets wait for readiness; cold and hot attempts prepare without
  consuming, then commit only after successful native navigation in the issuing
  window generation. True Runtime bootstrap failure discards the target;
  WebView handoff failure retains it. Hot navigation stays on the adopted Runtime
  origin, and an old attempt cannot clear a newer delivery, even for the same URL.
- Register the `avibe` scheme for `bot.avibe.desktop` via the v2 deep-link plugin.
- Use the v2 window-state plugin as the only native frame store, restoring before
  showing `main`. DPI-aware monitor work-area clamping preserves minimum size and
  title-bar visibility. Native move/resize events debounce the plugin's save API.
- Keep bootstrap content changes and Runtime navigation independent of geometry.
  Hide/Open keeps the native window instead of rebuilding or re-centering it.

## Evidence

- Unit: parser grammar, exact path/origin mapping, bounded literal identifiers,
  pending delivery and one-shot consumption, clamp visibility/minimum/idempotence.
- Scenario: existing fake-Runtime bootstrap harness covers delayed readiness,
  one-shot successful commit, handoff retry, true bootstrap failure discard, and
  generation changes. Pure-owner tests cover navigation failure and preservation
  of newer deliveries (including equal URLs and a previously empty stash).
- Contract: shell source/config tests pin native entry points, unchanged command
  declarations/capabilities, bootstrap-only authority, and frame-only lifecycle.
- Native boundary: actual Foundation descriptors and the Objective-C selector
  preserve literal text into the shared parser/stash, accepting the valid route
  and rejecting `ignored/../target` and `ignored/%2E%2E/target`. Descriptor coverage
  includes missing data, embedded NUL, and Unicode, without an AppKit event loop.
- Local passed: `npm ci`, `npm run build`, `npm run test:i18n`,
  `cargo fmt --all -- --check`,
  `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and
  `cargo test --workspace --all-features` (160 passing tests including one doctest).
- CI gate: exact-head `desktop-shell` (macOS and Windows) and `lint` required.

## Known-by-design and residual acceptance

- **G6 corrupt/missing store recovery is already owned by the locked plugin.**
  `tauri-plugin-window-state` 2.4.1 has Cargo checksum
  `73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704`.
  Its [published setup implementation](https://github.com/tauri-apps/plugins-workspace/blob/e7a68fa63755603b9fa12d28e077eea645551d24/plugins/window-state/src/lib.rs#L396-L406)
  calls `load_saved_window_states(...).unwrap_or_default()` and returns `Ok(())`.
  Missing, unreadable, malformed, truncated, or schema-invalid `.window-state.json`
  data therefore becomes an empty cache, not a propagated app-startup error.
  Restoration only applies a non-default cached frame, so empty/default state
  leaves the configured centered 1200x800 frame in place. Do not add a parallel
  preflight parser, quarantine, or store to duplicate this recovery path.
  Review comment 3979712068 was independently checked by the orchestrator and
  classified as a false positive on the locked dependency, not a product fix.
  A throwaway Rust probe also initialized the actual 2.4.1 plugin under Tauri
  2.11.5 MockRuntime with missing, malformed, truncated, invalid-schema, and empty
  valid fixtures: all five setups succeeded without changing fixture bytes.
  The probe used absolute test-owned filenames and did not run an AppKit event
  loop or claim visual frame evidence; no project dependency or source changed.
- G8 native multi-window and G4 notifications are deferred; Python/IM HTTPS
  producers and React routes are unchanged. Malformed links are silently dropped.
- No new application IPC command, capability, or remote grant. Plugin commands
  remain off the Workbench capability; link handlers are native, not JavaScript.
- Fullscreen, Spaces, visibility, routes, and scroll are not restored.
- Isolated packaged OS scheme activation and native frame set/quit/relaunch,
  hide/Open, maximized restore, and removed-display acceptance remain manual
  integration checks. This PR uses the contracts' CI minimum of clamp properties
  plus native registration/source-boundary checks; it does not claim GUI evidence.
- `npm ci` reports an existing high-severity `nanoid` advisory from the unchanged
  JavaScript lockfile. Rust dependencies are the two requested v2 plugins plus
  the approved macOS-only Foundation adapter dependencies; Cargo generated every
  lockfile change.

## Review correction

Codex review 5165620370 on 722e04e143 identified one root-cause class: the macOS
adapter stringified a URL that Tao had already normalized. The orchestrator
confirmed the finding and approved the raw GURL entry path. The replacement
preserves the frozen grammar; other OS adapters and G6 remain unchanged.

Codex review 5167442411 on 12f5b5855f identified a distinct second class:
consuming pending navigation before the native window accepted it. The approved
two-phase change is implemented in the existing owner, with one shared cold/hot
success-commit boundary and no mutex held across native navigation.

### Frozen stash ruling (September 10, 2026)

> Two-phase: prepare vs commit. Consume only after `navigate` returns Ok and
> window generation is still the issuer's. Do not hold the DeepLinks mutex across
> native `navigate`.

| Event | Stash |
| --- | --- |
| Missing window, generation change, `navigate` Err, or `WorkbenchNavigationFailed` | Retain: Runtime is ready; this is WebView handoff failure |
| True Runtime bootstrap Failed | Discard: no half-navigated Workbench over a failed Runtime |
| Newer link received during an attempt | Replace the prepared target; committing the old attempt must not clear the new one |

Review inventory: three findings-bearing heads with three different classes;
the third (bc281d373, corrupt-store setup) is the independently verified false
positive documented in the ledger. 229e0aeed, 33cf7af11, and a68cb96999 received
clean reviews. The orchestrator verified that no repeated-class or consecutive
post-rewrite failure threshold has fired. A re-flag of the ledgered class will
be escalated before any code edit or push.
The ruling is also recorded in the implementation plan; authoritative contract
paragraph publication remains owned by the desktop documentation follow-up.

## Current delivery gates

- Head: `bc281d37365e8460795039d3af7f8f8921ba5ef8`, the newline-portable
  shell-boundary test correction after the two-phase navigation fix, on top of
  `desktop` at `186192a9eb4c09c5992d6aa59de5e7e28cc5ef27`.
- **Baseline flake fix incorporated:** [#1981](https://github.com/avibe-bot/avibe/pull/1981)
  merged into `desktop` on September 10, 2026 at 12:55:00 UTC. Its TestServer
  accepted-stream blocking-read fix addresses [#1978](https://github.com/avibe-bot/avibe/issues/1978).
  Base-sync commit `12f5b5855` imported only the upstream `health.rs` test-fixture
  change and its three tests. That file still exactly matches the updated
  base; this lane made no independent health-fixture edits.
- Every prescribed local gate passed again after the newline-portability fix,
  including all 160 workspace tests. The independent Tauri-free parser/owner
  tests also passed for the unchanged product implementation.
- Prior head `a68cb96999` received an exact-head
  [Codex PASS](https://github.com/avibe-bot/avibe/pull/1980#issuecomment-5619490408),
  green macOS `desktop-shell`, and green
  [lint](https://github.com/avibe-bot/avibe/actions/runs/34482220682).
  The Windows failure in
  [run 34482220772](https://github.com/avibe-bot/avibe/actions/runs/34482220772)
  was a source-boundary assertion hardcoding LF after a branch delimiter;
  Windows checkout uses CRLF. The same consuming assertion now runs over both
  LF and CRLF source, and checks the first statement after whitespace rather
  than a fixed newline/indent. That regression failed locally before the fix
  and passed afterward. This correction changes only the test, not product
  behavior, dependencies, or `health.rs`. The orchestrator made the forward
  commit/push to preserve the lane harness history contract. This prior-head
  PASS is not reused: current-head Codex review and CI remain required.
- Prior head `12f5b5855` had green macOS/Windows
  [desktop-shell](https://github.com/avibe-bot/avibe/actions/runs/34479880968) and
  [lint](https://github.com/avibe-bot/avibe/actions/runs/34479880949), confirming
  #1981 cleared the baseline flake. That head had the navigation-commit P2, not a
  clean review. Current-head review and CI must both pass; no prior verdict or
  check is being reused as the current-head gate.
- Historical baseline failures are preserved in
  [run 34475343609](https://github.com/avibe-bot/avibe/actions/runs/34475343609)
  and [run 34465699737](https://github.com/avibe-bot/avibe/actions/runs/34465699737).
  No further rerun was requested; the orchestrator authorized incorporating the
  separately reviewed #1981 fix rather than broadening the G5/G6 implementation.
- Current-head [desktop-shell](https://github.com/avibe-bot/avibe/actions/runs/34483818250)
  is successful on macOS and Windows. Current-head
  [lint](https://github.com/avibe-bot/avibe/actions/runs/34483818231) attempt 1 failed
  in the unchanged baseline test
  `test_managed_watch_service_forever_timeout_retries_when_explicitly_allowed`
  (`tests/test_watches.py:787`, `last_exit_code` was `None`, expected `124`, after
  a fixed 0.2-second wait). The orchestrator authorized exactly one failed-job
  rerun including the aggregate job; attempt 2 completed successfully. Every
  expected check on this exact head is terminal and successful. No second
  rerun, Python change, or watch-fixture change was needed. The first-attempt
  failure is retained as baseline timing-flake evidence, not a G5/G6 defect.
- After the false-positive ledger and thread resolution, same-head review
  [request 5619825255](https://github.com/avibe-bot/avibe/pull/1980#issuecomment-5619825255)
  was rejected by the bot for
  [code-review usage limits](https://github.com/avibe-bot/avibe/pull/1980#issuecomment-5619827792).
  No pickup eyes or clean PASS exists for this post-ledger review request. This
  is an external review-availability blocker, not permission to reuse an older
  PASS or waive the review gate. It has been escalated to the orchestrator.
- The same durable PR/CI watch remains armed for GitHub review and CI activity.
  The orchestrator must explicitly signal quota recovery; this watcher does not
  monitor account quota state or Session decisions.

Do not merge from this lane. Current-head CI is green and all review threads
are resolved, but a clean post-ledger exact-head Codex verdict is still blocked
on review availability. The manual integration checks above remain outstanding.
