### PR TITLE
feat(desktop): native notifications from Workbench SSE

### DIFF
--- a/desktop/Cargo.lock
+++ b/desktop/Cargo.lock
@@ -248,6 +248,7 @@ dependencies = [
  "tauri-plugin-autostart",
  "tauri-plugin-deep-link",
  "tauri-plugin-dialog",
+ "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tauri-plugin-single-instance",
  "tauri-plugin-window-state",
@@ -260,6 +261,7 @@ name = "avibe-runtime-host"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "chrono",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -2054,6 +2056,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca"
+dependencies = [
+ "cc",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "time",
+ "uuid",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2156,6 +2172,20 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "notify-rust"
+version = "4.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
+]
 
 [[package]]
 name = "num-conv"
@@ -2638,6 +2668,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2734,6 +2773,35 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "raw-window-handle"
@@ -3720,6 +3788,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-notification"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad2fd40946aef810c4be9fd33a2d1b9b397cb79042b2d21c81a0a8f204354fd1"
+dependencies = [
+ "log",
+ "notify-rust",
+ "rand",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.19",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3870,6 +3957,17 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 1.1.3+spec-1.1.0",
+]
+
+[[package]]
+name = "tauri-winrt-notification"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed071c670382e85fc2f48ae706492d8c338f4f89bf72520d32f8abfe880aade"
+dependencies = [
+ "thiserror 2.0.19",
+ "windows",
+ "windows-version",
 ]
 
 [[package]]
@@ -5254,6 +5352,26 @@ dependencies = [
  "serde",
  "winnow 1.0.4",
  "zvariant",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d35102a9f36d089ccae9e4c6802bc118be4487b80aaffc0ab4e0cf5ce92d2873"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c01f5ab44258da43cf276c74a2763db2ff3969c9c652c3f2de07041d0b2bc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -263,6 +263,19 @@ the window and the mark in the Dock are the same file and cannot drift apart.
 Vite fingerprints it into `dist/assets/`; nothing depends on the icon path at
 runtime.
 
+## Notifications
+
+The native tray's Notifications toggle is on by default and persists across
+app restarts. While the main window is unfocused or hidden, the shell consumes
+the existing Workbench SSE stream for pending Vault approvals and qualifying
+terminal background runs. The connection belongs to the shell, not the WebView;
+SSE reconnection is independent of the readiness monitor. Copy comes only from
+the native locale catalog, and no notification capability is granted to web
+content. OS notification permissions and Do Not Disturb remain OS-managed.
+v1 uses OS-default notification activation; explicit cross-platform show/focus
+and session deep-link targets require follow-up work. See
+`../docs/plans/desktop-notifications-sse.md` for the frozen contract.
+
 ## CI
 
 `.github/workflows/desktop-shell.yml` runs on macOS and Windows whenever

--- a/desktop/runtime-host/Cargo.toml
+++ b/desktop/runtime-host/Cargo.toml
@@ -8,6 +8,7 @@ publish.workspace = true
 
 [dependencies]
 async-trait.workspace = true
+chrono = { version = "0.4", default-features = false, features = ["std"] }
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/desktop/runtime-host/src/lib.rs
+++ b/desktop/runtime-host/src/lib.rs
@@ -24,6 +24,7 @@ pub mod bootstrap;
 pub mod deep_link;
 pub mod health;
 pub mod launcher;
+pub mod notifications;
 pub mod origin;
 pub mod private_runtime;
 pub mod status;

--- a/desktop/runtime-host/src/notifications.rs
+++ b/desktop/runtime-host/src/notifications.rs
@@ -1,0 +1,489 @@
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use chrono::DateTime;
+use serde::Deserialize;
+use tokio::time::Instant;
+use url::Url;
+
+use crate::LoopbackOrigin;
+
+pub const RETAINED_KEYS: usize = 512;
+pub const RETENTION: Duration = Duration::from_secs(24 * 60 * 60);
+const MAX_EVENT_BYTES: usize = 64 * 1024;
+const MAX_DETAIL_BYTES: usize = 256 * 1024;
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+const STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(45);
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct SseFrame {
+    pub event: String,
+    pub data: String,
+}
+
+#[derive(Default)]
+pub struct SseDecoder {
+    line: Vec<u8>,
+    event: String,
+    data: String,
+    skip_lf: bool,
+    started: bool,
+    bytes: usize,
+    discarded: bool,
+    line_has_bytes: bool,
+}
+
+impl SseDecoder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn push(&mut self, chunk: &[u8]) -> Vec<SseFrame> {
+        let mut frames = Vec::new();
+        for byte in chunk {
+            if self.skip_lf && *byte == b'\n' {
+                self.skip_lf = false;
+                continue;
+            }
+            self.skip_lf = *byte == b'\r';
+            if matches!(byte, b'\r' | b'\n') {
+                self.finish_line(&mut frames);
+            } else {
+                self.line_has_bytes = true;
+                if self.bytes < MAX_EVENT_BYTES {
+                    self.line.push(*byte);
+                    self.bytes += 1;
+                } else {
+                    self.discarded = true;
+                }
+            }
+        }
+        frames
+    }
+
+    fn finish_line(&mut self, frames: &mut Vec<SseFrame>) {
+        if !std::mem::replace(&mut self.line_has_bytes, false) {
+            if !self.discarded && !self.data.is_empty() {
+                self.data.pop();
+                frames.push(SseFrame {
+                    event: std::mem::take(&mut self.event),
+                    data: std::mem::take(&mut self.data),
+                });
+            }
+            self.event.clear();
+            self.data.clear();
+            self.bytes = 0;
+            self.discarded = false;
+            return;
+        }
+        let line = std::mem::take(&mut self.line);
+        let Ok(line) = std::str::from_utf8(&line) else {
+            self.discarded = true;
+            return;
+        };
+        let line = if !std::mem::replace(&mut self.started, true) {
+            line.strip_prefix('\u{feff}').unwrap_or(line)
+        } else {
+            line
+        };
+        if self.discarded || line.starts_with(':') {
+            return;
+        }
+        let (field, value) = line.split_once(':').unwrap_or((line, ""));
+        let value = value.strip_prefix(' ').unwrap_or(value);
+        match field {
+            "event" => self.event = value.to_owned(),
+            "data" => {
+                self.data.push_str(value);
+                self.data.push('\n');
+            }
+            _ => {}
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum NotificationIntent {
+    ApprovalRequested,
+    RunSucceeded,
+    RunFailed,
+    RunCanceled,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct NotificationGate {
+    pub enabled: bool,
+    pub focused: bool,
+    pub visible: bool,
+}
+
+impl NotificationGate {
+    pub fn allows(self) -> bool {
+        self.enabled && !(self.focused && self.visible)
+    }
+}
+
+pub trait NotificationSink: Send + Sync {
+    fn gate(&self) -> NotificationGate;
+    fn deliver(&self, intent: NotificationIntent);
+}
+
+#[derive(Default)]
+struct RetainedKeys(VecDeque<(String, Instant)>);
+
+impl RetainedKeys {
+    fn insert(&mut self, key: &str, now: Instant) -> bool {
+        self.0.retain(|(_, inserted)| now.duration_since(*inserted) < RETENTION);
+        if let Some(index) = self.0.iter().position(|(retained, _)| retained == key) {
+            let retained = self.0.remove(index).expect("the retained key exists");
+            self.0.push_back(retained);
+            return false;
+        }
+        if self.0.len() == RETAINED_KEYS {
+            self.0.pop_front();
+        }
+        self.0.push_back((key.to_owned(), now));
+        true
+    }
+
+    fn remove(&mut self, key: &str) {
+        self.0.retain(|(retained, _)| retained != key);
+    }
+}
+
+#[derive(Default)]
+pub struct NotificationFilter {
+    approvals: RetainedKeys,
+    runs: RetainedKeys,
+}
+
+#[derive(Deserialize)]
+struct Envelope {
+    #[serde(rename = "type")]
+    event: String,
+    data: serde_json::Value,
+}
+
+#[derive(Deserialize)]
+struct Approval {
+    request_id: String,
+    request_status: String,
+}
+
+#[derive(Clone, Default, Deserialize)]
+pub struct RunTimestamps {
+    pub started_at: Option<String>,
+    pub completed_at: Option<String>,
+    pub updated_at: Option<String>,
+}
+
+impl RunTimestamps {
+    fn completion(&self) -> Option<&str> {
+        self.completed_at.as_deref().or(self.updated_at.as_deref())
+    }
+
+    fn missing(&self) -> bool {
+        self.started_at.is_none() || self.completion().is_none()
+    }
+
+    fn is_long_running(&self) -> bool {
+        let duration = self
+            .started_at
+            .as_deref()
+            .zip(self.completion())
+            .and_then(|(start, end)| {
+                let start = DateTime::parse_from_rfc3339(start).ok()?;
+                let end = DateTime::parse_from_rfc3339(end).ok()?;
+                Some(end.signed_duration_since(start))
+            });
+        duration.is_some_and(|duration| duration >= chrono::Duration::seconds(30))
+    }
+
+    fn fill_missing(&mut self, other: Self) {
+        if self.started_at.is_none() {
+            self.started_at = other.started_at;
+        }
+        if self.completion().is_none() {
+            self.completed_at = other.completed_at;
+            self.updated_at = other.updated_at;
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct RunEvent {
+    run_id: String,
+    status: String,
+    run_type: Option<String>,
+    #[serde(flatten)]
+    stamps: RunTimestamps,
+}
+
+enum Candidate {
+    Ready(NotificationIntent),
+    Refetch {
+        run_id: String,
+        stamps: RunTimestamps,
+        intent: NotificationIntent,
+    },
+}
+
+impl NotificationFilter {
+    fn consider(&mut self, frame: SseFrame, now: Instant) -> Option<Candidate> {
+        if !matches!(frame.event.as_str(), "vaults.updated" | "runs.updated") {
+            return None;
+        }
+        let envelope: Envelope = serde_json::from_str(&frame.data).ok()?;
+        if envelope.event != frame.event {
+            return None;
+        }
+        if frame.event == "vaults.updated" {
+            let approval: Approval = serde_json::from_value(envelope.data).ok()?;
+            if approval.request_id.is_empty() {
+                return None;
+            }
+            if approval.request_status != "pending" {
+                self.approvals.remove(&approval.request_id);
+                return None;
+            }
+            return self
+                .approvals
+                .insert(&approval.request_id, now)
+                .then_some(Candidate::Ready(NotificationIntent::ApprovalRequested));
+        }
+        let run: RunEvent = serde_json::from_value(envelope.data).ok()?;
+        if run.run_id.is_empty() {
+            return None;
+        }
+        let intent = match run.status.as_str() {
+            "succeeded" => NotificationIntent::RunSucceeded,
+            "failed" => NotificationIntent::RunFailed,
+            "canceled" => NotificationIntent::RunCanceled,
+            _ => return None,
+        };
+        if !self.runs.insert(&run.run_id, now) {
+            return None;
+        }
+        if matches!(run.run_type.as_deref(), Some("scheduled" | "watch")) || run.stamps.is_long_running() {
+            return Some(Candidate::Ready(intent));
+        }
+        run.stamps.missing().then_some(Candidate::Refetch {
+            run_id: run.run_id,
+            stamps: run.stamps,
+            intent,
+        })
+    }
+}
+
+#[async_trait]
+pub trait EventStream: Send {
+    async fn next_chunk(&mut self) -> Result<Option<Vec<u8>>, StreamError>;
+}
+
+#[derive(Debug)]
+pub struct StreamError;
+
+#[async_trait]
+pub trait NotificationTransport: Send + Sync {
+    async fn connect(&self) -> Result<Box<dyn EventStream>, StreamError>;
+    async fn run_timestamps(&self, run_id: &str) -> Option<RunTimestamps>;
+}
+
+pub struct HttpNotificationTransport {
+    client: reqwest::Client,
+    origin: LoopbackOrigin,
+}
+
+impl HttpNotificationTransport {
+    pub fn new(origin: LoopbackOrigin) -> Result<Self, reqwest::Error> {
+        Ok(Self {
+            client: reqwest::Client::builder()
+                .connect_timeout(REQUEST_TIMEOUT)
+                .redirect(reqwest::redirect::Policy::none())
+                .no_proxy()
+                .build()?,
+            origin,
+        })
+    }
+
+    fn url(&self, path: &str) -> Url {
+        Url::parse(&format!("{}{path}", self.origin.as_str())).expect("the Runtime origin is validated")
+    }
+}
+
+struct HttpEventStream(reqwest::Response);
+
+#[async_trait]
+impl EventStream for HttpEventStream {
+    async fn next_chunk(&mut self) -> Result<Option<Vec<u8>>, StreamError> {
+        self.0
+            .chunk()
+            .await
+            .map(|chunk| chunk.map(|chunk| chunk.to_vec()))
+            .map_err(|_| StreamError)
+    }
+}
+
+#[async_trait]
+impl NotificationTransport for HttpNotificationTransport {
+    async fn connect(&self) -> Result<Box<dyn EventStream>, StreamError> {
+        let response = tokio::time::timeout(
+            REQUEST_TIMEOUT,
+            self.client
+                .get(self.url("/api/events"))
+                .header("Accept", "text/event-stream")
+                .send(),
+        )
+        .await
+        .map_err(|_| StreamError)?
+        .map_err(|_| StreamError)?;
+        let content_type = response
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok());
+        if response.status() != reqwest::StatusCode::OK
+            || !content_type.is_some_and(|value| {
+                value
+                    .split(';')
+                    .next()
+                    .is_some_and(|mime| mime.trim() == "text/event-stream")
+            })
+        {
+            return Err(StreamError);
+        }
+        Ok(Box::new(HttpEventStream(response)))
+    }
+
+    async fn run_timestamps(&self, run_id: &str) -> Option<RunTimestamps> {
+        if matches!(run_id, "" | "." | "..") {
+            return None;
+        }
+        let mut url = self.url("/api/harness/runs/");
+        url.path_segments_mut().ok()?.pop_if_empty().push(run_id);
+        let response = self.client.get(url).timeout(REQUEST_TIMEOUT).send().await.ok()?;
+        if !response.status().is_success() {
+            return None;
+        }
+        let bytes = bounded_detail_body(response).await?;
+        let detail: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+        if !detail.get("ok")?.as_bool()? || detail.get("run")?.get("id")?.as_str()? != run_id {
+            return None;
+        }
+        serde_json::from_value(detail.get("run")?.clone()).ok()
+    }
+}
+
+async fn bounded_detail_body(mut response: reqwest::Response) -> Option<Vec<u8>> {
+    if response
+        .content_length()
+        .is_some_and(|size| size > MAX_DETAIL_BYTES as u64)
+    {
+        return None;
+    }
+    let mut body = Vec::new();
+    while let Some(chunk) = response.chunk().await.ok()? {
+        if chunk.len() > MAX_DETAIL_BYTES.saturating_sub(body.len()) {
+            return None;
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Some(body)
+}
+
+#[derive(Default)]
+pub struct ReconnectBackoff {
+    failures: u32,
+}
+
+impl ReconnectBackoff {
+    pub fn next_delay(&mut self) -> Duration {
+        let delay = Duration::from_secs(1u64 << self.failures.min(5)).min(Duration::from_secs(30));
+        self.failures = self.failures.saturating_add(1);
+        delay
+    }
+
+    pub fn reset(&mut self) {
+        self.failures = 0;
+    }
+}
+
+pub async fn run_notifications(
+    transport: &dyn NotificationTransport,
+    filter: Arc<Mutex<NotificationFilter>>,
+    sink: &dyn NotificationSink,
+) {
+    let mut backoff = ReconnectBackoff::default();
+    loop {
+        let connected_at = Instant::now();
+        if let Ok(mut stream) = transport.connect().await {
+            let mut decoder = SseDecoder::new();
+            while let Ok(Ok(Some(chunk))) = tokio::time::timeout(STREAM_IDLE_TIMEOUT, stream.next_chunk()).await {
+                if Instant::now().duration_since(connected_at) >= STREAM_IDLE_TIMEOUT {
+                    backoff.reset();
+                }
+                let allowed_at_receipt = sink.gate().allows();
+                let candidates = decoder
+                    .push(&chunk)
+                    .into_iter()
+                    .filter_map(|frame| {
+                        filter
+                            .lock()
+                            .ok()
+                            .and_then(|mut filter| filter.consider(frame, Instant::now()))
+                    })
+                    .collect::<Vec<_>>();
+                for candidate in candidates.into_iter().filter(|_| allowed_at_receipt) {
+                    let intent = match candidate {
+                        Candidate::Ready(intent) => Some(intent),
+                        Candidate::Refetch {
+                            run_id,
+                            mut stamps,
+                            intent,
+                        } => {
+                            if !sink.gate().allows() {
+                                continue;
+                            }
+                            if let Ok(Some(detail)) =
+                                tokio::time::timeout(REQUEST_TIMEOUT, transport.run_timestamps(&run_id)).await
+                            {
+                                stamps.fill_missing(detail);
+                            }
+                            stamps.is_long_running().then_some(intent)
+                        }
+                    };
+                    if let Some(intent) = intent.filter(|_| sink.gate().allows()) {
+                        sink.deliver(intent);
+                    }
+                }
+            }
+        }
+        tokio::time::sleep(backoff.next_delay()).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test(start_paused = true)]
+    async fn both_retained_sets_are_bounded_by_size_and_age_even_without_transition_events() {
+        for keys in [
+            &mut NotificationFilter::default().approvals,
+            &mut NotificationFilter::default().runs,
+        ] {
+            let created = Instant::now();
+            for index in 0..RETAINED_KEYS * 3 {
+                assert!(keys.insert(&index.to_string(), created));
+                assert!(keys.0.len() <= RETAINED_KEYS);
+            }
+            assert_eq!(keys.0.len(), RETAINED_KEYS);
+            assert!(keys.insert("0", created));
+            assert!(!keys.insert("0", created));
+            tokio::time::advance(RETENTION).await;
+            assert!(keys.insert("0", Instant::now()));
+            assert_eq!(keys.0.len(), 1);
+        }
+    }
+}

--- a/desktop/runtime-host/tests/notification_http.rs
+++ b/desktop/runtime-host/tests/notification_http.rs
@@ -1,0 +1,213 @@
+use std::collections::VecDeque;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use avibe_runtime_host::notifications::{HttpNotificationTransport, NotificationTransport, SseDecoder};
+use avibe_runtime_host::LoopbackOrigin;
+use serde_json::json;
+
+struct FakeServer {
+    origin: LoopbackOrigin,
+    requests: Arc<Mutex<Vec<String>>>,
+    stopped: Arc<AtomicBool>,
+    thread: Option<std::thread::JoinHandle<()>>,
+}
+
+impl FakeServer {
+    fn start(responses: impl IntoIterator<Item = Vec<u8>>) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let origin = LoopbackOrigin::parse(&format!("http://{}", listener.local_addr().unwrap())).unwrap();
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let received = requests.clone();
+        let stopped = Arc::new(AtomicBool::new(false));
+        let stop = stopped.clone();
+        let mut responses = responses.into_iter().collect::<VecDeque<_>>();
+        let thread = std::thread::spawn(move || {
+            while !stop.load(Ordering::SeqCst) {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        stream.set_nonblocking(false).unwrap();
+                        stream.set_read_timeout(Some(Duration::from_millis(50))).unwrap();
+                        stream.set_write_timeout(Some(Duration::from_secs(1))).unwrap();
+                        let mut request = Vec::new();
+                        let deadline = Instant::now() + Duration::from_secs(3);
+                        while !request.windows(4).any(|chunk| chunk == b"\r\n\r\n") {
+                            if stop.load(Ordering::SeqCst) {
+                                return;
+                            }
+                            assert!(
+                                Instant::now() < deadline,
+                                "request headers must arrive before the deadline"
+                            );
+                            let mut buffer = [0; 1024];
+                            match stream.read(&mut buffer) {
+                                Ok(0) => panic!("request headers were truncated"),
+                                Ok(length) => request.extend_from_slice(&buffer[..length]),
+                                Err(error)
+                                    if matches!(
+                                        error.kind(),
+                                        std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                                    ) =>
+                                {
+                                    continue
+                                }
+                                Err(error) => panic!("fake request failed: {error}"),
+                            }
+                            assert!(request.len() <= 16 * 1024);
+                        }
+                        received.lock().unwrap().push(String::from_utf8(request).unwrap());
+                        let response = responses.pop_front().expect("only the expected requests are allowed");
+                        let _ = stream.write_all(&response);
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(Duration::from_millis(1));
+                    }
+                    Err(error) => panic!("fake listener failed: {error}"),
+                }
+            }
+        });
+        Self {
+            origin,
+            requests,
+            stopped,
+            thread: Some(thread),
+        }
+    }
+
+    fn transport(&self) -> HttpNotificationTransport {
+        HttpNotificationTransport::new(self.origin.clone()).unwrap()
+    }
+}
+
+impl Drop for FakeServer {
+    fn drop(&mut self) {
+        self.stopped.store(true, Ordering::SeqCst);
+        if let Some(thread) = self.thread.take() {
+            let result = thread.join();
+            if !std::thread::panicking() {
+                result.expect("fake server exited cleanly");
+            }
+        }
+    }
+}
+
+fn response(status: &str, content_type: &str, body: &[u8]) -> Vec<u8> {
+    let mut response = format!(
+        "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        body.len()
+    )
+    .into_bytes();
+    response.extend_from_slice(body);
+    response
+}
+
+#[tokio::test]
+async fn production_framing_uses_only_the_adopted_origin_and_reconnect_never_sends_a_replay_cursor() {
+    let event = b": stream connected\n\nevent: connected\ndata: {}\n\n: ping\n\nid: never-replay\nevent: vaults.updated\ndata: {\"type\":\"vaults.updated\",\"data\":{\"request_id\":\"request\",\"request_status\":\"pending\"}}\n\n";
+    let server = FakeServer::start([
+        response("200 OK", "text/event-stream; charset=utf-8", event),
+        response("200 OK", "text/event-stream", b": stream connected\n\n"),
+    ]);
+    let transport = server.transport();
+    let mut first = transport.connect().await.unwrap();
+    let mut decoder = SseDecoder::new();
+    let mut frames = Vec::new();
+    while let Some(chunk) = first.next_chunk().await.unwrap() {
+        frames.extend(decoder.push(&chunk));
+    }
+    assert_eq!(frames.len(), 2);
+    assert_eq!(frames[1].event, "vaults.updated");
+    let mut second = transport.connect().await.unwrap();
+    while second.next_chunk().await.unwrap().is_some() {}
+    let requests = server.requests.lock().unwrap();
+    assert_eq!(requests.len(), 2);
+    for request in requests.iter() {
+        let normalized = request.to_ascii_lowercase();
+        assert!(request.starts_with("GET /api/events HTTP/1.1\r\n"));
+        assert!(normalized.contains("accept: text/event-stream\r\n"));
+        for forbidden in ["last-event-id:", "authorization:", "cookie:"] {
+            assert!(!normalized.contains(forbidden));
+        }
+    }
+}
+
+#[tokio::test]
+async fn stream_and_detail_redirects_never_delegate_trust_to_another_origin() {
+    let target = FakeServer::start([]);
+    let redirect = format!(
+        "HTTP/1.1 302 Found\r\nLocation: {}/api/events\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        target.origin.as_str()
+    )
+    .into_bytes();
+    let server = FakeServer::start([redirect.clone(), redirect]);
+    let transport = server.transport();
+    assert!(transport.connect().await.is_err());
+    assert!(transport.run_timestamps("run").await.is_none());
+    assert!(target.requests.lock().unwrap().is_empty());
+    assert_eq!(server.requests.lock().unwrap().len(), 2);
+}
+
+#[tokio::test]
+async fn stream_requires_a_successful_sse_response_not_an_arbitrary_live_http_endpoint() {
+    let server = FakeServer::start([
+        response("200 OK", "text/html", b"<html>not SSE</html>"),
+        response("503 Unavailable", "text/event-stream", b": unavailable\n\n"),
+        response("204 No Content", "text/event-stream", b""),
+    ]);
+    for _ in 0..3 {
+        assert!(server.transport().connect().await.is_err());
+    }
+}
+
+#[tokio::test]
+async fn refetch_requires_the_requested_run_and_bounds_untrusted_detail_bodies() {
+    let valid = json!({"ok": true, "run": {
+        "id": "run", "started_at": "2026-09-10T12:00:00Z", "updated_at": "2026-09-10T12:00:30Z",
+    }});
+    let server = FakeServer::start([
+        response("200 OK", "application/json", valid.to_string().as_bytes()),
+        response(
+            "200 OK",
+            "application/json",
+            json!({"ok": true, "run": {"id": "another"}}).to_string().as_bytes(),
+        ),
+        response("404 Not Found", "application/json", b"{}"),
+        response("200 OK", "application/json", b"not-json"),
+        response("200 OK", "application/json", &vec![b'x'; 256 * 1024 + 1]),
+        b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 999999999\r\nConnection: close\r\n\r\n"
+            .to_vec(),
+    ]);
+    let transport = server.transport();
+    let detail = transport.run_timestamps("run").await.unwrap();
+    assert_eq!(detail.started_at, Some("2026-09-10T12:00:00Z".into()));
+    assert_eq!(detail.updated_at, Some("2026-09-10T12:00:30Z".into()));
+    for _ in 0..5 {
+        assert!(transport.run_timestamps("run").await.is_none());
+    }
+    for request in server.requests.lock().unwrap().iter() {
+        assert!(request.starts_with("GET /api/harness/runs/run HTTP/1.1\r\n"));
+    }
+}
+
+#[tokio::test]
+async fn identifiers_are_encoded_as_one_path_segment_not_runtime_selected_routes() {
+    let server = FakeServer::start([response("404 Not Found", "application/json", b"{}")]);
+    let transport = server.transport();
+    for key in ["", ".", ".."] {
+        assert!(transport.run_timestamps(key).await.is_none());
+    }
+    assert!(server.requests.lock().unwrap().is_empty());
+    assert!(transport
+        .run_timestamps("../settings?token=secret#片段")
+        .await
+        .is_none());
+    let requests = server.requests.lock().unwrap();
+    assert_eq!(requests.len(), 1);
+    assert!(
+        requests[0].starts_with("GET /api/harness/runs/..%2Fsettings%3Ftoken=secret%23%E7%89%87%E6%AE%B5 HTTP/1.1\r\n")
+    );
+}

--- a/desktop/runtime-host/tests/notifications.rs
+++ b/desktop/runtime-host/tests/notifications.rs
@@ -1,0 +1,580 @@
+use std::collections::{HashMap, VecDeque};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use avibe_runtime_host::notifications::{
+    run_notifications, EventStream, NotificationFilter, NotificationGate, NotificationIntent, NotificationSink,
+    NotificationTransport, ReconnectBackoff, RunTimestamps, SseDecoder, StreamError, RETAINED_KEYS, RETENTION,
+};
+use serde_json::{json, Value};
+use tokio::time::Instant;
+
+struct FakeStream {
+    chunks: VecDeque<Vec<u8>>,
+    drop_after: bool,
+}
+
+#[async_trait]
+impl EventStream for FakeStream {
+    async fn next_chunk(&mut self) -> Result<Option<Vec<u8>>, StreamError> {
+        if let Some(chunk) = self.chunks.pop_front() {
+            return Ok(Some(chunk));
+        }
+        if self.drop_after {
+            Ok(None)
+        } else {
+            std::future::pending().await
+        }
+    }
+}
+
+#[derive(Default)]
+struct FakeTransport {
+    streams: Mutex<VecDeque<FakeStream>>,
+    connected_at: Mutex<Vec<Instant>>,
+    details: Mutex<HashMap<String, RunTimestamps>>,
+    refetched: Mutex<Vec<String>>,
+    detail_delay: Duration,
+}
+
+#[async_trait]
+impl NotificationTransport for FakeTransport {
+    async fn connect(&self) -> Result<Box<dyn EventStream>, StreamError> {
+        self.connected_at.lock().unwrap().push(Instant::now());
+        self.streams
+            .lock()
+            .unwrap()
+            .pop_front()
+            .map(|stream| Box::new(stream) as Box<dyn EventStream>)
+            .ok_or(StreamError)
+    }
+
+    async fn run_timestamps(&self, run_id: &str) -> Option<RunTimestamps> {
+        self.refetched.lock().unwrap().push(run_id.to_owned());
+        tokio::time::sleep(self.detail_delay).await;
+        self.details.lock().unwrap().get(run_id).cloned()
+    }
+}
+
+impl FakeTransport {
+    fn stream(&self, frames: impl IntoIterator<Item = Vec<u8>>, drop_after: bool) {
+        self.streams.lock().unwrap().push_back(FakeStream {
+            chunks: frames.into_iter().collect(),
+            drop_after,
+        });
+    }
+}
+
+struct FakeSink {
+    enabled: AtomicBool,
+    focused: AtomicBool,
+    visible: AtomicBool,
+    delivered: Mutex<Vec<NotificationIntent>>,
+}
+
+impl Default for FakeSink {
+    fn default() -> Self {
+        Self {
+            enabled: AtomicBool::new(true),
+            focused: AtomicBool::new(false),
+            visible: AtomicBool::new(true),
+            delivered: Mutex::new(Vec::new()),
+        }
+    }
+}
+
+impl NotificationSink for FakeSink {
+    fn gate(&self) -> NotificationGate {
+        NotificationGate {
+            enabled: self.enabled.load(Ordering::SeqCst),
+            focused: self.focused.load(Ordering::SeqCst),
+            visible: self.visible.load(Ordering::SeqCst),
+        }
+    }
+
+    fn deliver(&self, intent: NotificationIntent) {
+        self.delivered.lock().unwrap().push(intent);
+    }
+}
+
+fn frame(event: &str, data: Value) -> Vec<u8> {
+    format!(
+        "event: {event}\r\ndata: {}\r\n\r\n",
+        json!({"type": event, "data": data})
+    )
+    .into_bytes()
+}
+
+fn approval(request_id: impl ToString, status: &str) -> Vec<u8> {
+    frame(
+        "vaults.updated",
+        json!({"request_id": request_id.to_string(), "request_status": status}),
+    )
+}
+
+fn run(run_id: impl ToString, run_type: &str, seconds: u64) -> Vec<u8> {
+    frame(
+        "runs.updated",
+        json!({
+            "run_id": run_id.to_string(), "run_type": run_type, "status": "succeeded",
+            "started_at": "2026-09-10T12:00:00+00:00",
+            "completed_at": format!("2026-09-10T12:{:02}:{:02}+00:00", seconds / 60, seconds % 60),
+        }),
+    )
+}
+
+fn spawn(transport: Arc<FakeTransport>, sink: Arc<FakeSink>) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        run_notifications(&*transport, Arc::new(Mutex::new(NotificationFilter::default())), &*sink).await;
+    })
+}
+
+async fn settle() {
+    for _ in 0..20 {
+        tokio::task::yield_now().await;
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn global_sse_is_an_allow_list_not_a_second_event_bus() {
+    let transport = Arc::new(FakeTransport::default());
+    let sink = Arc::new(FakeSink::default());
+    let mut chunks = vec![b": stream connected\n\nevent: connected\ndata: {}\n\n: ping\n\n".to_vec()];
+    for event in [
+        "message.new",
+        "session.activity",
+        "queue.updated",
+        "inbox.unread.changed",
+        "show.event",
+        "invented.event",
+    ] {
+        chunks.push(frame(event, json!({
+            "request_id": "approval", "request_status": "pending", "run_id": "run", "status": "succeeded", "run_type": "scheduled",
+        })));
+    }
+    chunks.extend([approval("approval", "pending"), run("run", "watch", 2)]);
+    transport.stream(chunks, false);
+    let task = spawn(transport, sink.clone());
+    settle().await;
+    assert_eq!(
+        *sink.delivered.lock().unwrap(),
+        [NotificationIntent::ApprovalRequested, NotificationIntent::RunSucceeded]
+    );
+    task.abort();
+}
+
+#[tokio::test(start_paused = true)]
+async fn approvals_reset_only_on_observed_non_pending_transitions() {
+    let transport = Arc::new(FakeTransport::default());
+    let sink = Arc::new(FakeSink::default());
+    transport.stream(
+        [
+            approval("request", "pending"),
+            approval("request", "pending"),
+            approval("request", "approved"),
+            approval("request", "pending"),
+            approval("request", "pending"),
+        ],
+        false,
+    );
+    let task = spawn(transport, sink.clone());
+    settle().await;
+    assert_eq!(
+        *sink.delivered.lock().unwrap(),
+        vec![NotificationIntent::ApprovalRequested; 2]
+    );
+    task.abort();
+}
+
+#[tokio::test(start_paused = true)]
+async fn malformed_or_mismatched_envelopes_cannot_become_attention_and_runtime_copy_is_never_forwarded() {
+    let transport = Arc::new(FakeTransport::default());
+    let sink = Arc::new(FakeSink::default());
+    let pending = json!({"request_id": "request", "request_status": "pending"});
+    transport.stream(
+        [
+            b"event: vaults.updated\ndata: not-json\n\n".to_vec(),
+            b"event: vaults.updated\ndata: {\"type\":\"runs.updated\",\"data\":{}}\n\n".to_vec(),
+            frame("vaults.updated", json!({"request_status": "pending"})),
+            frame("vaults.updated", json!({"request_id": "", "request_status": "pending"})),
+            frame(
+                "runs.updated",
+                json!({"run_id": "run", "status": "running", "run_type": "scheduled"}),
+            ),
+            frame(
+                "runs.updated",
+                json!({"run_id": "", "status": "failed", "run_type": "scheduled"}),
+            ),
+            frame("vaults.updated", pending),
+            frame(
+                "runs.updated",
+                json!({
+                    "run_id": "run", "status": "failed", "run_type": "scheduled", "session_id": "untrusted\ntext",
+                    "title": "untrusted title", "body": "untrusted body", "error": "untrusted error",
+                }),
+            ),
+        ],
+        false,
+    );
+    let task = spawn(transport, sink.clone());
+    settle().await;
+    assert_eq!(
+        *sink.delivered.lock().unwrap(),
+        [NotificationIntent::ApprovalRequested, NotificationIntent::RunFailed]
+    );
+    task.abort();
+}
+
+#[tokio::test(start_paused = true)]
+async fn refetch_timeout_is_bounded_and_cannot_block_later_attention_forever() {
+    let transport = Arc::new(FakeTransport {
+        detail_delay: Duration::from_secs(60),
+        ..FakeTransport::default()
+    });
+    let sink = Arc::new(FakeSink::default());
+    transport.stream(
+        [
+            frame("runs.updated", json!({"run_id": "run", "status": "failed"})),
+            approval("request", "pending"),
+        ],
+        false,
+    );
+    let task = spawn(transport.clone(), sink.clone());
+    settle().await;
+    tokio::time::advance(Duration::from_secs(5)).await;
+    settle().await;
+    assert_eq!(*transport.refetched.lock().unwrap(), ["run"]);
+    assert_eq!(*sink.delivered.lock().unwrap(), [NotificationIntent::ApprovalRequested]);
+    task.abort();
+}
+
+#[tokio::test(start_paused = true)]
+async fn idle_streams_reconnect_and_rejected_connections_back_off_without_bootstrap_recovery() {
+    let transport = Arc::new(FakeTransport::default());
+    let sink = Arc::new(FakeSink::default());
+    transport.stream([b": stream connected\n\n".to_vec()], false);
+    let task = spawn(transport.clone(), sink.clone());
+    settle().await;
+    tokio::time::advance(Duration::from_secs(45)).await;
+    settle().await;
+    for seconds in [1, 2, 4, 8, 16, 30, 30] {
+        let before = transport.connected_at.lock().unwrap().len();
+        tokio::time::advance(Duration::from_secs(seconds)).await;
+        settle().await;
+        assert_eq!(transport.connected_at.lock().unwrap().len(), before + 1);
+    }
+    transport.stream([approval("recovered", "pending")], false);
+    tokio::time::advance(Duration::from_secs(30)).await;
+    settle().await;
+    assert_eq!(*sink.delivered.lock().unwrap(), [NotificationIntent::ApprovalRequested]);
+    task.abort();
+}
+
+#[tokio::test(start_paused = true)]
+async fn durable_duration_not_arrival_or_attach_time_controls_all_other_run_kinds() {
+    let transport = Arc::new(FakeTransport::default());
+    let sink = Arc::new(FakeSink::default());
+    tokio::time::advance(Duration::from_secs(60)).await;
+    let mut chunks = Vec::new();
+    let mut expected = 0;
+    for kind in ["agent_run", "scheduled", "watch", "task", "foreground", "new_kind"] {
+        for seconds in [0, 2, 29, 30, 31, 90] {
+            chunks.push(run(format!("{kind}-{seconds}"), kind, seconds));
+            expected += usize::from(seconds >= 30 || matches!(kind, "scheduled" | "watch"));
+        }
+    }
+    transport.stream(chunks, false);
+    let task = spawn(transport.clone(), sink.clone());
+    settle().await;
+    assert_eq!(
+        *sink.delivered.lock().unwrap(),
+        vec![NotificationIntent::RunSucceeded; expected]
+    );
+    assert!(transport.refetched.lock().unwrap().is_empty());
+    task.abort();
+}
+
+#[tokio::test(start_paused = true)]
+async fn terminal_stamps_cover_offsets_updated_at_precision_and_fail_closed_values() {
+    let transport = Arc::new(FakeTransport::default());
+    let sink = Arc::new(FakeSink::default());
+    let cases = [
+        ("2026-09-10T20:00:00+08:00", "2026-09-10T12:00:30Z", true),
+        ("2026-09-10T12:00:00.000001Z", "2026-09-10T12:00:30Z", false),
+        ("2026-09-10T12:00:00Z", "2026-09-10T12:00:29.999999Z", false),
+        ("2026-09-10T12:00:00Z", "2026-09-10T11:59:00Z", false),
+        ("invalid", "2026-09-10T12:00:30Z", false),
+        ("2026-09-10T12:00:00Z", "invalid", false),
+    ];
+    let mut chunks = Vec::new();
+    let mut expected = 0;
+    for (index, (started, completed, long)) in cases.iter().enumerate() {
+        for stamp in ["completed_at", "updated_at"] {
+            let mut data = json!({"run_id": format!("{index}-{stamp}"), "status": "failed", "started_at": started});
+            data[stamp] = json!(completed);
+            chunks.push(frame("runs.updated", data));
+            expected += usize::from(*long);
+        }
+    }
+    chunks.push(frame(
+        "runs.updated",
+        json!({
+            "run_id": "completed-wins", "status": "succeeded", "started_at": "2026-09-10T12:00:00Z",
+            "completed_at": "2026-09-10T12:00:02Z", "updated_at": "2026-09-10T12:01:00Z",
+        }),
+    ));
+    transport.stream(chunks, false);
+    let task = spawn(transport.clone(), sink.clone());
+    settle().await;
+    assert_eq!(
+        *sink.delivered.lock().unwrap(),
+        vec![NotificationIntent::RunFailed; expected]
+    );
+    assert!(transport.refetched.lock().unwrap().is_empty());
+    task.abort();
+}
+
+#[tokio::test(start_paused = true)]
+async fn missing_stamps_refetch_once_per_retained_terminal_and_then_fail_closed() {
+    let transport = Arc::new(FakeTransport::default());
+    let sink = Arc::new(FakeSink::default());
+    let complete = RunTimestamps {
+        started_at: Some("2026-09-10T12:00:00Z".into()),
+        completed_at: Some("2026-09-10T12:00:30Z".into()),
+        ..RunTimestamps::default()
+    };
+    let mut chunks = Vec::new();
+    for (index, stamps) in [
+        complete.clone(),
+        RunTimestamps {
+            started_at: None,
+            ..complete.clone()
+        },
+        RunTimestamps {
+            completed_at: None,
+            ..complete.clone()
+        },
+        RunTimestamps::default(),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let key = index.to_string();
+        transport.details.lock().unwrap().insert(key.clone(), stamps);
+        let event = frame(
+            "runs.updated",
+            json!({"run_id": key, "status": "canceled", "run_type": "agent_run"}),
+        );
+        chunks.extend([event.clone(), event]);
+    }
+    let event = frame("runs.updated", json!({"run_id": "404", "status": "canceled"}));
+    chunks.extend([event.clone(), event]);
+    for (key, data) in [
+        ("fill-start", json!({"completed_at": "2026-09-10T12:00:30Z"})),
+        ("fill-end", json!({"started_at": "2026-09-10T12:00:00Z"})),
+    ] {
+        transport.details.lock().unwrap().insert(key.into(), complete.clone());
+        let mut data = data;
+        data["run_id"] = json!(key);
+        data["status"] = json!("canceled");
+        chunks.push(frame("runs.updated", data));
+    }
+    transport.stream(chunks, false);
+    let task = spawn(transport.clone(), sink.clone());
+    settle().await;
+    assert_eq!(
+        *sink.delivered.lock().unwrap(),
+        vec![NotificationIntent::RunCanceled; 3]
+    );
+    assert_eq!(transport.refetched.lock().unwrap().len(), 7);
+    task.abort();
+}
+
+#[tokio::test(start_paused = true)]
+async fn both_key_classes_evict_the_oldest_and_allow_it_to_notify_again() {
+    for approval_class in [true, false] {
+        let transport = Arc::new(FakeTransport::default());
+        let sink = Arc::new(FakeSink::default());
+        let event = |index| {
+            if approval_class {
+                approval(index, "pending")
+            } else {
+                run(index, "watch", 0)
+            }
+        };
+        let mut chunks = (0..=RETAINED_KEYS).map(event).collect::<Vec<_>>();
+        chunks.push(event(RETAINED_KEYS));
+        chunks.push(event(0));
+        transport.stream(chunks, false);
+        let task = spawn(transport, sink.clone());
+        settle().await;
+        assert_eq!(sink.delivered.lock().unwrap().len(), RETAINED_KEYS + 2);
+        task.abort();
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn both_key_classes_expire_after_24_hours_despite_missing_transitions() {
+    let filter = Arc::new(Mutex::new(NotificationFilter::default()));
+    let sink = Arc::new(FakeSink::default());
+    for (elapsed, expected) in [
+        (Duration::ZERO, 2),
+        (RETENTION - Duration::from_secs(1), 2),
+        (Duration::from_secs(1), 4),
+    ] {
+        tokio::time::advance(elapsed).await;
+        let transport = Arc::new(FakeTransport::default());
+        transport.stream([approval("same", "pending"), run("same", "watch", 0)], false);
+        let retained = filter.clone();
+        let output = sink.clone();
+        let task = tokio::spawn(async move { run_notifications(&*transport, retained, &*output).await });
+        settle().await;
+        assert_eq!(sink.delivered.lock().unwrap().len(), expected);
+        task.abort();
+        assert!(task.await.unwrap_err().is_cancelled());
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn gate_suppression_is_not_a_queue_or_a_disconnect() {
+    for enabled in [false, true] {
+        for focused in [false, true] {
+            for visible in [false, true] {
+                let transport = Arc::new(FakeTransport::default());
+                let sink = Arc::new(FakeSink::default());
+                sink.enabled.store(enabled, Ordering::SeqCst);
+                sink.focused.store(focused, Ordering::SeqCst);
+                sink.visible.store(visible, Ordering::SeqCst);
+                transport.stream([approval("same", "pending")], true);
+                transport.stream([approval("same", "pending"), approval("new", "pending")], false);
+                let task = spawn(transport.clone(), sink.clone());
+                settle().await;
+                let expected = usize::from(enabled && !(focused && visible));
+                assert_eq!(sink.delivered.lock().unwrap().len(), expected);
+                sink.enabled.store(true, Ordering::SeqCst);
+                sink.focused.store(false, Ordering::SeqCst);
+                tokio::time::advance(Duration::from_secs(1)).await;
+                settle().await;
+                assert_eq!(sink.delivered.lock().unwrap().len(), expected + 1);
+                assert_eq!(transport.connected_at.lock().unwrap().len(), 2);
+                task.abort();
+            }
+        }
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn focus_is_rechecked_after_refetch_without_deferring_the_notification() {
+    let transport = Arc::new(FakeTransport {
+        detail_delay: Duration::from_secs(2),
+        ..FakeTransport::default()
+    });
+    let sink = Arc::new(FakeSink::default());
+    transport.details.lock().unwrap().insert(
+        "run".into(),
+        RunTimestamps {
+            started_at: Some("2026-09-10T12:00:00Z".into()),
+            completed_at: Some("2026-09-10T12:01:00Z".into()),
+            ..RunTimestamps::default()
+        },
+    );
+    transport.stream(
+        [frame("runs.updated", json!({"run_id": "run", "status": "succeeded"}))],
+        false,
+    );
+    let task = spawn(transport, sink.clone());
+    settle().await;
+    sink.focused.store(true, Ordering::SeqCst);
+    tokio::time::advance(Duration::from_secs(2)).await;
+    settle().await;
+    assert!(sink.delivered.lock().unwrap().is_empty());
+    sink.focused.store(false, Ordering::SeqCst);
+    settle().await;
+    assert!(sink.delivered.lock().unwrap().is_empty());
+    task.abort();
+}
+
+#[tokio::test(start_paused = true)]
+async fn reconnect_discards_partial_frames_keeps_dedup_and_has_no_bootstrap_dependency() {
+    let transport = Arc::new(FakeTransport::default());
+    let sink = Arc::new(FakeSink::default());
+    transport.stream(
+        [approval("first", "pending"), b"event: vaults.updated\ndata: {".to_vec()],
+        true,
+    );
+    transport.stream([approval("first", "pending"), approval("second", "pending")], false);
+    let task = spawn(transport.clone(), sink.clone());
+    settle().await;
+    assert_eq!(sink.delivered.lock().unwrap().len(), 1);
+    tokio::time::advance(Duration::from_millis(999)).await;
+    settle().await;
+    assert_eq!(transport.connected_at.lock().unwrap().len(), 1);
+    tokio::time::advance(Duration::from_millis(1)).await;
+    settle().await;
+    assert_eq!(transport.connected_at.lock().unwrap().len(), 2);
+    assert_eq!(sink.delivered.lock().unwrap().len(), 2);
+    task.abort();
+    assert!(task.await.unwrap_err().is_cancelled());
+    tokio::time::advance(Duration::from_secs(120)).await;
+    assert_eq!(transport.connected_at.lock().unwrap().len(), 2);
+}
+
+#[test]
+fn framing_is_invariant_under_byte_chunking_and_line_endings() {
+    for ending in ["\n", "\r\n", "\r"] {
+        let source = [
+            "\u{feff}: stream connected",
+            "",
+            "event: vaults.updated",
+            "id: ignored",
+            "retry: 0",
+            "data: {",
+            "data: \"type\":\"vaults.updated\",\"data\":{\"request_id\":\"请求\",\"request_status\":\"pending\"}}",
+            "",
+            "",
+        ]
+        .join(ending);
+        for chunk_size in 1..=source.len() {
+            let mut decoder = SseDecoder::new();
+            let frames = source
+                .as_bytes()
+                .chunks(chunk_size)
+                .flat_map(|chunk| decoder.push(chunk))
+                .collect::<Vec<_>>();
+            assert_eq!(frames.len(), 1);
+            assert_eq!(frames[0].event, "vaults.updated");
+            assert_eq!(
+                serde_json::from_str::<Value>(&frames[0].data).unwrap()["data"]["request_id"],
+                "请求"
+            );
+        }
+    }
+}
+
+#[test]
+fn oversized_or_invalid_frames_are_discarded_until_the_next_real_blank_line() {
+    let mut source = b"event: vaults.updated\ndata: ".to_vec();
+    source.extend(vec![b'x'; 128 * 1024]);
+    source.extend(b"\nevent: vaults.updated\ndata: hidden\n\n");
+    source.extend(b"event: vaults.updated\ndata: \xff\n\n");
+    source.extend(approval("valid", "pending"));
+    let mut decoder = SseDecoder::new();
+    let frames = source
+        .chunks(71)
+        .flat_map(|chunk| decoder.push(chunk))
+        .collect::<Vec<_>>();
+    assert_eq!(frames.len(), 1);
+    assert!(frames[0].data.contains("valid"));
+}
+
+#[test]
+fn reconnect_backoff_is_positive_capped_and_resettable() {
+    let mut backoff = ReconnectBackoff::default();
+    for expected in [1, 2, 4, 8, 16, 30, 30, 30, 30] {
+        assert_eq!(backoff.next_delay(), Duration::from_secs(expected));
+    }
+    backoff.reset();
+    assert_eq!(backoff.next_delay(), Duration::from_secs(1));
+}

--- a/desktop/scripts/verify-i18n.mjs
+++ b/desktop/scripts/verify-i18n.mjs
@@ -53,6 +53,26 @@ assert.deepEqual(
 )
 assert.deepEqual(Object.keys(zh.notices).sort(), expectedNoticeCodes)
 
+const notificationKeys = [
+  'approvalRequested.body',
+  'approvalRequested.title',
+  'runCanceled.body',
+  'runCanceled.title',
+  'runFailed.body',
+  'runFailed.title',
+  'runSucceeded.body',
+  'runSucceeded.title',
+  'toggle',
+]
+assert.deepEqual(leafShape(en.notifications), notificationKeys)
+assert.deepEqual(leafShape(zh.notifications), notificationKeys)
+for (const key of notificationKeys) {
+  const english = key.split('.').reduce((value, segment) => value[segment], en.notifications)
+  const chinese = key.split('.').reduce((value, segment) => value[segment], zh.notifications)
+  assert.ok(english.length > 0 && chinese.length > 0)
+  assert.deepEqual(placeholders(chinese), placeholders(english), `placeholder mismatch for notifications.${key}`)
+}
+
 for (const code of expectedNoticeCodes) {
   assert.deepEqual(
     placeholders(zh.notices[code]),

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -28,6 +28,7 @@ tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-autostart = "2"
 tauri-plugin-deep-link = "2"
 tauri-plugin-dialog = "2"
+tauri-plugin-notification = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-single-instance = "2"
 tauri-plugin-window-state = "2"

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -19,6 +19,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 mod native_frame;
+mod notifications;
 
 #[cfg(target_os = "macos")]
 mod macos_deep_link;
@@ -87,6 +88,7 @@ struct ProductCatalog {
 #[derive(Deserialize)]
 struct DesktopBootstrapCatalog {
     tray: NativeTrayCatalog,
+    notifications: notifications::NativeNotificationCatalog,
     #[cfg(feature = "bundled-runtime")]
     uninstall: NativeUninstallCatalog,
 }
@@ -270,6 +272,7 @@ struct NativeMenus {
     status: MenuItem<tauri::Wry>,
     stop: MenuItem<tauri::Wry>,
     login: CheckMenuItem<tauri::Wry>,
+    notifications: CheckMenuItem<tauri::Wry>,
     stop_present: AtomicBool,
     displayed: Mutex<Option<(TrayRuntimeState, bool)>>,
 }
@@ -290,6 +293,16 @@ fn install_native_tray(app: &AppHandle) -> tauri::Result<()> {
         None::<&str>,
     )?;
     let quit = MenuItem::with_id(app, QUIT_MENU_ID, &catalog.quit, true, None::<&str>)?;
+    let notifications = CheckMenuItem::with_id(
+        app,
+        notifications::MENU_ID,
+        native_catalog_for_locales(sys_locale::get_locales())
+            .notifications
+            .toggle,
+        true,
+        app.state::<notifications::Notifications>().enabled(),
+        None::<&str>,
+    )?;
     let tray = Menu::with_items(
         app,
         &[
@@ -297,6 +310,7 @@ fn install_native_tray(app: &AppHandle) -> tauri::Result<()> {
             &status,
             &PredefinedMenuItem::separator(app)?,
             &login,
+            &notifications,
             &PredefinedMenuItem::separator(app)?,
             &quit,
         ],
@@ -321,6 +335,7 @@ fn install_native_tray(app: &AppHandle) -> tauri::Result<()> {
         status,
         stop,
         login,
+        notifications,
         stop_present: AtomicBool::new(false),
         displayed: Mutex::new(None),
     });
@@ -439,6 +454,7 @@ fn quit_choice(result: MessageDialogResult, catalog: &NativeTrayCatalog) -> Quit
 }
 
 fn exit_shell(app: &AppHandle) {
+    notifications::stop(app);
     app.state::<Shell>().exit_authorized.store(true, Ordering::SeqCst);
     app.exit(0);
 }
@@ -530,6 +546,7 @@ fn stop_runtime(app: AppHandle, quit: bool) {
         return;
     }
     refresh_runtime_tray(&app, TrayRuntimeState::Stopping);
+    notifications::stop(&app);
     tauri::async_runtime::spawn(async move {
         match host.stop_owned_runtime().await {
             Ok(()) if quit => exit_shell(&app),
@@ -790,6 +807,7 @@ fn open_workbench(app: &AppHandle, ready: &BootstrapStatus, activity: Arc<Atomic
         let _ = activity.compare_exchange(ACTIVITY_BOOTSTRAP, ACTIVITY_IDLE, Ordering::SeqCst, Ordering::SeqCst);
         return;
     };
+    notifications::start(app, origin.clone());
     let window_generation = app.state::<Shell>().window_generation.clone();
     loop {
         let observed_generation = window_generation.load(Ordering::SeqCst);
@@ -857,6 +875,7 @@ fn workbench_navigation_failure_status(ready: &BootstrapStatus, origin: &Loopbac
 /// Watches the exact origin that bootstrap proved ready. The caller owns the
 /// shell's single monitor activity until this task exits or begins recovery.
 fn start_runtime_monitor(app: AppHandle, origin: LoopbackOrigin, activity: Arc<AtomicU8>) {
+    notifications::start(&app, origin.clone());
     let host = app.state::<Shell>().host.clone();
     let generation = app.state::<Shell>().monitor_generation.clone();
     let observed_generation = generation.fetch_add(1, Ordering::SeqCst) + 1;
@@ -897,6 +916,7 @@ fn start_runtime_monitor(app: AppHandle, origin: LoopbackOrigin, activity: Arc<A
                 }
                 // This only releases retained launch ownership. The desktop
                 // shell never sends a stop signal to the old Runtime.
+                notifications::stop(&app);
                 host.reset_after_confirmed_runtime_loss();
                 if return_to_bootstrap(&app) {
                     spawn_owned_bootstrap(app);
@@ -934,6 +954,7 @@ fn return_to_bootstrap(app: &AppHandle) -> bool {
     if window.navigate(bootstrap_url).is_err() {
         return false;
     }
+    notifications::stop(app);
     let _ = set_active_origin(app, None);
     true
 }
@@ -1202,6 +1223,7 @@ fn request_private_runtime_removal(app: AppHandle) {
                 return;
             }
 
+            notifications::stop(&confirmation_app);
             tauri::async_runtime::spawn(async move {
                 match host.remove_private_runtime(active_origin.as_ref()).await {
                     Ok(true) => {
@@ -1248,12 +1270,20 @@ pub fn run() {
         .plugin(native_frame::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_autostart::Builder::new().build())
+        .plugin(tauri_plugin_notification::init())
         .on_menu_event(|app, event| {
             match event.id().as_ref() {
                 OPEN_MENU_ID => focus_or_restore_main_window(app),
                 STOP_MENU_ID => request_runtime_lifecycle(app.clone(), false),
                 QUIT_MENU_ID => request_runtime_lifecycle(app.clone(), true),
                 LOGIN_MENU_ID => toggle_start_at_login(app),
+                notifications::MENU_ID => {
+                    let notifications = app.state::<notifications::Notifications>();
+                    notifications.toggle();
+                    if let Some(menus) = app.try_state::<NativeMenus>() {
+                        let _ = menus.notifications.set_checked(notifications.enabled());
+                    }
+                }
                 _ => {}
             }
             #[cfg(feature = "bundled-runtime")]
@@ -1347,6 +1377,9 @@ pub fn run() {
                 }
             };
             app.manage(Shell::new(host, bootstrap_url));
+            app.manage(notifications::Notifications::new(
+                app.path().app_local_data_dir()?.join("notifications.json"),
+            ));
             if let Ok(mut links) = app.state::<Mutex<DeepLinks>>().lock() {
                 links.receive(
                     std::env::args_os()

--- a/desktop/src-tauri/src/notifications.rs
+++ b/desktop/src-tauri/src/notifications.rs
@@ -1,0 +1,295 @@
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use avibe_runtime_host::notifications::{
+    run_notifications, HttpNotificationTransport, NotificationFilter, NotificationGate, NotificationIntent,
+    NotificationSink,
+};
+use avibe_runtime_host::LoopbackOrigin;
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Manager};
+use tauri_plugin_notification::NotificationExt;
+
+use crate::{native_catalog_for_locales, MAIN_WINDOW};
+
+pub const MENU_ID: &str = "notifications";
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NativeNotificationCatalog {
+    pub toggle: String,
+    approval_requested: NotificationCopy,
+    run_succeeded: NotificationCopy,
+    run_failed: NotificationCopy,
+    run_canceled: NotificationCopy,
+}
+
+#[derive(Clone, Deserialize)]
+struct NotificationCopy {
+    title: String,
+    body: String,
+}
+
+impl NativeNotificationCatalog {
+    fn copy(&self, intent: NotificationIntent) -> NotificationCopy {
+        match intent {
+            NotificationIntent::ApprovalRequested => &self.approval_requested,
+            NotificationIntent::RunSucceeded => &self.run_succeeded,
+            NotificationIntent::RunFailed => &self.run_failed,
+            NotificationIntent::RunCanceled => &self.run_canceled,
+        }
+        .clone()
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+struct Preference {
+    enabled: bool,
+}
+
+fn read_preference(path: &Path) -> std::io::Result<bool> {
+    match std::fs::read(path) {
+        Ok(bytes) => serde_json::from_slice::<Preference>(&bytes)
+            .map(|preference| preference.enabled)
+            .map_err(std::io::Error::other),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(true),
+        Err(error) => Err(error),
+    }
+}
+
+fn write_preference(path: &Path, enabled: bool) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let bytes = serde_json::to_vec(&Preference { enabled })?;
+    let temporary = path.with_extension("tmp");
+    let result = std::fs::write(&temporary, bytes).and_then(|()| std::fs::rename(&temporary, path));
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temporary);
+    }
+    result
+}
+
+struct Connection {
+    origin: LoopbackOrigin,
+    task: tauri::async_runtime::JoinHandle<()>,
+}
+
+pub struct Notifications {
+    preference_path: PathBuf,
+    enabled: Arc<AtomicBool>,
+    generation: Arc<AtomicU64>,
+    connection: Mutex<Option<Connection>>,
+    filter: Arc<Mutex<NotificationFilter>>,
+}
+
+impl Notifications {
+    pub fn new(preference_path: PathBuf) -> Self {
+        let enabled = read_preference(&preference_path).unwrap_or_else(|_| {
+            eprintln!("Desktop notifications disabled: the notification preference could not be read.");
+            false
+        });
+        Self {
+            preference_path,
+            enabled: Arc::new(AtomicBool::new(enabled)),
+            generation: Arc::new(AtomicU64::new(0)),
+            connection: Mutex::new(None),
+            filter: Arc::new(Mutex::new(NotificationFilter::default())),
+        }
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.enabled.load(Ordering::SeqCst)
+    }
+
+    pub fn toggle(&self) {
+        let enabled = !self.enabled();
+        if write_preference(&self.preference_path, enabled).is_ok() {
+            self.enabled.store(enabled, Ordering::SeqCst);
+        } else {
+            eprintln!("The desktop notification preference could not be saved.");
+        }
+    }
+
+    pub fn start(&self, app: &AppHandle, origin: LoopbackOrigin) {
+        let mut connection = self.connection.lock().expect("notification connection lock");
+        if connection.as_ref().is_some_and(|current| current.origin == origin) {
+            return;
+        }
+        let observed_generation = self.generation.fetch_add(1, Ordering::SeqCst) + 1;
+        if let Some(previous) = connection.take() {
+            previous.task.abort();
+        }
+        let Ok(transport) = HttpNotificationTransport::new(origin.clone()) else {
+            eprintln!("The desktop notification connection could not be initialized.");
+            return;
+        };
+        let sink = NativeSink {
+            app: app.clone(),
+            enabled: self.enabled.clone(),
+            generation: self.generation.clone(),
+            observed_generation,
+        };
+        let filter = self.filter.clone();
+        *connection = Some(Connection {
+            origin,
+            task: tauri::async_runtime::spawn(async move {
+                run_notifications(&transport, filter, &sink).await;
+            }),
+        });
+    }
+
+    pub fn stop(&self) {
+        let mut connection = self.connection.lock().expect("notification connection lock");
+        self.generation.fetch_add(1, Ordering::SeqCst);
+        if let Some(connection) = connection.take() {
+            connection.task.abort();
+        }
+    }
+}
+
+#[derive(Clone)]
+struct NativeSink {
+    app: AppHandle,
+    enabled: Arc<AtomicBool>,
+    generation: Arc<AtomicU64>,
+    observed_generation: u64,
+}
+
+impl NotificationSink for NativeSink {
+    fn gate(&self) -> NotificationGate {
+        let window = self.app.get_webview_window(MAIN_WINDOW);
+        NotificationGate {
+            enabled: self.enabled.load(Ordering::SeqCst)
+                && self.generation.load(Ordering::SeqCst) == self.observed_generation,
+            focused: window
+                .as_ref()
+                .is_some_and(|window| window.is_focused().unwrap_or(true)),
+            visible: window
+                .as_ref()
+                .is_some_and(|window| window.is_visible().unwrap_or(true)),
+        }
+    }
+
+    fn deliver(&self, intent: NotificationIntent) {
+        let sink = self.clone();
+        let _ = self.app.run_on_main_thread(move || {
+            if !sink.gate().allows() {
+                return;
+            }
+            let copy = native_catalog_for_locales(sys_locale::get_locales())
+                .notifications
+                .copy(intent);
+            if sink
+                .app
+                .notification()
+                .builder()
+                .title(copy.title)
+                .body(copy.body)
+                .show()
+                .is_err()
+            {
+                eprintln!("The desktop notification could not be submitted to the operating system.");
+            }
+        });
+    }
+}
+
+pub fn start(app: &AppHandle, origin: LoopbackOrigin) {
+    app.state::<Notifications>().start(app, origin);
+}
+
+pub fn stop(app: &AppHandle) {
+    app.state::<Notifications>().stop();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestDirectory(PathBuf);
+
+    impl TestDirectory {
+        fn new() -> Self {
+            static NEXT: AtomicU64 = AtomicU64::new(0);
+            let directory = std::env::temp_dir().join(format!(
+                "avibe-notification-preference-{}-{}",
+                std::process::id(),
+                NEXT.fetch_add(1, Ordering::SeqCst)
+            ));
+            std::fs::create_dir(&directory).unwrap();
+            Self(directory)
+        }
+    }
+
+    impl Drop for TestDirectory {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn preference_defaults_on_and_persists_the_tray_choice_across_restarts() {
+        let directory = TestDirectory::new();
+        let path = directory.0.join("notifications.json");
+        let state = Notifications::new(path.clone());
+        assert!(state.enabled());
+        state.toggle();
+        assert!(!state.enabled());
+        let restarted = Notifications::new(path.clone());
+        assert!(!restarted.enabled());
+        restarted.toggle();
+        assert!(Notifications::new(path).enabled());
+    }
+
+    #[test]
+    fn unreadable_preferences_fail_closed_and_failed_writes_preserve_the_choice() {
+        let directory = TestDirectory::new();
+        let path = directory.0.join("notifications.json");
+        std::fs::write(&path, "invalid").unwrap();
+        assert!(!Notifications::new(path.clone()).enabled());
+        std::fs::remove_file(&path).unwrap();
+        let state = Notifications::new(path.clone());
+        std::fs::create_dir(&path).unwrap();
+        state.toggle();
+        assert!(state.enabled());
+        assert!(!path.with_extension("tmp").exists());
+    }
+
+    #[test]
+    fn every_intent_uses_only_native_catalog_copy_in_both_locales() {
+        for locale in ["en-US", "zh-CN"] {
+            let catalog = native_catalog_for_locales([locale.to_owned()]).notifications;
+            assert!(!catalog.toggle.is_empty());
+            for intent in [
+                NotificationIntent::ApprovalRequested,
+                NotificationIntent::RunSucceeded,
+                NotificationIntent::RunFailed,
+                NotificationIntent::RunCanceled,
+            ] {
+                let copy = catalog.copy(intent);
+                assert!(!copy.title.is_empty() && !copy.body.is_empty());
+                assert!(!copy.body.contains("{{"));
+            }
+        }
+    }
+
+    #[test]
+    fn stopping_invalidates_dispatched_intents_and_aborts_the_connection_task() {
+        let directory = TestDirectory::new();
+        let state = Notifications::new(directory.0.join("notifications.json"));
+        let task = tauri::async_runtime::spawn(std::future::pending());
+        *state.connection.lock().unwrap() = Some(Connection {
+            origin: LoopbackOrigin::parse("http://127.0.0.1:5123").unwrap(),
+            task,
+        });
+        let previous = state.generation.load(Ordering::SeqCst);
+        state.stop();
+        assert!(state.connection.lock().unwrap().is_none());
+        assert_ne!(state.generation.load(Ordering::SeqCst), previous);
+        assert!(state.enabled());
+        state.stop();
+        assert!(state.connection.lock().unwrap().is_none());
+    }
+}

--- a/desktop/src-tauri/tests/shell_boundaries.rs
+++ b/desktop/src-tauri/tests/shell_boundaries.rs
@@ -95,6 +95,94 @@ fn the_shell_enables_no_capability_beyond_bootstrap() {
 }
 
 #[test]
+fn notifications_are_native_only_without_remote_capabilities_or_workbench_callable_commands() {
+    let source = shipping_source("src/lib.rs");
+    let native = shipping_source("src/notifications.rs");
+    let build = shipping_source("build.rs");
+    assert!(source.contains(".plugin(tauri_plugin_notification::init())"));
+    assert!(native.contains("NotificationExt"));
+    assert!(native.contains(".notification()"));
+    assert!(native.contains("sink.gate().allows()"));
+    assert!(!build.contains("notification"));
+    let commands = source
+        .split(".invoke_handler(tauri::generate_handler![")
+        .nth(1)
+        .unwrap()
+        .split("])")
+        .next()
+        .unwrap();
+    assert!(!commands.contains("notification"));
+    for forbidden in ["#[tauri::command]", "invoke_handler", ".listen(", ".emit(", ".eval("] {
+        assert!(
+            !native.contains(forbidden),
+            "notification path must not use {forbidden}"
+        );
+    }
+    for entry in std::fs::read_dir(crate_dir().join("capabilities")).unwrap() {
+        let path = entry.unwrap().path();
+        if path.extension().is_some_and(|extension| extension == "json") {
+            let capability = read_json(path);
+            assert!(capability.get("remote").is_none());
+            assert!(!capability["permissions"].to_string().contains("notification:"));
+        }
+    }
+}
+
+#[test]
+fn notification_lifecycle_follows_runtime_ownership_not_webview_visibility_or_sse_health() {
+    let source = shipping_source("src/lib.rs");
+    for (function, next_function, required) in [
+        (
+            "fn open_workbench(",
+            "fn workbench_navigation_failure_status",
+            "notifications::start(app, origin.clone())",
+        ),
+        (
+            "fn start_runtime_monitor(",
+            "fn return_to_bootstrap",
+            "notifications::stop(&app)",
+        ),
+        (
+            "fn stop_runtime(",
+            "fn toggle_start_at_login",
+            "notifications::stop(&app)",
+        ),
+        (
+            "fn exit_shell(",
+            "fn request_runtime_lifecycle",
+            "notifications::stop(app)",
+        ),
+        (
+            "fn request_private_runtime_removal(",
+            "pub fn run()",
+            "notifications::stop(&confirmation_app)",
+        ),
+    ] {
+        let body = source
+            .split(function)
+            .nth(1)
+            .unwrap()
+            .split(next_function)
+            .next()
+            .unwrap();
+        assert!(body.contains(required), "{function} must retain {required}");
+    }
+    let close = source
+        .split("event: WindowEvent::CloseRequested")
+        .nth(1)
+        .unwrap()
+        .split("if let RunEvent::ExitRequested")
+        .next()
+        .unwrap();
+    assert!(!close.contains("notifications::stop"));
+    let native = shipping_source("src/notifications.rs");
+    assert!(native.contains("previous.task.abort()"));
+    assert!(native.contains("current.origin == origin"));
+    assert!(native.contains("observed_generation"));
+    assert!(!native.contains("/ready") && !native.contains("bootstrap"));
+}
+
+#[test]
 fn deep_links_have_native_entry_points_without_a_workbench_callable_command() {
     let source = shipping_source("src/lib.rs");
     let build = shipping_source("build.rs");

--- a/docs/plans/desktop-notifications-implementation.md
+++ b/docs/plans/desktop-notifications-implementation.md
@@ -1,0 +1,55 @@
+# Desktop notification consumer implementation
+
+## Change contract
+
+Implement `desktop-notifications-sse.md` on the shell side without changing
+Python, HTTP routes, loopback authentication, WebView IPC, or capabilities.
+The orchestrator approved OS-default activation for v1 on 2026-09-11;
+cross-platform explicit activation requires a separate native adapter.
+The orchestrator also approved the existing locked chrono 0.4 dependency
+for durable timestamp parsing (std only, no clock).
+
+## Data flow and ownership
+
+After readiness succeeds, the shell owns one cancellable SSE task for the
+validated Runtime origin. Transport loss retries only that task with capped
+backoff. Three readiness failures, Stop, Uninstall, and Quit cancel it.
+Window visibility and the stored notification preference only suppress
+delivery; they neither disconnect the stream nor queue events for later.
+The shell retains bounded filter state across stream reconnections.
+
+The Tauri-free runtime-host parses production SSE framing, allows only the
+two frozen event classes, deduplicates each class at 512 keys/24h, and
+computes duration from durable timestamps. Missing stamps trigger one
+bounded detail GET; missing/invalid stamps then fail closed. Scheduled
+and watch runs are the only duration-independent kinds. Generic localized
+copy carries no untrusted Runtime text.
+
+## Verification plan
+
+- Fake SSE collaborators under a virtual clock prove allow-list filtering,
+  suppression without replay, duration independent of arrival/attachment,
+  refetch-once/fail-closed, bounded approval/run retention, and reconnect.
+- A loopback fake HTTP server proves framing, bounded reads, redirect refusal,
+  exact routes, and no replay cursor on reconnection.
+- Shell tests prove lifecycle ownership, preference persistence against
+  test-owned paths, and notification intentions without calling the OS.
+- Boundary tests keep all notification privileges away from WebViews.
+- Both native catalogs use the frozen keys and matching placeholders.
+- Run desktop npm install/build/i18n, UI build, and Rust fmt/clippy/tests
+  across the workspace/all features before PR handoff.
+
+## Integration acceptance
+
+Real OS permission, delivery, OS-default activation, hidden-to-tray behavior,
+and menu interaction remain packaged macOS/Windows acceptance. The producer
+PR #1982 adds terminal timestamp fields independently and must merge first.
+
+## Local evidence
+
+Desktop npm install/build/i18n, UI npm install/build, workspace all-features
+Rust tests, and all-target/all-feature clippy with warnings denied pass.
+The notification suites exercise the production HTTP adapter against an
+isolated loopback server and drive filter/reconnect behavior with a virtual
+clock. No test submits an OS notification or starts the user's Runtime.
+Packaged OS acceptance is deliberately not claimed by these checks.

--- a/docs/plans/desktop-notifications-sse.md
+++ b/docs/plans/desktop-notifications-sse.md
@@ -25,9 +25,9 @@ Default on. The tray has a checkable "Notifications" item that persists
 the preference. System Focus / Do Not Disturb is left to the OS; Avibe
 does not reimplement it.
 
-Clicking a notification focuses the Avibe window. Deep-link navigation
-into a specific session (`avibe://session/<id>`) is G5 and is **not**
-in this slice — the click is "come back to Avibe", not "open this row".
+Notification activation follows the OS-default behavior described in
+**Click** below. Deep-link navigation into a specific session
+(`avibe://session/<id>`) is G5 and is **not** in this slice.
 
 ## Why SSE, not polling
 
@@ -202,9 +202,14 @@ notification path does not grant any `remote` capability.
 
 ### Click
 
-Click = `show` + `unminimize` + `set_focus` on the main window.
-No Workbench navigation in v1 (that is G5). If the window was hidden
-to tray, this is the same path as the tray "Open Avibe" item.
+v1 ships **OS-default activation**, not a shell click callback: on macOS,
+clicking a banner activates the sending app by default (approximately
+show + focus); on Windows, unpackaged-toast click behavior is OS/backend
+dependent and may only dismiss. The notification plugin's desktop API
+does not expose an action callback. Explicit cross-platform click =
+`show` + `unminimize` + `set_focus` is **v2 with native activation adapter
+(macOS UNUserNotificationCenter delegate + Windows toast activation)**.
+No Workbench navigation or simulated click wiring is included in v1.
 
 ## Frozen architecture split
 
@@ -280,5 +285,5 @@ the state in which notifications matter.
 
 Does not depend on G1 signing or G2 auto-update.
 
-Does not block G5; G5 should reuse the same notification click
-once deep links exist (swap `show window` for `show + navigate`).
+Does not block G5. A notification-specific deep-link target follows the
+native activation adapter rather than assuming a v1 click callback exists.

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -45,6 +45,25 @@
       "stopFailure": "The Runtime could not be stopped safely. Avibe remains open. Try again after checking the Runtime.",
       "loginFailure": "The login setting could not be read or changed. Check your operating system's login settings and try again."
     },
+    "notifications": {
+      "toggle": "Notifications",
+      "approvalRequested": {
+        "title": "Approval needed",
+        "body": "A Vault request is waiting for your approval."
+      },
+      "runSucceeded": {
+        "title": "Run completed",
+        "body": "Background work has finished successfully."
+      },
+      "runFailed": {
+        "title": "Run failed",
+        "body": "Background work could not finish. Open the Workbench to review it."
+      },
+      "runCanceled": {
+        "title": "Run canceled",
+        "body": "Background work was canceled."
+      }
+    },
     "uninstall": {
       "menuLabel": "Uninstall Avibe…",
       "confirmTitle": "Uninstall Avibe",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -45,6 +45,25 @@
       "stopFailure": "无法安全停止运行时，应用将保持打开。请检查运行时后重试。",
       "loginFailure": "无法读取或更改登录启动设置。请检查操作系统的登录设置后重试。"
     },
+    "notifications": {
+      "toggle": "通知",
+      "approvalRequested": {
+        "title": "需要授权",
+        "body": "有一项密钥库请求正等待你的授权。"
+      },
+      "runSucceeded": {
+        "title": "运行已完成",
+        "body": "后台工作已成功完成。"
+      },
+      "runFailed": {
+        "title": "运行失败",
+        "body": "后台工作未能完成，请打开工作台查看详情。"
+      },
+      "runCanceled": {
+        "title": "运行已取消",
+        "body": "后台工作已取消。"
+      }
+    },
     "uninstall": {
       "menuLabel": "卸载 Avibe…",
       "confirmTitle": "卸载 Avibe",


### PR DESCRIPTION
## Capability and contract

Native desktop notifications now consume the existing Workbench SSE stream
after Runtime readiness, including while the window is hidden to the tray.
The tray gains a persistent, default-on Notifications toggle next to Start
at Login. This is the G4 consumer implementation of
`docs/plans/desktop-notifications-sse.md`; the implementation and acceptance
notes are in `docs/plans/desktop-notifications-implementation.md`.

**Dependency: requires #1982 merged first.** This branch is based directly
on `desktop`, not stacked on the producer branch. The existing run detail
endpoint already supports the one-shot timestamp fallback.

### Boundaries and behavior

- `runtime-host` remains Tauri-free: bounded SSE decoding, an exact two-event
  allow-list, durable completion-minus-start duration, one bounded timestamp
  refetch, separate 512-key/24-hour approval and run dedup sets, and bounded
  reconnect backoff independent of `/ready`.
- Only `scheduled` and `watch` bypass the 30-second duration threshold;
  `agent_run` and future kinds follow duration. Missing/invalid timestamps fail
  closed. Suppressed events are consumed, never queued for later delivery.
- The shell owns one connection per adopted origin, keeps it through window
  closure, and cancels on confirmed readiness loss, Stop, Uninstall, or Quit.
  Generation checks also reject stale main-thread notification deliveries.
- Focused+visible or disabled notifications suppress delivery. Notification
  title/body are fixed native catalog copy in both locales; no untrusted
  Runtime title, output, or error is interpolated.
- The notification plugin is Rust-only. No Python, HTTP route, authentication,
  IPC command, capability, deep-link implementation, or window-state change.
  The explicitly approved dependencies are `tauri-plugin-notification = "2"`
  and existing locked chrono 0.4.45 with std-only features; Cargo generated
  the lockfile without updating existing package versions.

## Evidence layers

- Unit/contract: virtual-clock fake SSE tests assert allow-list filtering,
  dedup reset/capacity/TTL, durable duration independent of attachment or
  delayed receipt, refetch-once/fail-closed, precision/offsets, focus/preference
  suppression without replay, and reconnect/backoff/timeout behavior.
- HTTP boundary: an isolated loopback fake server exercises the real reqwest
  adapter, production framing, absent replay/auth headers, redirect refusal,
  response bounds, matching run identity, and single-segment URL encoding.
- Native/privilege contract: persistence uses test-owned temporary paths;
  tests assert native catalog intentions and shell lifecycle/capability
  wiring without sending any OS notification.
- Local validation passed: desktop `npm ci`, `npm run build`,
  `npm run test:i18n`; UI `npm ci` and `npm run build`;
  `cargo fmt --all -- --check`;
  `cargo clippy --workspace --all-targets --all-features -- -D warnings`;
  `cargo test --workspace --all-features` (188 tests including the doc-test).
- Scenario IDs: G4's frozen **Tests (invariants)** section is the scenario
  contract; no separate desktop scenario catalog exists.
- No user Runtime was restarted or real OS notification emitted. The
  unchanged npm lockfiles report audit warnings; UI dependency/chunk warnings
  and Cargo's local cache-cleanup permission warning are outside this change.

## Known-by-design

1. **Real OS acceptance remains integration work.** Notification permission,
   visible native delivery, hidden-to-tray behavior, and tray-toggle UX need
   packaged macOS/Windows acceptance; green Rust tests do not claim it.
2. **v1 uses OS-default activation, not an explicit click callback.** The
   orchestrator amended the contract because the desktop notification plugin
   drops its native handle and exposes no desktop action callback. macOS
   normally activates the sending app; Windows behavior is backend/OS
   dependent and may only dismiss. Explicit cross-platform
   show+unminimize+focus is **v2 with native activation adapter (macOS
   UNUserNotificationCenter delegate + Windows toast activation)**. No fake
   click wiring or explicit-click claim is included.
3. **Notification-specific deep-link targets remain a G5 follow-up.** No
   session navigation or deep-link code is changed here.
4. **SSE has no replay.** Missed events stay missed; pending Vault state is
   recoverable in Workbench. Retained keys are bounded, so an evicted/expired
   pending request or run may notify again by design.

5. **Windows replacement is already implemented; intentionally unchanged.**
   Review thread `PRRT_kwDOPbFPYs6hN4-s` claimed that `std::fs::rename`
   cannot replace an existing Windows destination. The Rust standard library
   explicitly uses `MoveFileExW(..., MOVEFILE_REPLACE_EXISTING)` for this
   operation ([pinned source](https://github.com/rust-lang/rust/blob/1.90.0/library/std/src/sys/fs/windows.rs#L1244-L1245)).
   More importantly, the exact PR head's
   [Windows CI job](https://github.com/avibe-bot/avibe/actions/runs/34520276319/job/103015765171)
   passed the existing consuming test
   `notifications::tests::preference_defaults_on_and_persists_the_tray_choice_across_restarts`:
   default on -> toggle off -> reconstruct state -> toggle on -> reconstruct
   state again. This exercises replacing the existing preference file, not
   just its initial creation. Keep the current replacement path rather than
   adding a delete-before-rename gap or an unnecessary platform adapter.

Do not merge from this lane. Await exact-head Codex review, zero unresolved
threads, passing desktop-shell/lint CI, and orchestrator integration approval.
