### PR TITLE
feat(desktop): carry run timestamps on terminal runs.updated

### DIFF
--- a/core/inbox_events.py
+++ b/core/inbox_events.py
@@ -113,6 +113,8 @@ def run_updated_payload(
     session_id: str | None = None,
     definition_id: str | None = None,
     updated_at: str | None = None,
+    started_at: str | None = None,
+    completed_at: str | None = None,
     cancel_requested: bool | None = None,
 ) -> dict[str, Any]:
     """Minimal run-lifecycle payload for browser refetch-on-event consumers."""
@@ -126,6 +128,10 @@ def run_updated_payload(
         payload["definition_id"] = definition_id
     if updated_at:
         payload["updated_at"] = updated_at
+    if started_at:
+        payload["started_at"] = started_at
+    if completed_at:
+        payload["completed_at"] = completed_at
     if cancel_requested is not None:
         payload["cancel_requested"] = cancel_requested
     return payload

--- a/docs/plans/desktop-run-terminal-timestamps.md
+++ b/docs/plans/desktop-run-terminal-timestamps.md
@@ -1,0 +1,55 @@
+# G4 terminal run timestamp producer
+
+## Contract and scope
+
+The authoritative contract is `desktop-notifications-sse.md`, specifically
+`"Background" for run.terminal` and `Python changes in v1`. The desktop consumer
+needs durable duration, not elapsed time since event receipt. Terminal row events
+carry the stored `started_at` and `completed_at` when available; missing stamps
+remain missing. Non-terminal payloads do not change.
+
+No desktop, transport, event-name, visibility, timestamp-storage, or notification
+policy changes belong to this lane. The detail endpoint already exposes both
+timestamps through `SQLiteBackgroundTaskStore._run_from_row`.
+
+## Publisher inventory and design
+
+At base `395d7c2c75980cb154bce3aa83abda7a92ff9450`, every row publisher converges on
+`storage/background.py::_publish_run_rows_updated`:
+
+- Direct callers: `cancel_run`, `claim_pending_run`, `mark_run_execution_started`,
+  `update_run_status`, `mark_run_queued_from_running`,
+  `recover_claimed_pre_execution_run`, `record_run_message`, `record_run_output`,
+  `settle_run_terminal`, `defer_run_terminal`, and `settle_deferred_run` (including
+  participant rows).
+- Deferred callers use `run_update_event_transaction`; snapshots are full rows
+  or fetched with `_run_rows_for_ids`, including session teardown writes.
+- `core/inbox_events.py::publish_run_updated` delegates to `run_updated_payload`;
+  there are no other direct callers. Add optional timestamp passthrough here.
+- `core/internal_server.py` relays the supplied event without projecting it.
+  `vibe/ui_server.py::_archive_publish_run_updates` sends a session invalidation,
+  not a terminal run status. `core/runtime_work.py` consumes the event.
+
+Normalize status once in the shared row publisher, then pass each stored timestamp
+only when that status belongs to `TERMINAL_RUN_STATUSES`. Keep existing local bus
+and controller bridge behavior unchanged, with no new reads or fabricated dates.
+
+## Verification
+
+- [x] Optional payload timestamps are preserved independently or omitted.
+- [x] Every existing status alias preserves the non-terminal payload or adds only
+  available terminal timestamps; the local bus and controller bridge agree.
+- [x] Real persisted lifecycle events carry durable stamps across execution run
+  types, watch-runtime rows, and an unknown future type. Completion differs from
+  update time so the contract cannot silently regress to receipt/update timing.
+- [x] List/detail projection and the HTTP detail endpoint expose stored timestamps,
+  including nulls for incomplete history.
+- [x] Focused Python tests and changed-file Ruff pass (190 tests across inbox
+  events, Harness run projection, and the FastAPI UI server).
+
+Delivery gates: exact-head Codex review, zero unresolved threads, and green CI.
+Track those changing remote gates on the PR rather than in this source snapshot.
+
+Native notification behavior remains for the Rust consumer lane and the
+orchestrator's integration verification. The consumer declares `requires #<PR>`
+for this producer PR; neither lane merges itself.

--- a/storage/background.py
+++ b/storage/background.py
@@ -2005,13 +2005,16 @@ def _publish_run_rows_updated(rows: list[Any]) -> None:
         if not run_id:
             continue
         try:
+            status = normalize_run_status(row.get("status"))
             payload = run_updated_payload(
                 run_id=run_id,
-                status=normalize_run_status(row.get("status")),
+                status=status,
                 run_type=row.get("run_type"),
                 session_id=row.get("session_id"),
                 definition_id=row.get("definition_id"),
                 updated_at=row.get("updated_at"),
+                started_at=row.get("started_at") if status in TERMINAL_RUN_STATUSES else None,
+                completed_at=row.get("completed_at") if status in TERMINAL_RUN_STATUSES else None,
                 cancel_requested=bool(row.get("cancel_requested")),
             )
             bus.publish(RUNS_UPDATED_EVENT, payload)

--- a/tests/test_harness_run_projection.py
+++ b/tests/test_harness_run_projection.py
@@ -275,15 +275,27 @@ def test_get_run_enriches_identically_to_the_list(tmp_path: Path) -> None:
             }
         )
         store.enqueue_run(
-            _run("run_detail", run_type="watch", definition_id="watch_detail", session_id=session_id)
+            _run(
+                "run_detail",
+                run_type="watch",
+                definition_id="watch_detail",
+                session_id=session_id,
+                started_at="2026-07-25T23:59:20Z",
+                completed_at=NOW,
+            )
         )
         listed = store.list_runs_page(page_request=None).items[0]
         detail = store.get_run("run_detail")
     finally:
         store.close()
 
