### PR TITLE
fix(desktop): retry WouldBlock in health TestServer reads

### DIFF
--- a/desktop/runtime-host/src/health.rs
+++ b/desktop/runtime-host/src/health.rs
@@ -171,7 +171,7 @@ fn parse_runtime_identity_mismatch_body(body: &str) -> Option<RuntimeReadiness> 
 mod tests {
     use super::*;
     use std::io::{Read, Write};
-    use std::net::TcpListener;
+    use std::net::{Shutdown, TcpListener, TcpStream};
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
 
@@ -199,7 +199,10 @@ mod tests {
                     match listener.accept() {
                         Ok((mut stream, _)) => {
                             thread_contacted.store(true, Ordering::SeqCst);
-                            let _ = stream.set_read_timeout(Some(Duration::from_secs(1)));
+                            stream.set_nonblocking(false).expect("test request stream is blocking");
+                            stream
+                                .set_read_timeout(Some(Duration::from_secs(1)))
+                                .expect("test request reads are bounded");
                             let mut request = Vec::new();
                             while !request.windows(4).any(|bytes| bytes == b"\r\n\r\n") {
                                 let mut chunk = [0_u8; 1024];
@@ -243,6 +246,79 @@ mod tests {
         bytes.extend_from_slice(b"\r\n");
         bytes.extend_from_slice(body);
         bytes
+    }
+
+    #[test]
+    fn test_server_waits_for_complete_request_headers() {
+        let expected_response = response("200 OK", &[], READY_BODY.as_bytes());
+        let server = TestServer::start(expected_response.clone());
+        let mut client =
+            TcpStream::connect(server.origin.as_str().trim_start_matches("http://")).expect("test client connects");
+        client
+            .set_read_timeout(Some(Duration::from_millis(50)))
+            .expect("test client reads are bounded");
+
+        for fragment in [b"".as_slice(), b"GET /ready HTTP/1.1\r\nHost: localhost\r\n".as_slice()] {
+            client.write_all(fragment).expect("test request fragment writes");
+            let mut pending_response = [0_u8; 1];
+            let error = client
+                .read(&mut pending_response)
+                .expect_err("test server waits until the headers are complete");
+            assert!(matches!(
+                error.kind(),
+                std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+            ));
+        }
+
+        client.write_all(b"\r\n").expect("test request headers complete");
+        client
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .expect("test response reads are bounded");
+        let mut actual_response = Vec::new();
+        client.read_to_end(&mut actual_response).expect("test response reads");
+        assert_eq!(actual_response, expected_response);
+        assert!(server.finish());
+    }
+
+    #[test]
+    fn test_server_rejects_truncated_request_headers() {
+        let mut server = TestServer::start(Vec::new());
+        let mut client =
+            TcpStream::connect(server.origin.as_str().trim_start_matches("http://")).expect("test client connects");
+        client
+            .write_all(b"GET /ready HTTP/1.1\r\n")
+            .expect("test request writes");
+        client.shutdown(Shutdown::Write).expect("test request ends");
+        let failure = server
+            .handle
+            .take()
+            .expect("test server has a thread")
+            .join()
+            .expect_err("truncated headers fail the test server");
+        assert_eq!(
+            failure.downcast_ref::<&str>(),
+            Some(&"test request contains complete headers")
+        );
+    }
+
+    #[test]
+    fn test_server_rejects_oversized_request_headers() {
+        let mut server = TestServer::start(Vec::new());
+        let mut client =
+            TcpStream::connect(server.origin.as_str().trim_start_matches("http://")).expect("test client connects");
+        client
+            .write_all(&vec![b'x'; 16 * 1024 + 1])
+            .expect("test request writes");
+        let failure = server
+            .handle
+            .take()
+            .expect("test server has a thread")
+            .join()
+            .expect_err("oversized headers fail the test server");
+        assert_eq!(
+            failure.downcast_ref::<&str>(),
+            Some(&"test request headers are bounded")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #1978. Make the test-only health server wait for request bytes instead of panicking when an accepted macOS socket inherits the listener's nonblocking mode.

Normalize the accepted stream with `set_nonblocking(false)` before applying the existing one-second read timeout. This is the smaller accepted-stream alternative to a hand-written WouldBlock retry loop. Timeout setup now fails explicitly if the fixture cannot establish its bound.

## Change contract

- Scope: only `desktop/runtime-host/src/health.rs`, entirely inside `#[cfg(test)]`.
- A valid request may arrive late or in fragments; the fixture responds only after the complete header terminator arrives.
- EOF before complete headers and headers exceeding 16 KiB still fail closed at the original assertions. New tests check the exact server panic payloads, not merely that a thread panicked.
- The production probe, its timeouts, response-size validation, and no-redirect policy remain byte-for-byte unchanged. No #1980 files or workflows change.
- Dependencies: none; target the `desktop` integration branch. Do not merge as part of this lane.

## Failure evidence

- #1971, head `5474b3ce46e79dbe7dd087b6ac52ea2e15d13864`: [desktop-shell run 34439361567, attempt 1](https://github.com/avibe-bot/avibe/actions/runs/34439361567/attempts/1) fails the accept-body, identity-mismatch, and no-redirect health tests at `health.rs:206`, `test request reads`, OS error 35 / `WouldBlock`. The same run reached green on attempt 3 without changing that head.
- #1980, head `33cf7af11c20edcea0b38d91f06918abe19dcd78`: [macOS job 102864657823](https://github.com/avibe-bot/avibe/actions/runs/34475343609/job/102864657823) fails `the_probe_does_not_follow_redirects` at the identical fixture read and error, rather than in its G5/G6 code.
- Local macOS red/green: the new delayed/fragmented-request test fails before the fix with the same OS error 35 / `WouldBlock` at line 206 and premature EOF at the client; it passes after accepted-stream normalization.

## Validation

- `npm ci && npm run build` in `desktop/`: passed before Cargo validation.
- `cargo test -p avibe-runtime-host --all-features`: passed, 81 unit tests and 21 integration tests.
- `cargo fmt --all -- --check`: passed.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: passed.
- All 11 health tests passed in 50 consecutive additional runs (550 successful test executions), including all three previously flaky probe tests.
- Unit evidence: new delayed/fragmented request, truncated-header EOF, and oversized-header fixture tests; existing probe assertions unchanged.
- Contract evidence: exact failure assertions and byte-for-byte comparison of the production source before `#[cfg(test)]`.
- Scenario evidence: no desktop scenario catalog exists; existing bootstrap integration tests passed unchanged.
- Exact-head review/CI: [Codex PASS](https://github.com/avibe-bot/avibe/pull/1981#issuecomment-5618667593) on `8b81888f308065097948585d7f954b5b740c2428`; zero unresolved review threads. [desktop-shell](https://github.com/avibe-bot/avibe/actions/runs/34476420536) and [lint](https://github.com/avibe-bot/avibe/actions/runs/34476420560) both passed on attempt 1; all 16 PR checks succeeded. Actual macOS and Windows job logs confirm all 11 health tests passed.
- Residual manual checks: no installed service restart or tenant-facing operation was performed; desktop end-to-end integration remains the orchestrator's acceptance pass. This lane does not merge the PR.

## Known-by-design ledger

- This is test robustness, not a production timeout change. The existing one-second per-read timeout remains; genuine read timeouts and non-transient errors still fail the fixture. No blanket retries or error suppression are added.
- Listener accept remains nonblocking so an uncontacted redirect target can stop normally. Only an accepted request stream becomes blocking.
- `npm ci` reports one existing high-severity dependency advisory. Dependency remediation is outside this one-file fixture fix; no dependency or lockfile is changed.