-    projected = ("session_title", "session_label", "session_is_workbench", "definition_name", "definition_kind")
+    projected = (
+        "session_title", "session_label", "session_is_workbench", "definition_name", "definition_kind",
+        "started_at", "completed_at",
+    )
     assert {key: detail[key] for key in projected} == {key: listed[key] for key in projected}
+    assert detail["started_at"] == "2026-07-25T23:59:20Z"
+    assert detail["completed_at"] == NOW
 
 
 def test_run_enrichment_is_batched(tmp_path: Path) -> None:

--- a/tests/test_inbox_events.py
+++ b/tests/test_inbox_events.py
@@ -24,6 +24,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from core.inbox_events import InboxEventBus
+from storage.background import EXECUTION_RUN_TYPES, RUN_STATUS_ALIASES, TERMINAL_RUN_STATUSES
 
 
 def test_publish_delivers_to_subscriber():
@@ -106,7 +107,64 @@ def test_synchronous_callback_failure_does_not_break_queue_delivery():
     assert asyncio.run(scenario()) == ("turn.end", {"session_id": "s1"})
 
 
-def test_sqlite_background_store_publishes_run_updates(tmp_path):
+@pytest.mark.parametrize("started_at", [None, "2026-07-04T00:00:01+00:00"])
+@pytest.mark.parametrize("completed_at", [None, "2026-07-04T00:00:02+00:00"])
+def test_run_updated_publisher_preserves_available_timestamps(monkeypatch, started_at, completed_at):
+    from core import inbox_events
+
+    published = []
+    monkeypatch.setattr(inbox_events.bus, "publish", lambda *event: published.append(event))
+    inbox_events.publish_run_updated(
+        run_id="run_stamps",
+        status="succeeded",
+        started_at=started_at,
+        completed_at=completed_at,
+    )
+
+    expected = {"run_id": "run_stamps", "status": "succeeded"}
+    expected.update(
+        (key, value)
+        for key, value in {"started_at": started_at, "completed_at": completed_at}.items()
+        if value is not None
+    )
+    assert published == [(inbox_events.RUNS_UPDATED_EVENT, expected)]
+
+
+@pytest.mark.parametrize("stored_status, status", RUN_STATUS_ALIASES.items())
+@pytest.mark.parametrize("started_at", [None, "2026-07-04T00:00:01+00:00"])
+@pytest.mark.parametrize("completed_at", [None, "2026-07-04T00:00:02+00:00"])
+def test_run_row_events_only_add_available_terminal_timestamps(
+    monkeypatch, stored_status, status, started_at, completed_at
+):
+    from core import inbox_events
+    from storage.background import _publish_run_rows_updated
+
+    published = []
+    bridged = []
+    monkeypatch.setattr(inbox_events, "_CONTROLLER_PROCESS", False)
+    monkeypatch.setattr(inbox_events.bus, "publish", lambda *event: published.append(event))
+    monkeypatch.setattr(
+        "vibe.internal_client.publish_event_sync",
+        lambda event_type, data, **kwargs: bridged.append((event_type, data)),
+    )
+    _publish_run_rows_updated(
+        [{"id": "run_stamps", "status": stored_status, "started_at": started_at, "completed_at": completed_at}]
+    )
+
+    expected = {"run_id": "run_stamps", "status": status, "cancel_requested": False}
+    if status in TERMINAL_RUN_STATUSES:
+        expected.update(
+            (key, value)
+            for key, value in {"started_at": started_at, "completed_at": completed_at}.items()
+            if value is not None
+        )
+    assert published == [(inbox_events.RUNS_UPDATED_EVENT, expected)]
+    assert bridged == published
+
+
+@pytest.mark.parametrize("terminal_status", sorted(TERMINAL_RUN_STATUSES))
+@pytest.mark.parametrize("run_type", sorted(EXECUTION_RUN_TYPES | {"watch_runtime", "future_run_type"}))
+def test_sqlite_background_store_publishes_run_updates(tmp_path, run_type, terminal_status):
     async def scenario():
         from core import inbox_events
         from storage.background import SQLiteBackgroundTaskStore
@@ -117,7 +175,7 @@ def test_sqlite_background_store_publishes_run_updates(tmp_path):
             store.enqueue_run(
                 {
                     "id": "run_evt_1",
-                    "request_type": "agent_run",
+                    "request_type": run_type,
                     "status": "queued",
                     "message": "hello",
                     "created_at": "2026-07-04T00:00:00+00:00",
@@ -133,35 +191,44 @@ def test_sqlite_background_store_publishes_run_updates(tmp_path):
 
             store.update_run_status(
                 "run_evt_1",
-                status="failed",
-                updated_at="2026-07-04T00:00:02+00:00",
+                status=terminal_status,
+                updated_at="2026-07-04T00:01:02+00:00",
                 completed_at="2026-07-04T00:00:02+00:00",
-                error="boom",
             )
-            failed = await asyncio.wait_for(queue.get(), timeout=1.0)
-            return queued, running, failed
+            terminal = await asyncio.wait_for(queue.get(), timeout=1.0)
+            return queued, running, terminal, store.get_run("run_evt_1")
         finally:
             store.close()
             inbox_events.bus.unsubscribe(sub_id)
 
-    queued, running, failed = asyncio.run(scenario())
+    queued, running, terminal, persisted = asyncio.run(scenario())
     assert queued == (
         "runs.updated",
         {
             "run_id": "run_evt_1",
             "status": "queued",
-            "run_type": "agent_run",
+            "run_type": run_type,
             "session_id": "ses_evt",
             "updated_at": "2026-07-04T00:00:00+00:00",
             "cancel_requested": False,
         },
     )
-    assert running[0] == "runs.updated"
-    assert running[1]["run_id"] == "run_evt_1"
-    assert running[1]["status"] == "running"
-    assert failed[0] == "runs.updated"
-    assert failed[1]["run_id"] == "run_evt_1"
-    assert failed[1]["status"] == "failed"
+    assert running == (
+        "runs.updated",
+        {**queued[1], "status": "running", "updated_at": "2026-07-04T00:00:01+00:00"},
+    )
+    assert persisted["started_at"] == "2026-07-04T00:00:01+00:00"
+    assert persisted["completed_at"] == "2026-07-04T00:00:02+00:00"
+    assert terminal == (
+        "runs.updated",
+        {
+            **queued[1],
+            "status": terminal_status,
+            "started_at": persisted["started_at"],
+            "completed_at": persisted["completed_at"],
+            "updated_at": "2026-07-04T00:01:02+00:00",
+        },
+    )
 
 
 def test_hfr_156_sqlite_commit_bridges_run_update_to_controller(tmp_path, monkeypatch):

--- a/tests/test_ui_server_fastapi.py
+++ b/tests/test_ui_server_fastapi.py
@@ -1151,6 +1151,37 @@ def test_normalize_response_supports_body_headers_tuple():
     assert response.body == b"ok"
 
 
+@pytest.mark.parametrize("started_at", [None, "2026-07-04T00:00:01+00:00"])
+@pytest.mark.parametrize("completed_at", [None, "2026-07-04T00:00:02+00:00"])
+def test_harness_run_detail_preserves_stored_duration_timestamps(started_at, completed_at):
+    from storage.background import SQLiteBackgroundTaskStore
+
+    ensure_sqlite_state()
+    store = SQLiteBackgroundTaskStore()
+    try:
+        store.enqueue_run(
+            {
+                "id": "run-duration",
+                "run_type": "agent_run",
+                "status": "succeeded",
+                "created_at": "2026-07-04T00:00:00+00:00",
+                "updated_at": "2026-07-04T00:01:02+00:00",
+                "started_at": started_at,
+                "completed_at": completed_at,
+            }
+        )
+    finally:
+        store.close()
+
+    response = app.test_client().get("/api/harness/runs/run-duration")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["ok"] is True
+    assert payload["run"]["started_at"] == started_at
+    assert payload["run"]["completed_at"] == completed_at
+
+
 def test_harness_routes_page_filter_and_return_counts(monkeypatch, tmp_path):
     from storage.background import SQLiteBackgroundTaskStore
 


### PR DESCRIPTION
## Capability and contract

Terminal `runs.updated` events carry the run row's durable ISO-8601 `started_at` and `completed_at` when available, so the desktop consumer can apply its frozen 30-second rule without using receipt time.

Authoritative contract: `docs/plans/desktop-notifications-sse.md`, sections **"Background" for run.terminal** and **Python changes in v1**. Producer inventory and verification notes: `docs/plans/desktop-run-terminal-timestamps.md`.

## Scope

- Add optional timestamp passthrough to `run_updated_payload`.
- Populate timestamps at the shared row publisher only for normalized terminal statuses; this covers direct and deferred terminalization paths without new database reads.
- Verify that the existing Harness detail endpoint and list/detail projections expose durable timestamps; no endpoint change was needed.
- Preserve non-terminal payloads, event names, SSE transport, and the control-plane/data-location boundaries. No `desktop/**` or `visibility` changes.

## Evidence

- Regression-first: new timestamp assertions fail before the producer change and pass afterward.
- Unit/contract: 190 tests passed across `test_inbox_events.py`, `test_harness_run_projection.py`, and `test_ui_server_fastapi.py`.
- Invariants cover every existing status alias, execution run types plus watch-runtime and a future type, independent missing stamps, local-bus/controller-bridge agreement, and durable completion distinct from later update time.
- HTTP: the real test-client request to `GET /api/harness/runs/<run_id>` preserves stored timestamps, including nulls.
- Related scenario: **HFR-156**, committed run updates bridge to the controller; existing scenario checks remain included.
- Changed-file Ruff and whitespace checks passed.
- Expanded runtime/bridge/terminalization verification: 803 additional tests passed (993 total local tests). CI and exact-head Codex review remain delivery gates.

## Dependencies and residual integration

The Rust notification consumer lane depends on this producer PR and must declare `requires #1982` in its PR body. This PR targets **desktop**, not master, and is not stacked on the consumer.

Native notification behavior and the cross-lane end-to-end acceptance are deferred to the Rust lane and the orchestrator's integration pass. No local service restart or live user-state mutation was used for verification. Never merge from this lane.

## Known by design

- Missing durable timestamps remain missing: the shell refetches once and fails closed under the frozen contract. The producer never invents a start/completion date or substitutes receipt time.
- Session-archive invalidations without a run status remain invalidations, not synthesized terminal run events.


